### PR TITLE
Fix `//#check-mrl` turbo cache inputs

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -269,16 +269,26 @@
     },
 
     "//#check-mrl": {
+      // Keep in sync with .monorepolint.config.mjs
       "inputs": [
         "package.json",
         ".monorepolint.config.mjs",
+        "dprint.json",
         "packages/*/package.json",
         "packages/*/tsconfig.json",
-        "packages/*/src/public/*",
-        "examples/*/*/package.json",
-        "examples/*/*/tsconfig.json",
-        "examples-extra/*/*/package.json",
-        "examples-extra/*/*/tsconfig.json",
+        "packages/*/tsconfig.cjs.json",
+        "packages/*/vitest.config.mts",
+        "packages/*/tsup.config.js",
+        "packages/*/turbo.json",
+        "packages/*/api-extractor.json",
+        "packages/*/README.md",
+        "packages/*/src/public/**",
+        "examples/*/package.json",
+        "examples-extra/*/package.json",
+        "examples-extra/basic/*/package.json",
+        "tests/*/package.json",
+        "benchmarks/*/*/package.json",
+        "docs/package.json",
         "templates/*"
       ]
     },


### PR DESCRIPTION
The `//#check-mrl` inputs list didn't cover every file monorepolint validates, so an mrl violation could be cached as a pass until the cache busted for an unrelated reason (as happened with #3671, surfacing only in #3767).

Changes:
- Adds the per-package generated-config file types (`vitest.config.mts`, `tsup.config.js`, `turbo.json`, `api-extractor.json`, `tsconfig.cjs.json`, `README.md` under `packages/*`).
- Widens `src/public/*` to `src/public/**` — `ourExportsConvention` scans it recursively, so nested files (e.g. `experimental/*`) drive the generated `exports` map.
- Adds `dprint.json` — the `vitest.config.mts` rule formats its expected contents via dprint, so its config affects the check result.
- Fixes the workspace-root `package.json` globs so they cover every root in `pnpm-workspace.yaml` (`examples/*` was the wrong depth; `examples-extra/*`, `examples-extra/basic/*`, `tests/*`, `benchmarks/*/*`, `docs` were missing).

`tsconfig.json` is tracked only for `packages/*` — the other roots are all minimal monorepolint archetypes that skip `standardTsconfig`, so mrl never validates their `tsconfig.json` (verified by corrupting one and watching `mrl check` pass).

Verified: re-running is `>>> FULL TURBO`, and editing a `packages/*/vitest.config.mts`, a nested `src/public/**` file, or `dprint.json` now busts the cache instead of replaying a pass.

**⚠️ Reviewer note:** this list still has to be hand-maintained in lockstep with `.monorepolint.config.mjs` and will drift again as mrl rules change. Given `mrl check` is ~3s, runs once, and has no dependents, `"cache": false` may be the more maintainable long-term fix. No changeset (root build config, no published package changed).
