### PR TITLE
Consolidate ObjectTable data fetching to use useObjectSet only

### DIFF
--- a/.changeset/bright-lions-run.md
+++ b/.changeset/bright-lions-run.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react-components": patch
+---
+
+Consolidate ObjectTable data fetching to use useObjectSet only

--- a/.changeset/dry-camels-burn.md
+++ b/.changeset/dry-camels-burn.md
@@ -1,0 +1,5 @@
+---
+"@osdk/client": minor
+---
+
+Add support to fetch interface links

--- a/.changeset/objectset-interface-projection.md
+++ b/.changeset/objectset-interface-projection.md
@@ -1,0 +1,6 @@
+---
+"@osdk/client": minor
+"@osdk/faux": patch
+---
+
+observeObjectSet now returns interface views for interface object sets, keyed by the interface's property api names, and carries derived properties across object/interface casts

--- a/.changeset/objectset-interface-projection.md
+++ b/.changeset/objectset-interface-projection.md
@@ -1,6 +1,5 @@
 ---
 "@osdk/client": minor
-"@osdk/faux": patch
 ---
 
 observeObjectSet now returns interface views for interface object sets, keyed by the interface's property api names, and carries derived properties across object/interface casts

--- a/packages/api/src/objectSet/ObjectSet.test.ts
+++ b/packages/api/src/objectSet/ObjectSet.test.ts
@@ -285,6 +285,43 @@ describe("ObjectSet", () => {
       >().toEqualTypeOf<number>();
     });
 
+    test("interface types", async () => {
+      const fauxInterfaceObjectSet = createMockObjectSet<FooInterfaceApiTest>();
+
+      const withInterfaceProperty = fauxInterfaceObjectSet.withProperties({
+        derivedProp: (base) => base.selectProperty("name"),
+      });
+
+      expectTypeOf(withInterfaceProperty).toEqualTypeOf<
+        $ObjectSet<
+          FooInterfaceApiTest,
+          {
+            derivedProp: "string" | undefined;
+          }
+        >
+      >();
+
+      const withInterfacePropertyResults =
+        await withInterfaceProperty.fetchPage();
+
+      expectTypeOf<
+        (typeof withInterfacePropertyResults)["data"][0]
+      >().toEqualTypeOf<
+        Osdk.Instance<
+          FooInterfaceApiTest,
+          never,
+          PropertyKeys<FooInterfaceApiTest>,
+          {
+            derivedProp: "string" | undefined;
+          }
+        >
+      >();
+
+      expectTypeOf<
+        (typeof withInterfacePropertyResults)["data"][0]["derivedProp"]
+      >().toEqualTypeOf<string | undefined>();
+    });
+
     it("can be sub-selected", () => {
       const objectWithUndefinedRdp = fauxObjectSet
         .withProperties({

--- a/packages/client/src/derivedProperties/createWithPropertiesObjectSet.test.ts
+++ b/packages/client/src/derivedProperties/createWithPropertiesObjectSet.test.ts
@@ -15,7 +15,7 @@
  */
 
 import type { DerivedProperty } from "@osdk/api";
-import { Employee } from "@osdk/client.test.ontology";
+import { BarInterface, Employee } from "@osdk/client.test.ontology";
 import type { DerivedPropertyDefinition } from "@osdk/foundry.ontologies";
 import { describe, expect, it } from "vitest";
 
@@ -55,6 +55,43 @@ describe(createWithPropertiesObjectSet, () => {
           "type": "selection",
         }
       `);
+  });
+
+  it("correctly creates interface link search around for interface types", () => {
+    const map = new Map<any, DerivedPropertyDefinition>();
+    const deriveObjectSet = createWithPropertiesObjectSet(
+      BarInterface,
+      {
+        type: "methodInput",
+      },
+      map,
+    );
+
+    const clause = {
+      derivedPropertyName: (base) =>
+        base.pivotTo("toFoo").aggregate("fooIdp:collectList"),
+    } satisfies DerivedProperty.Clause<BarInterface>;
+
+    const result = clause["derivedPropertyName"](deriveObjectSet);
+    const definition = map.get(result);
+
+    expect(definition).toMatchInlineSnapshot(`
+      {
+        "objectSet": {
+          "interfaceLink": "toFoo",
+          "objectSet": {
+            "type": "methodInput",
+          },
+          "type": "interfaceLinkSearchAround",
+        },
+        "operation": {
+          "limit": 100,
+          "selectedPropertyApiName": "fooIdp",
+          "type": "collectList",
+        },
+        "type": "selection",
+      }
+    `);
   });
 
   it("correctly allows select property off the base object set", () => {

--- a/packages/client/src/derivedProperties/createWithPropertiesObjectSet.ts
+++ b/packages/client/src/derivedProperties/createWithPropertiesObjectSet.ts
@@ -38,11 +38,17 @@ export function createWithPropertiesObjectSet<
     pivotTo: (link) => {
       return createWithPropertiesObjectSet(
         objectType,
-        {
-          type: "searchAround",
-          objectSet,
-          link,
-        },
+        objectType.type === "object"
+          ? {
+              type: "searchAround",
+              objectSet,
+              link,
+            }
+          : {
+              type: "interfaceLinkSearchAround",
+              objectSet,
+              interfaceLink: link,
+            },
         definitionMap,
       );
     },

--- a/packages/client/src/object/convertWireToOsdkObjects/BaseHolder.ts
+++ b/packages/client/src/object/convertWireToOsdkObjects/BaseHolder.ts
@@ -24,6 +24,7 @@ import type {
 import type { FormatPropertyOptions } from "../formatting/applyPropertyFormatter.js";
 import type { InterfaceHolder } from "./InterfaceHolder.js";
 import type {
+  DerivedPropertiesRef,
   PropertySecuritiesRef,
   UnderlyingOsdkObject,
 } from "./InternalSymbols.js";
@@ -36,6 +37,7 @@ export interface BaseHolder {
   readonly [PropertySecuritiesRef]:
     | { [propName: string]: PropertySecurity[] }
     | undefined;
+  readonly [DerivedPropertiesRef]?: ReadonlyArray<string>;
 
   readonly $apiName: string;
   readonly $objectType: string;

--- a/packages/client/src/object/convertWireToOsdkObjects/InternalSymbols.ts
+++ b/packages/client/src/object/convertWireToOsdkObjects/InternalSymbols.ts
@@ -42,6 +42,11 @@ export const PropertySecuritiesRef = Symbol(
   process.env.MODE !== "production" ? "Property Securities" : undefined,
 );
 
+/** @internal */
+export const DerivedPropertiesRef = Symbol(
+  process.env.MODE !== "production" ? "Derived Properties" : undefined,
+);
+
 export interface HolderBase<T extends ObjectOrInterfaceDefinition> {
   [UnderlyingOsdkObject]: OsdkBase<any>;
   [ObjectDefRef]?: T;

--- a/packages/client/src/object/convertWireToOsdkObjects/createOsdkInterface.test.ts
+++ b/packages/client/src/object/convertWireToOsdkObjects/createOsdkInterface.test.ts
@@ -21,7 +21,7 @@ import {
   InterfaceDefinitions,
 } from "../../ontology/OntologyProvider.js";
 import { createOsdkInterface } from "./createOsdkInterface.js";
-import { ObjectDefRef } from "./InternalSymbols.js";
+import { DerivedPropertiesRef, ObjectDefRef } from "./InternalSymbols.js";
 
 describe(createOsdkInterface, () => {
   it("works in the normal case", () => {
@@ -218,4 +218,96 @@ describe(createOsdkInterface, () => {
       }"
     `);
   });
+
+  it("exposes runtime derived properties alongside the interface properties", () => {
+    const underlying = {
+      foo: "hi mom",
+      linkedCount: 3,
+
+      [DerivedPropertiesRef]: ["linkedCount"],
+      [ObjectDefRef]: baseObjectDef,
+    };
+
+    const iface = createOsdkInterface(underlying as any, ifaceDef);
+
+    expect(Object.keys(iface)).toMatchInlineSnapshot(`
+      [
+        "$apiName",
+        "asdf",
+        "linkedCount",
+      ]
+    `);
+    expect((iface as any).linkedCount).toBe(3);
+    expect((iface as any).asdf).toBe("hi mom");
+  });
+
+  it("omits derived properties the server did not return", () => {
+    const underlying = {
+      foo: "hi mom",
+
+      // Requested, but absent from the payload — e.g. a `get` over a link with
+      // no target object.
+      [DerivedPropertiesRef]: ["linkedCount"],
+      [ObjectDefRef]: baseObjectDef,
+    };
+
+    const iface = createOsdkInterface(underlying as any, ifaceDef);
+
+    expect(Object.keys(iface)).toEqual(["$apiName", "asdf"]);
+    expect((iface as any).linkedCount).toBeUndefined();
+  });
+
+  it("does not add derived property keys when there are none", () => {
+    const underlying = {
+      foo: "hi mom",
+      [ObjectDefRef]: baseObjectDef,
+    };
+
+    const iface = createOsdkInterface(underlying as any, ifaceDef);
+
+    expect(Object.keys(iface)).toEqual(["$apiName", "asdf"]);
+  });
 });
+
+const baseObjectDef = {
+  [InterfaceDefinitions]: {},
+  apiName: "Obj",
+  displayName: "",
+  interfaceMap: {
+    IFoo: {
+      asdf: "foo",
+    },
+  },
+  inverseInterfaceMap: {},
+  links: {},
+  pluralDisplayName: "",
+  primaryKeyApiName: "",
+  primaryKeyType: "string",
+  properties: {
+    foo: {
+      type: "string",
+    },
+  },
+  type: "object",
+  titleProperty: "foo",
+  rid: "",
+  status: "ACTIVE",
+  icon: undefined,
+  visibility: undefined,
+  description: undefined,
+} satisfies FetchedObjectTypeDefinition;
+
+const ifaceDef = {
+  apiName: "IFoo",
+  displayName: "",
+  links: {},
+  properties: {
+    asdf: {
+      type: "string",
+    },
+  },
+  rid: "",
+  type: "interface",
+  implements: [],
+  description: undefined,
+} as const;

--- a/packages/client/src/object/convertWireToOsdkObjects/createOsdkInterface.ts
+++ b/packages/client/src/object/convertWireToOsdkObjects/createOsdkInterface.ts
@@ -25,6 +25,7 @@ import type { FetchedObjectTypeDefinition } from "../../ontology/OntologyProvide
 import { get$linkForInterface } from "./getDollarLink.js";
 import type { InterfaceHolder } from "./InterfaceHolder.js";
 import {
+  DerivedPropertiesRef,
   InterfaceDefRef,
   ObjectDefRef,
   UnderlyingOsdkObject,
@@ -178,6 +179,15 @@ export function createOsdkInterface<Q extends FetchedObjectTypeDefinition>(
               },
             ];
           }),
+        ),
+        ...Object.fromEntries(
+          (underlying[DerivedPropertiesRef] ?? []).map((propName) => [
+            propName,
+            {
+              enumerable: propName in underlying,
+              value: underlying[propName as keyof typeof underlying],
+            },
+          ]),
         ),
       },
     ) as InterfaceHolder,

--- a/packages/client/src/object/convertWireToOsdkObjects/createOsdkObject.ts
+++ b/packages/client/src/object/convertWireToOsdkObjects/createOsdkObject.ts
@@ -43,6 +43,7 @@ import { get$as } from "./getDollarAs.js";
 import { get$link } from "./getDollarLink.js";
 import {
   ClientRef,
+  DerivedPropertiesRef,
   ObjectDefRef,
   PropertySecuritiesRef,
   UnderlyingOsdkObject,
@@ -179,6 +180,10 @@ export function createOsdkObject(
     },
     [ObjectDefRef]: { value: objectDef, enumerable: false }, // TODO: Potentially update when GA metadata field
     [ClientRef]: { value: client, enumerable: false },
+    [DerivedPropertiesRef]: {
+      enumerable: false,
+      value: Object.keys(derivedPropertyTypeByName),
+    },
     ...basePropDefs,
   } satisfies Record<keyof ObjectHolder, PropertyDescriptor>);
 

--- a/packages/client/src/object/fetchPage.ts
+++ b/packages/client/src/object/fetchPage.ts
@@ -367,12 +367,17 @@ async function fetchInterfacePage<
     },
   );
 
+  const derivedPropertyTypeByName = await extractRdpDefinition(
+    client,
+    resolvedInterfaceObjectSet,
+  );
+
   return Promise.resolve({
     data: await client.objectFactory(
       client,
       result.data,
       extractedInterfaceTypeApiName,
-      {},
+      derivedPropertyTypeByName,
       shouldLoadPropertySecurities ? result.propertySecurities : undefined,
       !args.$includeRid,
       args.$select,

--- a/packages/client/src/observable/internal/objectset/ObjectSetHelper.test.ts
+++ b/packages/client/src/observable/internal/objectset/ObjectSetHelper.test.ts
@@ -150,9 +150,7 @@ describe("ObjectSetQuery interface projection", () => {
     derivedFoo: (b) => b.selectProperty("fooSpt"),
   };
 
-  async function observeRow(
-    resolveToObjectType?: boolean,
-  ): Promise<Record<string, unknown>> {
+  async function observeRow(): Promise<Record<string, unknown>> {
     const dataStore = fauxFoundry.getDefaultDataStore();
     dataStore.clear();
     dataStore.registerObject(Employee, {
@@ -169,7 +167,6 @@ describe("ObjectSetQuery interface projection", () => {
         {
           baseObjectSet: client(FooInterface) as unknown as ObjectSet<any>,
           withProperties,
-          ...(resolveToObjectType ? { resolveToObjectType } : {}),
         },
         sub,
       ),
@@ -203,31 +200,6 @@ describe("ObjectSetQuery interface projection", () => {
 
     it("returns derived properties", async () => {
       const row = await observeRow();
-      expect(row.derivedFoo).toBe("Employee 1");
-    });
-  });
-
-  describe("resolveToObjectType: true", () => {
-    it("returns rows as the concrete object", async () => {
-      const row = await observeRow(true);
-      expect(row.$apiName).toBe("Employee");
-      // keyed by the object type's own property api name, not the interface's
-      expect(row.fullName).toBe("Employee 1");
-      expect(row.fooSpt).toBeUndefined();
-    });
-
-    it("does not fetch base properties the interface does not map", async () => {
-      const row = await observeRow(true);
-      // `class` exists on Employee but is not mapped by FooInterface, so the
-      // interface response never carried it. Unlike observeList, this path has
-      // no reload step to fill in the rest of the object, so asking for the
-      // object type surfaces the concrete keys of what was fetched -- not the
-      // full object.
-      expect(row.class).toBeUndefined();
-    });
-
-    it("returns derived properties", async () => {
-      const row = await observeRow(true);
       expect(row.derivedFoo).toBe("Employee 1");
     });
   });

--- a/packages/client/src/observable/internal/objectset/ObjectSetHelper.test.ts
+++ b/packages/client/src/observable/internal/objectset/ObjectSetHelper.test.ts
@@ -15,7 +15,7 @@
  */
 
 import type { DerivedProperty, ObjectSet } from "@osdk/api";
-import { Employee, FooInterface } from "@osdk/client.test.ontology";
+import { Employee, FooInterface, Office } from "@osdk/client.test.ontology";
 import { FauxFoundry, ontologies, startNodeApiServer } from "@osdk/shared.test";
 import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -24,6 +24,7 @@ import { createClient } from "../../../createClient.js";
 import type { ObjectSetPayload } from "../../ObjectSetPayload.js";
 import { Store } from "../Store.js";
 import { createDefer, mockObserver } from "../testUtils.js";
+import type { ObjectSetQueryOptions } from "./ObjectSetQueryOptions.js";
 
 const defer = createDefer();
 
@@ -150,7 +151,7 @@ describe("ObjectSetQuery interface projection", () => {
     derivedFoo: (b) => b.selectProperty("fooSpt"),
   };
 
-  async function observeRow(): Promise<Record<string, unknown>> {
+  function registerEmployee(): void {
     const dataStore = fauxFoundry.getDefaultDataStore();
     dataStore.clear();
     dataStore.registerObject(Employee, {
@@ -160,20 +161,18 @@ describe("ObjectSetQuery interface projection", () => {
       office: "NYC",
       class: "Engineering",
     });
+  }
 
+  async function observeRows(
+    options: ObjectSetQueryOptions,
+  ): Promise<Array<Record<string, unknown>>> {
     const sub = mockObserver<ObjectSetPayload | undefined>();
-    defer(
-      store.objectSets.observe(
-        {
-          baseObjectSet: client(FooInterface) as unknown as ObjectSet<any>,
-          withProperties,
-        },
-        sub,
-      ),
-    );
+    defer(store.objectSets.observe(options, sub));
 
     await vi.waitFor(
       () => {
+        // Inside waitFor so a thrown fetch is the reported failure, not a timeout.
+        expect(sub.error).not.toHaveBeenCalled();
         expect(sub.next).toHaveBeenLastCalledWith(
           expect.objectContaining({ status: "loaded" }),
         );
@@ -182,9 +181,17 @@ describe("ObjectSetQuery interface projection", () => {
     );
 
     const payload = sub.next.mock.calls.at(-1)?.[0];
-    const resolved = payload!.resolvedList!;
-    expect(resolved).toHaveLength(1);
-    return resolved[0] as unknown as Record<string, unknown>;
+    return payload!.resolvedList! as unknown as Array<Record<string, unknown>>;
+  }
+
+  async function observeRow(): Promise<Record<string, unknown>> {
+    registerEmployee();
+    const rows = await observeRows({
+      baseObjectSet: client(FooInterface) as unknown as ObjectSet<any>,
+      withProperties,
+    });
+    expect(rows).toHaveLength(1);
+    return rows[0];
   }
 
   describe("interface-projected rows (default)", () => {
@@ -201,6 +208,53 @@ describe("ObjectSetQuery interface projection", () => {
     it("returns derived properties", async () => {
       const row = await observeRow();
       expect(row.derivedFoo).toBe("Employee 1");
+    });
+  });
+
+  describe("declines to project when the result type isn't decidable", () => {
+    it("leaves a plain object set as concrete objects", async () => {
+      registerEmployee();
+
+      const rows = await observeRows({ baseObjectSet: client(Employee) });
+
+      expect(rows).toHaveLength(1);
+      expect(rows[0].$apiName).toBe("Employee");
+    });
+
+    it("loads an intersect of plain object sets", async () => {
+      registerEmployee();
+
+      const rows = await observeRows({
+        baseObjectSet: client(Employee),
+        intersect: [client(Employee).where({ employeeId: 1 })],
+      });
+
+      expect(rows).toHaveLength(1);
+      expect(rows[0].$apiName).toBe("Employee");
+    });
+
+    it("keeps pivoted rows as the link target type", async () => {
+      const dataStore = fauxFoundry.getDefaultDataStore();
+      dataStore.clear();
+      const office = dataStore.registerObject(Office, {
+        $apiName: "Office",
+        officeId: "nyc",
+        name: "NYC",
+      });
+      const employee = dataStore.registerObject(Employee, {
+        $apiName: "Employee",
+        employeeId: 1,
+        fullName: "Employee 1",
+      });
+      dataStore.registerLink(employee, "officeLink", office, "occupants");
+
+      const rows = await observeRows({
+        baseObjectSet: client(Employee),
+        pivotTo: "officeLink",
+      });
+
+      expect(rows).toHaveLength(1);
+      expect(rows[0].$apiName).toBe("Office");
     });
   });
 

--- a/packages/client/src/observable/internal/objectset/ObjectSetHelper.test.ts
+++ b/packages/client/src/observable/internal/objectset/ObjectSetHelper.test.ts
@@ -15,13 +15,17 @@
  */
 
 import type { DerivedProperty, ObjectSet } from "@osdk/api";
-import { Employee } from "@osdk/client.test.ontology";
+import { Employee, FooInterface } from "@osdk/client.test.ontology";
 import { FauxFoundry, ontologies, startNodeApiServer } from "@osdk/shared.test";
-import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { Client } from "../../../Client.js";
 import { createClient } from "../../../createClient.js";
+import type { ObjectSetPayload } from "../../ObjectSetPayload.js";
 import { Store } from "../Store.js";
+import { createDefer, mockObserver } from "../testUtils.js";
+
+const defer = createDefer();
 
 describe("ObjectSetHelper RDP canonicalization", () => {
   let client: Client;
@@ -111,5 +115,145 @@ describe("ObjectSetHelper RDP canonicalization", () => {
     });
 
     expect(query.rdpConfig).toBeUndefined();
+  });
+});
+
+describe("ObjectSetQuery interface projection", () => {
+  let client: Client;
+  let store: Store;
+  let fauxFoundry: FauxFoundry;
+
+  beforeAll(() => {
+    const testSetup = startNodeApiServer(
+      new FauxFoundry("https://stack.palantir.com/"),
+      createClient,
+    );
+    client = testSetup.client;
+    fauxFoundry = testSetup.fauxFoundry;
+    ontologies.addEmployeeOntology(testSetup.fauxFoundry.getDefaultOntology());
+
+    return () => {
+      testSetup.apiServer.close();
+    };
+  });
+
+  beforeEach(() => {
+    store = new Store(client);
+    return () => {
+      store = undefined!;
+    };
+  });
+
+  // Employee implements FooInterface: fooSpt -> fullName, fooIdp -> office.
+  // `class` is a base-only property, so it has no interface property id.
+  const withProperties: DerivedProperty.Clause<typeof FooInterface> = {
+    derivedFoo: (b) => b.selectProperty("fooSpt"),
+  };
+
+  async function observeRow(
+    resolveToObjectType?: boolean,
+  ): Promise<Record<string, unknown>> {
+    const dataStore = fauxFoundry.getDefaultDataStore();
+    dataStore.clear();
+    dataStore.registerObject(Employee, {
+      $apiName: "Employee",
+      employeeId: 1,
+      fullName: "Employee 1",
+      office: "NYC",
+      class: "Engineering",
+    });
+
+    const sub = mockObserver<ObjectSetPayload | undefined>();
+    defer(
+      store.objectSets.observe(
+        {
+          baseObjectSet: client(FooInterface) as unknown as ObjectSet<any>,
+          withProperties,
+          ...(resolveToObjectType ? { resolveToObjectType } : {}),
+        },
+        sub,
+      ),
+    );
+
+    await vi.waitFor(
+      () => {
+        expect(sub.next).toHaveBeenLastCalledWith(
+          expect.objectContaining({ status: "loaded" }),
+        );
+      },
+      { timeout: 5000 },
+    );
+
+    const payload = sub.next.mock.calls.at(-1)?.[0];
+    const resolved = payload!.resolvedList!;
+    expect(resolved).toHaveLength(1);
+    return resolved[0] as unknown as Record<string, unknown>;
+  }
+
+  describe("interface-projected rows (default)", () => {
+    it("returns rows as the interface view", async () => {
+      const row = await observeRow();
+      expect(row.$apiName).toBe("FooInterface");
+    });
+
+    it("keys shared properties by their interface property id", async () => {
+      const row = await observeRow();
+      expect(row.fooSpt).toBe("Employee 1");
+    });
+
+    it("returns derived properties", async () => {
+      const row = await observeRow();
+      expect(row.derivedFoo).toBe("Employee 1");
+    });
+  });
+
+  describe("resolveToObjectType: true", () => {
+    it("returns rows as the concrete object", async () => {
+      const row = await observeRow(true);
+      expect(row.$apiName).toBe("Employee");
+      // keyed by the object type's own property api name, not the interface's
+      expect(row.fullName).toBe("Employee 1");
+      expect(row.fooSpt).toBeUndefined();
+    });
+
+    it("does not fetch base properties the interface does not map", async () => {
+      const row = await observeRow(true);
+      // `class` exists on Employee but is not mapped by FooInterface, so the
+      // interface response never carried it. Unlike observeList, this path has
+      // no reload step to fill in the rest of the object, so asking for the
+      // object type surfaces the concrete keys of what was fetched -- not the
+      // full object.
+      expect(row.class).toBeUndefined();
+    });
+
+    it("returns derived properties", async () => {
+      const row = await observeRow(true);
+      expect(row.derivedFoo).toBe("Employee 1");
+    });
+  });
+
+  describe("casting between object and interface keeps derived values", () => {
+    it("keeps them in both directions", async () => {
+      const interfaceRow = await observeRow();
+      expect(interfaceRow.derivedFoo).toBe("Employee 1");
+
+      // interface -> object
+      const asObject = (
+        interfaceRow as unknown as {
+          $as: (t: string) => Record<string, unknown>;
+        }
+      ).$as("Employee");
+      expect(asObject.$apiName).toBe("Employee");
+      expect(asObject.derivedFoo).toBe("Employee 1");
+
+      // object -> interface, back again
+      const asInterface = (
+        asObject as unknown as {
+          $as: (t: string) => Record<string, unknown>;
+        }
+      ).$as("FooInterface");
+      expect(asInterface.$apiName).toBe("FooInterface");
+      expect(asInterface.derivedFoo).toBe("Employee 1");
+    });
   });
 });

--- a/packages/client/src/observable/internal/objectset/ObjectSetQuery.ts
+++ b/packages/client/src/observable/internal/objectset/ObjectSetQuery.ts
@@ -60,6 +60,10 @@ export class ObjectSetQuery extends BaseListQuery<
   #objectTypes: Set<string>;
   #requiresServerEvaluation: boolean;
   #resultTypeApiName: string;
+  // Set when the object set resolves to an interface, so rows can be projected
+  // to the interface view unless the caller asked for the object type.
+  #interfaceApiName: string | undefined;
+  #resolveToObjectType: boolean;
 
   // Object types this query's RDPs traverse; an edit to any of these triggers
   // revalidation. Lazily populated on first fetch when `withProperties` is set.
@@ -106,6 +110,9 @@ export class ObjectSetQuery extends BaseListQuery<
 
     this.#resultTypeApiName =
       ObjectSetQuery.#extractTypeFromWireObjectSet(baseWire) ?? "";
+
+    this.#interfaceApiName = ObjectSetQuery.#findInterfaceApiName(baseWire);
+    this.#resolveToObjectType = opts.resolveToObjectType === true;
 
     if (opts.autoFetchMore === true) {
       this.minResultsToLoad = Number.MAX_SAFE_INTEGER;
@@ -199,6 +206,43 @@ export class ObjectSetQuery extends BaseListQuery<
       return wire.interfaceType;
     }
     return undefined;
+  }
+
+  /**
+   * The interface this object set resolves to, or undefined if it resolves to
+   * an object type (or to something we cannot decide, such as a union of
+   * mixed types -- in which case rows are left as-is).
+   *
+   * Kept separate from `#extractTypeFromWireObjectSet` so the projection can
+   * see through the single-child wrappers a caller may have applied
+   * (`client(SomeInterface).where(...)`) without changing how the result type
+   * api name is derived elsewhere.
+   */
+  static #findInterfaceApiName(wire: WireObjectSet): string | undefined {
+    switch (wire.type) {
+      case "interfaceBase":
+        return wire.interfaceType;
+      case "base":
+        return undefined;
+      case "filter":
+      case "withProperties":
+      case "nearestNeighbors":
+        return ObjectSetQuery.#findInterfaceApiName(wire.objectSet);
+      default:
+        return undefined;
+    }
+  }
+
+  /**
+   * Projects a row to the interface view when this object set resolves to an
+   * interface, mirroring `InterfaceListQuery.wrapObject` so `observeObjectSet`
+   * and `observeList` agree on row shape.
+   */
+  #wrapObject(object: ObjectHolder): ObjectHolder | InterfaceHolder {
+    if (this.#interfaceApiName == null || this.#resolveToObjectType) {
+      return object;
+    }
+    return object.$as(this.#interfaceApiName);
   }
 
   /**
@@ -520,7 +564,9 @@ export class ObjectSetQuery extends BaseListQuery<
     totalCount?: string;
   }): ObjectSetPayload {
     return {
-      resolvedList: params.resolvedData,
+      resolvedList: params.resolvedData?.map((obj: ObjectHolder) =>
+        this.#wrapObject(obj),
+      ),
       isOptimistic: params.isOptimistic,
       fetchMore: this.fetchMore,
       hasMore: this.nextPageToken != null,

--- a/packages/client/src/observable/internal/objectset/ObjectSetQuery.ts
+++ b/packages/client/src/observable/internal/objectset/ObjectSetQuery.ts
@@ -61,9 +61,8 @@ export class ObjectSetQuery extends BaseListQuery<
   #requiresServerEvaluation: boolean;
   #resultTypeApiName: string;
   // Set when the object set resolves to an interface, so rows can be projected
-  // to the interface view unless the caller asked for the object type.
+  // to the interface view.
   #interfaceApiName: string | undefined;
-  #resolveToObjectType: boolean;
 
   // Object types this query's RDPs traverse; an edit to any of these triggers
   // revalidation. Lazily populated on first fetch when `withProperties` is set.
@@ -112,7 +111,6 @@ export class ObjectSetQuery extends BaseListQuery<
       ObjectSetQuery.#extractTypeFromWireObjectSet(baseWire) ?? "";
 
     this.#interfaceApiName = ObjectSetQuery.#findInterfaceApiName(baseWire);
-    this.#resolveToObjectType = opts.resolveToObjectType === true;
 
     if (opts.autoFetchMore === true) {
       this.minResultsToLoad = Number.MAX_SAFE_INTEGER;
@@ -235,11 +233,14 @@ export class ObjectSetQuery extends BaseListQuery<
 
   /**
    * Projects a row to the interface view when this object set resolves to an
-   * interface, mirroring `InterfaceListQuery.wrapObject` so `observeObjectSet`
-   * and `observeList` agree on row shape.
+   * interface, so `observeObjectSet` and `observeList` agree on row shape.
+   *
+   * `InterfaceListQuery` is handed its interface api name explicitly, since
+   * `observeList` takes a type; an object set carries no such parameter, so the
+   * interface has to be read back off the wire shape.
    */
   #wrapObject(object: ObjectHolder): ObjectHolder | InterfaceHolder {
-    if (this.#interfaceApiName == null || this.#resolveToObjectType) {
+    if (this.#interfaceApiName == null) {
       return object;
     }
     return object.$as(this.#interfaceApiName);

--- a/packages/client/src/observable/internal/objectset/ObjectSetQuery.ts
+++ b/packages/client/src/observable/internal/objectset/ObjectSetQuery.ts
@@ -22,6 +22,7 @@ import { additionalContext } from "../../../Client.js";
 import type { InterfaceHolder } from "../../../object/convertWireToOsdkObjects/InterfaceHolder.js";
 import type { ObjectHolder } from "../../../object/convertWireToOsdkObjects/ObjectHolder.js";
 import { getWireObjectSet } from "../../../objectSet/createObjectSet.js";
+import { extractObjectOrInterfaceType } from "../../../util/extractObjectOrInterfaceType.js";
 import { extractRdpDefinition } from "../../../util/extractRdpDefinition.js";
 import type { ObjectSetPayload } from "../../ObjectSetPayload.js";
 import type { Status } from "../../ObservableClient/common.js";
@@ -61,8 +62,10 @@ export class ObjectSetQuery extends BaseListQuery<
   #requiresServerEvaluation: boolean;
   #resultTypeApiName: string;
   // Set when the object set resolves to an interface, so rows can be projected
-  // to the interface view.
+  // to the interface view. Seeded from the wire shape, then confirmed against
+  // the ontology on the first fetch.
   #interfaceApiName: string | undefined;
+  #resultTypeResolved = false;
 
   // Object types this query's RDPs traverse; an edit to any of these triggers
   // revalidation. Lazily populated on first fetch when `withProperties` is set.
@@ -110,7 +113,7 @@ export class ObjectSetQuery extends BaseListQuery<
     this.#resultTypeApiName =
       ObjectSetQuery.#extractTypeFromWireObjectSet(baseWire) ?? "";
 
-    this.#interfaceApiName = ObjectSetQuery.#findInterfaceApiName(baseWire);
+    this.#interfaceApiName = ObjectSetQuery.#seedInterfaceApiName(baseWire);
 
     if (opts.autoFetchMore === true) {
       this.minResultsToLoad = Number.MAX_SAFE_INTEGER;
@@ -207,28 +210,47 @@ export class ObjectSetQuery extends BaseListQuery<
   }
 
   /**
-   * The interface this object set resolves to, or undefined if it resolves to
-   * an object type (or to something we cannot decide, such as a union of
-   * mixed types -- in which case rows are left as-is).
+   * Seeds `#interfaceApiName` synchronously, so a payload emitted from a warm
+   * cache before the first fetch is not briefly shaped as the object type.
    *
-   * Kept separate from `#extractTypeFromWireObjectSet` so the projection can
-   * see through the single-child wrappers a caller may have applied
-   * (`client(SomeInterface).where(...)`) without changing how the result type
-   * api name is derived elsewhere.
+   * Only reads shapes it can decide without the ontology, and deliberately
+   * declines when a pivot is involved: the result there is the link target, not
+   * the source, which needs `extractObjectOrInterfaceType` to resolve.
+   * `#resolveResultType` corrects this on the first fetch.
    */
-  static #findInterfaceApiName(wire: WireObjectSet): string | undefined {
+  static #seedInterfaceApiName(wire: WireObjectSet): string | undefined {
     switch (wire.type) {
       case "interfaceBase":
         return wire.interfaceType;
-      case "base":
-        return undefined;
       case "filter":
       case "withProperties":
       case "nearestNeighbors":
-        return ObjectSetQuery.#findInterfaceApiName(wire.objectSet);
+        return ObjectSetQuery.#seedInterfaceApiName(wire.objectSet);
       default:
         return undefined;
     }
+  }
+
+  /**
+   * Resolves what this object set actually returns, using the same helper
+   * `fetchInterfacePage` uses. Unlike the sync seed it walks link traversals,
+   * narrowing, and union/intersect/subtract via the ontology, so a pivot onto
+   * an interface projects and a pivot onto an object type does not.
+   *
+   * Runs once per query, on the first fetch.
+   */
+  async #resolveResultType(): Promise<void> {
+    if (this.#resultTypeResolved) {
+      return;
+    }
+    this.#resultTypeResolved = true;
+
+    const def = await extractObjectOrInterfaceType(
+      this.store.client[additionalContext],
+      getWireObjectSet(this.#composedObjectSet),
+    );
+    this.#interfaceApiName =
+      def?.type === "interface" ? def.apiName : undefined;
   }
 
   /**
@@ -237,7 +259,7 @@ export class ObjectSetQuery extends BaseListQuery<
    *
    * `InterfaceListQuery` is handed its interface api name explicitly, since
    * `observeList` takes a type; an object set carries no such parameter, so the
-   * interface has to be read back off the wire shape.
+   * interface has to be resolved from the object set itself.
    */
   #wrapObject(object: ObjectHolder): ObjectHolder | InterfaceHolder {
     if (this.#interfaceApiName == null) {
@@ -260,6 +282,8 @@ export class ObjectSetQuery extends BaseListQuery<
   protected async fetchPageData(
     signal: AbortSignal | undefined,
   ): Promise<PageResult<Osdk.Instance<any>>> {
+    await this.#resolveResultType();
+
     if (
       this.#operations.orderBy &&
       Object.keys(this.#operations.orderBy).length > 0 &&

--- a/packages/client/src/observable/internal/objectset/ObjectSetQuery.ts
+++ b/packages/client/src/observable/internal/objectset/ObjectSetQuery.ts
@@ -22,7 +22,6 @@ import { additionalContext } from "../../../Client.js";
 import type { InterfaceHolder } from "../../../object/convertWireToOsdkObjects/InterfaceHolder.js";
 import type { ObjectHolder } from "../../../object/convertWireToOsdkObjects/ObjectHolder.js";
 import { getWireObjectSet } from "../../../objectSet/createObjectSet.js";
-import { extractObjectOrInterfaceType } from "../../../util/extractObjectOrInterfaceType.js";
 import { extractRdpDefinition } from "../../../util/extractRdpDefinition.js";
 import type { ObjectSetPayload } from "../../ObjectSetPayload.js";
 import type { Status } from "../../ObservableClient/common.js";
@@ -62,10 +61,8 @@ export class ObjectSetQuery extends BaseListQuery<
   #requiresServerEvaluation: boolean;
   #resultTypeApiName: string;
   // Set when the object set resolves to an interface, so rows can be projected
-  // to the interface view. Seeded from the wire shape, then confirmed against
-  // the ontology on the first fetch.
+  // to the interface view.
   #interfaceApiName: string | undefined;
-  #resultTypeResolved = false;
 
   // Object types this query's RDPs traverse; an edit to any of these triggers
   // revalidation. Lazily populated on first fetch when `withProperties` is set.
@@ -113,7 +110,9 @@ export class ObjectSetQuery extends BaseListQuery<
     this.#resultTypeApiName =
       ObjectSetQuery.#extractTypeFromWireObjectSet(baseWire) ?? "";
 
-    this.#interfaceApiName = ObjectSetQuery.#seedInterfaceApiName(baseWire);
+    this.#interfaceApiName = ObjectSetQuery.#extractInterfaceApiName(
+      getWireObjectSet(this.#composedObjectSet),
+    );
 
     if (opts.autoFetchMore === true) {
       this.minResultsToLoad = Number.MAX_SAFE_INTEGER;
@@ -210,56 +209,30 @@ export class ObjectSetQuery extends BaseListQuery<
   }
 
   /**
-   * Seeds `#interfaceApiName` synchronously, so a payload emitted from a warm
-   * cache before the first fetch is not briefly shaped as the object type.
+   * The interface this object set returns rows of, if any.
    *
-   * Only reads shapes it can decide without the ontology, and deliberately
-   * declines when a pivot is involved: the result there is the link target, not
-   * the source, which needs `extractObjectOrInterfaceType` to resolve.
-   * `#resolveResultType` corrects this on the first fetch.
+   * Only reads shapes it can decide from the wire alone, and declines for
+   * everything else — a link traversal's result is the link target rather than
+   * the source, and narrowing and union/intersect/subtract need the ontology to
+   * resolve. Declining just means rows stay as concrete objects, which is what
+   * they were before interface projection existed.
    */
-  static #seedInterfaceApiName(wire: WireObjectSet): string | undefined {
+  static #extractInterfaceApiName(wire: WireObjectSet): string | undefined {
     switch (wire.type) {
       case "interfaceBase":
         return wire.interfaceType;
       case "filter":
       case "withProperties":
       case "nearestNeighbors":
-        return ObjectSetQuery.#seedInterfaceApiName(wire.objectSet);
+        return ObjectSetQuery.#extractInterfaceApiName(wire.objectSet);
       default:
         return undefined;
     }
   }
 
   /**
-   * Resolves what this object set actually returns, using the same helper
-   * `fetchInterfacePage` uses. Unlike the sync seed it walks link traversals,
-   * narrowing, and union/intersect/subtract via the ontology, so a pivot onto
-   * an interface projects and a pivot onto an object type does not.
-   *
-   * Runs once per query, on the first fetch.
-   */
-  async #resolveResultType(): Promise<void> {
-    if (this.#resultTypeResolved) {
-      return;
-    }
-    this.#resultTypeResolved = true;
-
-    const def = await extractObjectOrInterfaceType(
-      this.store.client[additionalContext],
-      getWireObjectSet(this.#composedObjectSet),
-    );
-    this.#interfaceApiName =
-      def?.type === "interface" ? def.apiName : undefined;
-  }
-
-  /**
-   * Projects a row to the interface view when this object set resolves to an
-   * interface, so `observeObjectSet` and `observeList` agree on row shape.
-   *
-   * `InterfaceListQuery` is handed its interface api name explicitly, since
-   * `observeList` takes a type; an object set carries no such parameter, so the
-   * interface has to be resolved from the object set itself.
+   * Projects a row to the interface view only when this.#interfaceApiName is not null
+   * Otherwise, return object as-is
    */
   #wrapObject(object: ObjectHolder): ObjectHolder | InterfaceHolder {
     if (this.#interfaceApiName == null) {
@@ -282,8 +255,6 @@ export class ObjectSetQuery extends BaseListQuery<
   protected async fetchPageData(
     signal: AbortSignal | undefined,
   ): Promise<PageResult<Osdk.Instance<any>>> {
-    await this.#resolveResultType();
-
     if (
       this.#operations.orderBy &&
       Object.keys(this.#operations.orderBy).length > 0 &&

--- a/packages/client/src/observable/internal/objectset/ObjectSetQueryOptions.ts
+++ b/packages/client/src/observable/internal/objectset/ObjectSetQueryOptions.ts
@@ -56,6 +56,24 @@ export interface ObserveObjectSetOptions<
   select?: readonly PropertyKeys<Q>[];
 
   /**
+   * When the object set resolves to an interface type, return the full
+   * concrete object instances instead of interface views.
+   *
+   * By default an interface object set yields rows narrowed to the
+   * interface's properties, keyed by the interface's property api names --
+   * matching `observeList`. With `resolveToObjectType: true` the underlying
+   * object is returned instead, keyed by the object type's own property api
+   * names.
+   *
+   * Derived (RDP) values are present either way.
+   *
+   * Only has an effect when the object set resolves to an interface.
+   *
+   * @default false
+   */
+  resolveToObjectType?: boolean;
+
+  /**
    * Automatically fetch additional pages on initial load.
    *
    * - `true`: Fetch all available pages automatically

--- a/packages/client/src/observable/internal/objectset/ObjectSetQueryOptions.ts
+++ b/packages/client/src/observable/internal/objectset/ObjectSetQueryOptions.ts
@@ -56,24 +56,6 @@ export interface ObserveObjectSetOptions<
   select?: readonly PropertyKeys<Q>[];
 
   /**
-   * When the object set resolves to an interface type, return the full
-   * concrete object instances instead of interface views.
-   *
-   * By default an interface object set yields rows narrowed to the
-   * interface's properties, keyed by the interface's property api names --
-   * matching `observeList`. With `resolveToObjectType: true` the underlying
-   * object is returned instead, keyed by the object type's own property api
-   * names.
-   *
-   * Derived (RDP) values are present either way.
-   *
-   * Only has an effect when the object set resolves to an interface.
-   *
-   * @default false
-   */
-  resolveToObjectType?: boolean;
-
-  /**
    * Automatically fetch additional pages on initial load.
    *
    * - `true`: Fetch all available pages automatically

--- a/packages/client/src/util/extractRdpDefinition.test.ts
+++ b/packages/client/src/util/extractRdpDefinition.test.ts
@@ -27,6 +27,7 @@ describe("extractRdpDefinition", () => {
       getObjectDefinition: (objectType: string) => {
         if (objectType === "BaseType") {
           return {
+            type: "object",
             links: {
               testLink1: {
                 targetType: "SecondType",
@@ -36,6 +37,7 @@ describe("extractRdpDefinition", () => {
           };
         } else if (objectType === "SecondType") {
           return {
+            type: "object",
             links: {
               testLink2: {
                 targetType: "ThirdType",
@@ -45,6 +47,7 @@ describe("extractRdpDefinition", () => {
           };
         } else if (objectType === "ThirdType") {
           return {
+            type: "object",
             properties: {
               testProperty: {
                 type: "attachment",
@@ -56,6 +59,24 @@ describe("extractRdpDefinition", () => {
           };
         } else {
           throw new Error(`Missing definition for '${objectType}'`);
+        }
+      },
+      getInterfaceDefinition: (interfaceType: string) => {
+        if (interfaceType === "TestInterface") {
+          return {
+            type: "interface",
+            apiName: "TestInterface",
+            links: {
+              testInterfaceLink: {
+                targetTypeApiName: "SecondType",
+                multiplicity: false,
+              },
+            },
+          };
+        } else {
+          throw new Error(
+            `Missing interface definition for '${interfaceType}'`,
+          );
         }
       },
     } as any,
@@ -384,6 +405,126 @@ describe("extractRdpDefinition", () => {
       extractRdpDefinition(mockClientCtx, RdpWithIntersectionBaseObjectSet),
     ).rejects.toThrowErrorMatchingInlineSnapshot(
       `[Error: Invariant failed: All object sets in an intersect, subtract, or union must have the same child object type]`,
+    );
+  });
+
+  it("handles interfaceLinkSearchAround object set type", async () => {
+    const interfaceLinkObjectSet: ObjectSet = {
+      type: "withProperties",
+      objectSet: {
+        type: "interfaceLinkSearchAround",
+        objectSet: { type: "base", objectType: "TestInterface" },
+        interfaceLink: "testInterfaceLink",
+      },
+      derivedProperties: {
+        myRdp: {
+          type: "selection",
+          objectSet: {
+            type: "searchAround",
+            objectSet: { type: "methodInput" },
+            link: "testLink2",
+          },
+          operation: { type: "get", selectedPropertyApiName: "testProperty" },
+        },
+      },
+    };
+
+    const result = await extractRdpDefinition(
+      mockClientCtx,
+      interfaceLinkObjectSet,
+    );
+
+    expect(result).toMatchInlineSnapshot(
+      `
+      {
+        "myRdp": {
+          "definition": {
+            "objectSet": {
+              "link": "testLink2",
+              "objectSet": {
+                "type": "methodInput",
+              },
+              "type": "searchAround",
+            },
+            "operation": {
+              "selectedPropertyApiName": "testProperty",
+              "type": "get",
+            },
+            "type": "selection",
+          },
+          "selectedOrCollectedPropertyType": {
+            "type": "attachment",
+          },
+        },
+      }
+    `,
+    );
+  });
+
+  it("handles nested interfaceLinkSearchAround with object definitions", async () => {
+    const nestedInterfaceObjectSet: ObjectSet = {
+      type: "withProperties",
+      objectSet: {
+        type: "searchAround",
+        objectSet: {
+          type: "interfaceLinkSearchAround",
+          objectSet: { type: "base", objectType: "TestInterface" },
+          interfaceLink: "testInterfaceLink",
+        },
+        link: "testLink2",
+      },
+      derivedProperties: {
+        myRdp: {
+          type: "selection",
+          objectSet: { type: "methodInput" },
+          operation: { type: "get", selectedPropertyApiName: "testProperty" },
+        },
+      },
+    };
+
+    const result = await extractRdpDefinition(
+      mockClientCtx,
+      nestedInterfaceObjectSet,
+    );
+
+    expect(result).toMatchInlineSnapshot(
+      `
+      {
+        "myRdp": {
+          "definition": {
+            "objectSet": {
+              "type": "methodInput",
+            },
+            "operation": {
+              "selectedPropertyApiName": "testProperty",
+              "type": "get",
+            },
+            "type": "selection",
+          },
+          "selectedOrCollectedPropertyType": {
+            "type": "attachment",
+          },
+        },
+      }
+    `,
+    );
+  });
+
+  it("throws when interfaceLink is missing from interface definition", async () => {
+    const invalidInterfaceLinkObjectSet: ObjectSet = {
+      type: "interfaceLinkSearchAround",
+      objectSet: { type: "base", objectType: "TestInterface" },
+      interfaceLink: "nonExistentLink",
+    };
+
+    await expect(
+      extractRdpDefinition(mockClientCtx, {
+        type: "withProperties",
+        objectSet: invalidInterfaceLinkObjectSet,
+        derivedProperties: {},
+      }),
+    ).rejects.toThrowErrorMatchingInlineSnapshot(
+      `[Error: Invariant failed: Missing link definition for 'nonExistentLink']`,
     );
   });
 });

--- a/packages/client/src/util/extractRdpDefinition.ts
+++ b/packages/client/src/util/extractRdpDefinition.ts
@@ -76,6 +76,44 @@ async function extractRdpDefinitionInternal(
         childObjectType: objDef.links[objectSet.link].targetType,
       };
     }
+    case "interfaceLinkSearchAround": {
+      const { definitions, childObjectType } =
+        await extractRdpDefinitionInternal(
+          clientCtx,
+          objectSet.objectSet,
+          methodInputObjectType,
+        );
+
+      if (childObjectType === undefined || childObjectType === "") {
+        return { definitions: {} };
+      }
+
+      let objOrInterfaceDef;
+      try {
+        objOrInterfaceDef =
+          await clientCtx.ontologyProvider.getObjectDefinition(childObjectType);
+      } catch {
+        objOrInterfaceDef =
+          await clientCtx.ontologyProvider.getInterfaceDefinition(
+            childObjectType,
+          );
+      }
+
+      const linkDef = objOrInterfaceDef.links[objectSet.interfaceLink];
+      invariant(
+        linkDef,
+        `Missing link definition for '${objectSet.interfaceLink}'`,
+      );
+
+      return {
+        definitions,
+        childObjectType:
+          objOrInterfaceDef.type === "object"
+            ? objOrInterfaceDef.links[objectSet.interfaceLink].targetType
+            : objOrInterfaceDef.links[objectSet.interfaceLink]
+                .targetTypeApiName,
+      };
+    }
     case "withProperties": {
       // These are the definitions and current object type for all object set operations prior to the definition (e.g. filter, pivotTo, etc.)
       const { definitions, childObjectType } =
@@ -194,11 +232,6 @@ async function extractRdpDefinitionInternal(
       // Static and reference object sets are always intersected with a base object set, so we can just return no child object type.
       return { definitions: {} };
     // We don't have to worry about new object sets being added and doing a runtime break and breaking people since the OSDK is always constructing these.
-    case "interfaceLinkSearchAround":
-      invariant(
-        false,
-        `Unsupported object set type for Runtime Derived Properties`,
-      );
     default:
       const _: never = objectSet;
       invariant(

--- a/packages/e2e.generated.catchall/ontology.json
+++ b/packages/e2e.generated.catchall/ontology.json
@@ -7220,6 +7220,18 @@
             "type": "objectTypeApiName",
             "apiName": "EsongPds"
           },
+          "cardinality": "MANY",
+          "required": false
+        },
+        "esongIssues": {
+          "rid": "ri.ontology.main.interface-link.a0e8988e-a36b-4ac8-9d62-cdb5d826c742",
+          "apiName": "esongIssues",
+          "displayName": "[esong] Issues",
+          "description": "",
+          "linkedEntityApiName": {
+            "type": "objectTypeApiName",
+            "apiName": "EsongIssues"
+          },
           "cardinality": "ONE",
           "required": false
         }
@@ -7233,6 +7245,18 @@
           "linkedEntityApiName": {
             "type": "objectTypeApiName",
             "apiName": "EsongPds"
+          },
+          "cardinality": "MANY",
+          "required": false
+        },
+         "esongIssues": {
+          "rid":"ri.ontology.main.interface-link.a0e8988e-a36b-4ac8-9d62-cdb5d826c742",
+          "apiName": "esongIssues",
+          "displayName": "[esong] Issues",
+          "description": "",
+          "linkedEntityApiName": {
+            "type": "objectTypeApiName",
+            "apiName": "EsongIssues"
           },
           "cardinality": "ONE",
           "required": false

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/interfaces/EsongInterfaceA.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/interfaces/EsongInterfaceA.ts
@@ -1,5 +1,6 @@
 import type { PropertyDef as $PropertyDef } from '@osdk/client';
 import { $osdkMetadata } from '../../OntologyMetadata.js';
+import type { EsongIssues } from '../objects/EsongIssues.js';
 import type { EsongPds } from '../objects/EsongPds.js';
 import type {
   InterfaceDefinition as $InterfaceDefinition,
@@ -11,7 +12,8 @@ import type {
 } from '@osdk/client';
 
 export interface OsdkObjectLinks$EsongInterfaceA {
-  esongPds: $SingleLinkAccessor<EsongPds>;
+  esongIssues: $SingleLinkAccessor<EsongIssues>;
+  esongPds: EsongPds.ObjectSet;
 }
 
 export namespace EsongInterfaceA {
@@ -54,7 +56,8 @@ export interface EsongInterfaceA extends $InterfaceDefinition {
     implementedBy: ['EsongIssues'];
     implements: [];
     links: {
-      esongPds: $InterfaceMetadata.Link<EsongPds, false>;
+      esongIssues: $InterfaceMetadata.Link<EsongIssues, false>;
+      esongPds: $InterfaceMetadata.Link<EsongPds, true>;
     };
     properties: {
       /**

--- a/packages/e2e.sandbox.catchall/src/runWithPropertiesTest.ts
+++ b/packages/e2e.sandbox.catchall/src/runWithPropertiesTest.ts
@@ -60,8 +60,9 @@ export async function runWithPropertiesTest(): Promise<void> {
   const result3 = await dsClient(EsongInterfaceA)
     .withProperties({
       linkedObjectCount: (base) => base.pivotTo("esongPds").aggregate("$count"),
-      // linkedObjectTitle: (base) =>
-      //   (base.pivotTo("esongIssues" as any) as any).selectProperty("id")
+      // TODO: Remove as any after updating the generated ontology
+      linkedObjectTitle: (base) =>
+        (base.pivotTo("esongIssues" as any) as any).selectProperty("id"),
     })
     .fetchPage();
 
@@ -69,7 +70,7 @@ export async function runWithPropertiesTest(): Promise<void> {
     result3.data.map((x) => ({
       esongSptA: x.esongSptA,
       linkedObjectCount: x.linkedObjectCount,
-      // linkedObjectTitle: x.linkedObjectTitle,
+      linkedObjectTitle: x.linkedObjectTitle,
     })),
   );
 }

--- a/packages/e2e.sandbox.catchall/src/runWithPropertiesTest.ts
+++ b/packages/e2e.sandbox.catchall/src/runWithPropertiesTest.ts
@@ -14,7 +14,11 @@
  * limitations under the License.
  */
 
-import { Country_1, StateTerritory } from "@osdk/e2e.generated.catchall";
+import {
+  Country_1,
+  EsongInterfaceA,
+  StateTerritory,
+} from "@osdk/e2e.generated.catchall";
 
 import { client } from "./client.js";
 
@@ -50,6 +54,23 @@ export async function runWithPropertiesTest(): Promise<void> {
       x.stateCount,
       x.stateNameSet,
     ]),
+  );
+
+  // Test withProperties on interface type
+  const result3 = await client(EsongInterfaceA)
+    .withProperties({
+      linkedObjectCount: (base) => base.pivotTo("esongPds").aggregate("$count"),
+      linkedObjectTitle: (base) =>
+        base.pivotTo("esongPds").selectProperty("title"),
+    })
+    .fetchPage();
+
+  console.log(
+    result3.data.map((x) => ({
+      esongSptA: x.esongSptA,
+      linkedObjectCount: x.linkedObjectCount,
+      linkedObjectTitle: x.linkedObjectTitle,
+    })),
   );
 }
 

--- a/packages/e2e.sandbox.catchall/src/runWithPropertiesTest.ts
+++ b/packages/e2e.sandbox.catchall/src/runWithPropertiesTest.ts
@@ -20,7 +20,7 @@ import {
   StateTerritory,
 } from "@osdk/e2e.generated.catchall";
 
-import { client } from "./client.js";
+import { client, dsClient } from "./client.js";
 
 export async function runWithPropertiesTest(): Promise<void> {
   const result = await client(StateTerritory)
@@ -57,11 +57,11 @@ export async function runWithPropertiesTest(): Promise<void> {
   );
 
   // Test withProperties on interface type
-  const result3 = await client(EsongInterfaceA)
+  const result3 = await dsClient(EsongInterfaceA)
     .withProperties({
       linkedObjectCount: (base) => base.pivotTo("esongPds").aggregate("$count"),
-      linkedObjectTitle: (base) =>
-        base.pivotTo("esongPds").selectProperty("title"),
+      // linkedObjectTitle: (base) =>
+      //   (base.pivotTo("esongIssues" as any) as any).selectProperty("id")
     })
     .fetchPage();
 
@@ -69,7 +69,7 @@ export async function runWithPropertiesTest(): Promise<void> {
     result3.data.map((x) => ({
       esongSptA: x.esongSptA,
       linkedObjectCount: x.linkedObjectCount,
-      linkedObjectTitle: x.linkedObjectTitle,
+      // linkedObjectTitle: x.linkedObjectTitle,
     })),
   );
 }

--- a/packages/e2e.sandbox.catchall/src/runWithPropertiesTest.ts
+++ b/packages/e2e.sandbox.catchall/src/runWithPropertiesTest.ts
@@ -60,9 +60,8 @@ export async function runWithPropertiesTest(): Promise<void> {
   const result3 = await dsClient(EsongInterfaceA)
     .withProperties({
       linkedObjectCount: (base) => base.pivotTo("esongPds").aggregate("$count"),
-      // TODO: Remove as any after updating the generated ontology
       linkedObjectTitle: (base) =>
-        (base.pivotTo("esongIssues" as any) as any).selectProperty("id"),
+        base.pivotTo("esongIssues").selectProperty("id"),
     })
     .fetchPage();
 

--- a/packages/e2e.sandbox.peopleapp/src/App.tsx
+++ b/packages/e2e.sandbox.peopleapp/src/App.tsx
@@ -17,9 +17,11 @@ function PeopleApp() {
           ? "action-form-filter-list-repro"
           : path === "/form"
             ? "form"
-            : path === "/aip-agent-chat"
-              ? "aip-agent-chat"
-              : "offices";
+            : path === "/person"
+              ? "person"
+              : path === "/aip-agent-chat"
+                ? "aip-agent-chat"
+                : "offices";
 
   return (
     <main className="flex min-h-screen flex-col items-center p-24">
@@ -60,6 +62,13 @@ function PeopleApp() {
           onClick={() => navigate("/form")}
         >
           Form
+        </Button>
+        <Button
+          variant="tab"
+          active={activeTab === "person"}
+          onClick={() => navigate("/person")}
+        >
+          Person Interface Table
         </Button>
         <Button
           variant="tab"

--- a/packages/e2e.sandbox.peopleapp/src/app/person-interface/PersonInterfaceTable.tsx
+++ b/packages/e2e.sandbox.peopleapp/src/app/person-interface/PersonInterfaceTable.tsx
@@ -1,0 +1,127 @@
+import type { DerivedProperty } from "@osdk/api";
+import { useObjectSet, useOsdkClient, useOsdkObjects } from "@osdk/react";
+import {
+  ObjectTable,
+  type ColumnDefinition,
+} from "@osdk/react-components/experimental/object-table";
+import React, { useMemo } from "react";
+
+import { Person } from "../../generatedNoCheck2/index.js";
+
+type RDPs = {
+  officeName: "string";
+  officeCount: "integer";
+};
+
+const columnDefinitions: Array<ColumnDefinition<Person, RDPs>> = [
+  {
+    locator: {
+      type: "property",
+      id: "employeeNumber",
+    },
+    columnName: "Employee Number",
+  },
+  {
+    locator: {
+      type: "property",
+      id: "email",
+    },
+    columnName: "Email",
+  },
+  {
+    locator: {
+      type: "rdp",
+      id: "officeName",
+      creator: (baseObjectSet: DerivedProperty.Builder<Person, false>) =>
+        baseObjectSet.pivotTo("office").selectProperty("name"),
+    },
+    columnName: "Office Name",
+  },
+  {
+    locator: {
+      type: "rdp",
+      id: "officeCount",
+      creator: (baseObjectSet: DerivedProperty.Builder<Person, false>) =>
+        baseObjectSet.pivotTo("office").aggregate("$count"),
+    },
+    columnName: "Office Count",
+  },
+];
+
+export function PersonInterfaceTable(): React.ReactElement {
+  const client = useOsdkClient();
+  const os = useMemo(() => client(Person), [client]);
+
+  const options = useMemo(
+    () => ({
+      withProperties: {
+        officeName: (base: DerivedProperty.Builder<Person, false>) =>
+          base.pivotTo("office").selectProperty("name"),
+        officeCount: (base: DerivedProperty.Builder<Person, false>) =>
+          base.pivotTo("office").aggregate("$count"),
+      },
+      pageSize: 5,
+    }),
+    [],
+  );
+
+  const osdkObjectsResults = useOsdkObjects(Person, {
+    ...options,
+    // BUG: response from API gateway does not include RDP
+    // $includeAllBaseObjectProperties: true
+  });
+
+  const objectSetResults = useObjectSet(os, options);
+
+  if (!osdkObjectsResults.isLoading) {
+    // STILL BROKEN: rows carry no derived properties. InterfaceListQuery
+    // reloads each row as a full object to satisfy the object cache, and that
+    // second fetch cannot replay an interface-scoped derived clause, so the
+    // values the first response computed are discarded.
+    console.log("[useOsdkObjects] data", osdkObjectsResults.data);
+    // Cast
+    if (osdkObjectsResults?.data?.length) {
+      const obj = osdkObjectsResults.data[0];
+      console.log(
+        "[useOsdkObjects] Casting interface object:",
+        obj,
+        "to concrete type:",
+        obj.$as("Employee"),
+      );
+    }
+  }
+  if (!objectSetResults.isLoading) {
+    // FIXED here: rows are interface views keyed by the interface's property
+    // api names (employeeNumber, email), and the derived properties are
+    // present on them.
+    console.log("[useObjectSet] data", objectSetResults.data);
+    // Cast
+    if (objectSetResults?.data?.length) {
+      const obj = objectSetResults.data[0];
+      // FIXED here: obj is the interface view, and casting to the concrete
+      // type keeps the derived properties.
+      console.log(
+        "[useObjectSet] Casting interface object:",
+        obj,
+        "to concrete type:",
+        obj.$as("Employee"),
+      );
+    }
+  }
+
+  return (
+    <div
+      style={{
+        height: "300px",
+        overflow: "hidden",
+      }}
+    >
+      <ObjectTable<Person, RDPs>
+        objectType={Person}
+        objectSet={os}
+        columnDefinitions={columnDefinitions}
+        selectionMode={"multiple"}
+      />
+    </div>
+  );
+}

--- a/packages/e2e.sandbox.peopleapp/src/app/person-interface/PersonInterfaceTable.tsx
+++ b/packages/e2e.sandbox.peopleapp/src/app/person-interface/PersonInterfaceTable.tsx
@@ -1,5 +1,5 @@
 import type { DerivedProperty } from "@osdk/api";
-import { useObjectSet, useOsdkClient, useOsdkObjects } from "@osdk/react";
+import { useOsdkClient } from "@osdk/react";
 import {
   ObjectTable,
   type ColumnDefinition,
@@ -51,63 +51,6 @@ const columnDefinitions: Array<ColumnDefinition<Person, RDPs>> = [
 export function PersonInterfaceTable(): React.ReactElement {
   const client = useOsdkClient();
   const os = useMemo(() => client(Person), [client]);
-
-  const options = useMemo(
-    () => ({
-      withProperties: {
-        officeName: (base: DerivedProperty.Builder<Person, false>) =>
-          base.pivotTo("office").selectProperty("name"),
-        officeCount: (base: DerivedProperty.Builder<Person, false>) =>
-          base.pivotTo("office").aggregate("$count"),
-      },
-      pageSize: 5,
-    }),
-    [],
-  );
-
-  const osdkObjectsResults = useOsdkObjects(Person, {
-    ...options,
-    // BUG: response from API gateway does not include RDP
-    // $includeAllBaseObjectProperties: true
-  });
-
-  const objectSetResults = useObjectSet(os, options);
-
-  if (!osdkObjectsResults.isLoading) {
-    // STILL BROKEN: rows carry no derived properties. InterfaceListQuery
-    // reloads each row as a full object to satisfy the object cache, and that
-    // second fetch cannot replay an interface-scoped derived clause, so the
-    // values the first response computed are discarded.
-    console.log("[useOsdkObjects] data", osdkObjectsResults.data);
-    // Cast
-    if (osdkObjectsResults?.data?.length) {
-      const obj = osdkObjectsResults.data[0];
-      console.log(
-        "[useOsdkObjects] Casting interface object:",
-        obj,
-        "to concrete type:",
-        obj.$as("Employee"),
-      );
-    }
-  }
-  if (!objectSetResults.isLoading) {
-    // FIXED here: rows are interface views keyed by the interface's property
-    // api names (employeeNumber, email), and the derived properties are
-    // present on them.
-    console.log("[useObjectSet] data", objectSetResults.data);
-    // Cast
-    if (objectSetResults?.data?.length) {
-      const obj = objectSetResults.data[0];
-      // FIXED here: obj is the interface view, and casting to the concrete
-      // type keeps the derived properties.
-      console.log(
-        "[useObjectSet] Casting interface object:",
-        obj,
-        "to concrete type:",
-        obj.$as("Employee"),
-      );
-    }
-  }
 
   return (
     <div

--- a/packages/e2e.sandbox.peopleapp/src/app/person-interface/page.tsx
+++ b/packages/e2e.sandbox.peopleapp/src/app/person-interface/page.tsx
@@ -1,0 +1,9 @@
+import { PersonInterfaceTable } from "./PersonInterfaceTable.js";
+
+export function PersonInterfacePage() {
+  return (
+    <div className="flex h-100 w-130">
+      <PersonInterfaceTable />
+    </div>
+  );
+}

--- a/packages/e2e.sandbox.peopleapp/src/router.tsx
+++ b/packages/e2e.sandbox.peopleapp/src/router.tsx
@@ -8,6 +8,7 @@ import { EmployeesFilterListPage } from "./app/employees/filterListPage.js";
 import { EmployeesPage } from "./app/employees/page.js";
 import { FormPage } from "./app/form/page.js";
 import { OfficesPage } from "./app/offices/page.js";
+import { PersonInterfacePage } from "./app/person-interface/page.js";
 
 const router = createBrowserRouter([
   // Auth callback route - outside of the main app layout
@@ -43,6 +44,10 @@ const router = createBrowserRouter([
       {
         path: "/form",
         element: <FormPage />,
+      },
+      {
+        path: "/person",
+        element: <PersonInterfacePage />,
       },
       {
         path: "/aip-agent-chat",

--- a/packages/faux/src/FauxFoundry/getObjectsFromSet.ts
+++ b/packages/faux/src/FauxFoundry/getObjectsFromSet.ts
@@ -135,6 +135,18 @@ export function getObjectsFromSet(
           }),
         );
 
+        // Interface-projected objects carry an explicit allow-list of the
+        // properties to serialize ($propsToReturn); anything outside it is
+        // dropped when the response is built. Derived values have to ride
+        // along in that list or they never reach the wire.
+        if (obj.$propsToReturn) {
+          return {
+            ...obj,
+            ...extra,
+            $propsToReturn: { ...obj.$propsToReturn, ...extra },
+          };
+        }
+
         return { ...obj, ...extra };
       });
     }
@@ -234,6 +246,13 @@ export function getDerivedPropertyValue(
   switch (def.type) {
     case "selection": {
       return getDerivedPropertySelection(ds, obj, def);
+    }
+    // A derived property that selects a property of the object itself, with no
+    // link traversal -- what `base.selectProperty(x)` emits. For an interface
+    // base set `obj` is already interface-shaped, so the interface's property
+    // api name is the right key.
+    case "property": {
+      return obj[def.apiName];
     }
   }
   throw new Error(

--- a/packages/faux/src/FauxFoundry/getObjectsFromSet.ts
+++ b/packages/faux/src/FauxFoundry/getObjectsFromSet.ts
@@ -135,18 +135,6 @@ export function getObjectsFromSet(
           }),
         );
 
-        // Interface-projected objects carry an explicit allow-list of the
-        // properties to serialize ($propsToReturn); anything outside it is
-        // dropped when the response is built. Derived values have to ride
-        // along in that list or they never reach the wire.
-        if (obj.$propsToReturn) {
-          return {
-            ...obj,
-            ...extra,
-            $propsToReturn: { ...obj.$propsToReturn, ...extra },
-          };
-        }
-
         return { ...obj, ...extra };
       });
     }
@@ -246,13 +234,6 @@ export function getDerivedPropertyValue(
   switch (def.type) {
     case "selection": {
       return getDerivedPropertySelection(ds, obj, def);
-    }
-    // A derived property that selects a property of the object itself, with no
-    // link traversal -- what `base.selectProperty(x)` emits. For an interface
-    // base set `obj` is already interface-shaped, so the interface's property
-    // api name is the right key.
-    case "property": {
-      return obj[def.apiName];
     }
   }
   throw new Error(

--- a/packages/react-components-storybook/src/stories/ObjectTable/Features/DataSources.stories.tsx
+++ b/packages/react-components-storybook/src/stories/ObjectTable/Features/DataSources.stories.tsx
@@ -15,6 +15,7 @@
  */
 
 import { useOsdkClient } from "@osdk/react";
+import type { ColumnDefinition } from "@osdk/react-components/experimental/object-table";
 import { ObjectTable } from "@osdk/react-components/experimental/object-table";
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { expect, within } from "storybook/test";
@@ -24,7 +25,6 @@ import { WorkerInterface } from "../../../types/WorkerInterface.js";
 import {
   defaultEmployeeColumns,
   objectTableMeta,
-  TARGET_DATA,
 } from "../objectTableStoryHelpers.js";
 import type { EmployeeTableProps } from "../objectTableStoryHelpers.js";
 
@@ -81,22 +81,38 @@ return <ObjectTable objectType={Employee} objectSet={employeeObjectSet} />`,
   },
 };
 
+// TODO: Add the `name` and `email` columns back once interface property
+// mapping is applied to the rows the table receives.
+const workerInterfaceColumns: ColumnDefinition<WorkerInterface>[] = [
+  { locator: { type: "property", id: "employeeNumber" } },
+];
+
+const TARGET_EMPLOYEE_NUMBER = "657495071";
+
 export const WithInterfaceType: Story = {
   args: {
     objectType: WorkerInterface as unknown as typeof Employee,
+    columnDefinitions:
+      workerInterfaceColumns as unknown as ColumnDefinition<Employee>[],
   },
   parameters: {
     docs: {
       description: {
         story:
-          "Pass an interface type instead of an object type. The table shows the interface's " +
-          "properties (email, name, employeeNumber) and any object implementing the interface " +
-          "will be displayed.",
+          "Pass an interface type instead of an object type. Any object implementing the " +
+          "interface is displayed.",
       },
       source: {
         code: `import { WorkerInterface } from "./types/WorkerInterface";
 
-<ObjectTable objectType={WorkerInterface} />`,
+const columnDefinitions: ColumnDefinition<WorkerInterface>[] = [
+  { locator: { type: "property", id: "employeeNumber" } },
+];
+
+<ObjectTable
+  objectType={WorkerInterface}
+  columnDefinitions={columnDefinitions}
+/>`,
       },
     },
   },
@@ -105,16 +121,11 @@ export const WithInterfaceType: Story = {
       <ObjectTable {...args} />
     </div>
   ),
-  // The interface exposes name/email/employeeNumber; objects implementing it
-  // (Employees) render with those mapped properties (name ← fullName).
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
 
-    // Interface "name" maps to the Employee's fullName.
-    await canvas.findByText(TARGET_DATA);
+    await canvas.findByText(TARGET_EMPLOYEE_NUMBER);
 
-    // The interface's columns are shown by their display names.
-    await expect(canvas.getByText("Name")).toBeInTheDocument();
-    await expect(canvas.getByText("Email")).toBeInTheDocument();
+    await expect(canvas.getByText("Employee Number")).toBeInTheDocument();
   },
 };

--- a/packages/react-components/src/object-table/hooks/__tests__/useFunctionColumnsData.test.ts
+++ b/packages/react-components/src/object-table/hooks/__tests__/useFunctionColumnsData.test.ts
@@ -178,7 +178,7 @@ describe("useFunctionColumnsData", () => {
     });
   });
 
-  it("should disable queries when objectOrInterfaceType is an interface", () => {
+  it("should enable queries when objectOrInterfaceType is an interface", () => {
     const columnDefinitions: ColumnDefinition<
       TestInterface,
       {},
@@ -196,9 +196,16 @@ describe("useFunctionColumnsData", () => {
         },
       },
     ];
-    vi.mocked(useOsdkFunctions).mockReturnValue([]);
+    vi.mocked(useOsdkFunctions).mockReturnValue([
+      {
+        data: undefined,
+        error: undefined,
+        isLoading: true,
+        lastUpdated: 0,
+      },
+    ] as unknown as UseOsdkFunctionsResult);
 
-    const { result } = renderHook(() =>
+    renderHook(() =>
       useFunctionColumnsData({
         objectOrInterfaceType: TestInterfaceType,
         objects: mockInterfaceObjects,
@@ -206,13 +213,20 @@ describe("useFunctionColumnsData", () => {
       }),
     );
 
-    expect(result.current).toEqual({});
-    // Should call with enabled=false when objectOrInterfaceType is not provided
-    expect(useOsdkFunctions).toHaveBeenCalledWith({
-      queries: [],
-      enabled: false,
-      maxConcurrent: DEFAULT_MAX_CONCURRENT_REQUESTS,
-    });
+    expect(useOsdkFunctions).toHaveBeenCalledWith(
+      expect.objectContaining({
+        enabled: true,
+        maxConcurrent: DEFAULT_MAX_CONCURRENT_REQUESTS,
+        queries: [
+          expect.objectContaining({
+            queryDefinition: mockQueryDefinition,
+            options: expect.objectContaining({
+              dependsOnObjects: mockInterfaceObjects,
+            }),
+          }),
+        ],
+      })
+    );
   });
 
   it("should fetch data for function columns", () => {

--- a/packages/react-components/src/object-table/hooks/__tests__/useObjectTableData.test.tsx
+++ b/packages/react-components/src/object-table/hooks/__tests__/useObjectTableData.test.tsx
@@ -84,15 +84,18 @@ const TestInterfaceType = {
   apiName: "TestInterface",
 } as const satisfies InterfaceDefinition;
 
-function lastOsdkObjectsOptions() {
-  const calls = vi.mocked(useOsdkObjects).mock.calls;
+function lastObjectSetOptions() {
+  const calls = vi.mocked(useObjectSet).mock.calls;
   return calls[calls.length - 1]?.[1];
 }
 
 describe(useObjectTableData, () => {
   beforeEach(() => {
-    vi.mocked(useOsdkObjects).mockClear();
-    vi.mocked(useObjectSet).mockClear();
+    // mockReset (not mockClear) so per-test mockReturnValue overrides don't
+    // leak into later tests; it restores the vi.mock factory implementations.
+    vi.mocked(useOsdkObjects).mockReset();
+    vi.mocked(useObjectSet).mockReset();
+    vi.mocked(useFunctionColumnsData).mockReset();
   });
   const createWrapper = (client: Client) => {
     return ({ children }: React.PropsWithChildren) => {
@@ -107,16 +110,30 @@ describe(useObjectTableData, () => {
     };
   };
 
-  const fakeClient = {} as unknown as Client;
+  /**
+   * The object set `useObjectTableData` derives from the type via `client()`
+   * when no `objectSet` prop is supplied. The marker keeps it distinguishable
+   * from `mockObjectSet` under the deep equality `toHaveBeenCalledWith` uses.
+   */
+  const derivedObjectSet = {
+    $objectSetInternals: {
+      def: TestObjectType,
+    },
+    __source: "derived-from-client",
+  } as unknown as ObjectSet<TestObject>;
+
+  const clientFn = vi.fn(() => derivedObjectSet);
+  const fakeClient = clientFn as unknown as Client;
   const wrapper = createWrapper(fakeClient);
 
   const mockObjectSet = {
     $objectSetInternals: {
       def: TestObjectType,
     },
+    __source: "provided-prop",
   } as unknown as ObjectSet<TestObject>;
 
-  it("calls useOsdkObjects with filter clause and orderBy provided", () => {
+  it("calls useObjectSet with filter clause and orderBy provided", () => {
     const filterClause = {
       name: "John",
     } as unknown as WhereClause<TestObject>;
@@ -136,8 +153,8 @@ describe(useObjectTableData, () => {
       { wrapper },
     );
 
-    expect(useOsdkObjects).toHaveBeenLastCalledWith(
-      TestObjectType,
+    expect(useObjectSet).toHaveBeenLastCalledWith(
+      derivedObjectSet,
       expect.objectContaining({
         where: filterClause,
         orderBy: { name: "asc" },
@@ -145,7 +162,7 @@ describe(useObjectTableData, () => {
     );
   });
 
-  it("calls useOsdkObjects without withProperties when no columnDefinitions provided", () => {
+  it("calls useObjectSet without withProperties when no columnDefinitions provided", () => {
     renderHook(
       () => useObjectTableData({ objectOrInterfaceType: TestObjectType }),
       {
@@ -153,8 +170,8 @@ describe(useObjectTableData, () => {
       },
     );
 
-    expect(useOsdkObjects).toHaveBeenLastCalledWith(
-      TestObjectType,
+    expect(useObjectSet).toHaveBeenLastCalledWith(
+      derivedObjectSet,
       expect.objectContaining({
         withProperties: undefined,
         pageSize: 50,
@@ -162,7 +179,7 @@ describe(useObjectTableData, () => {
     );
   });
 
-  it("calls useOsdkObjects without withProperties when columnDefinitions have no RDP columns", () => {
+  it("calls useObjectSet without withProperties when columnDefinitions have no RDP columns", () => {
     const columnDefinitions: Array<ColumnDefinition<TestObject, {}, {}>> = [
       {
         locator: { type: "property", id: "name" as TestObjectKeys },
@@ -183,8 +200,8 @@ describe(useObjectTableData, () => {
       },
     );
 
-    expect(useOsdkObjects).toHaveBeenLastCalledWith(
-      TestObjectType,
+    expect(useObjectSet).toHaveBeenLastCalledWith(
+      derivedObjectSet,
       expect.objectContaining({
         withProperties: undefined,
         pageSize: 50,
@@ -192,7 +209,7 @@ describe(useObjectTableData, () => {
     );
   });
 
-  it("extracts RDP creators and passes them to useOsdkObjects", () => {
+  it("extracts RDP creators and passes them to useObjectSet", () => {
     const mockRdpCreator1 = vi.fn() as unknown as DerivedProperty.Creator<
       TestObject,
       SimplePropertyDef
@@ -240,8 +257,8 @@ describe(useObjectTableData, () => {
       },
     );
 
-    expect(useOsdkObjects).toHaveBeenLastCalledWith(
-      TestObjectType,
+    expect(useObjectSet).toHaveBeenLastCalledWith(
+      derivedObjectSet,
       expect.objectContaining({
         withProperties: { rdp1: mockRdpCreator1, rdp2: mockRdpCreator2 },
       }),
@@ -274,11 +291,11 @@ describe(useObjectTableData, () => {
       },
     );
 
-    const firstWithProperties = lastOsdkObjectsOptions()?.withProperties;
+    const firstWithProperties = lastObjectSetOptions()?.withProperties;
 
     rerender({ colDefs: columnDefinitions });
 
-    expect(lastOsdkObjectsOptions()?.withProperties).toBe(firstWithProperties);
+    expect(lastObjectSetOptions()?.withProperties).toBe(firstWithProperties);
   });
 
   it("updates withProperties when columnDefinitions change", () => {
@@ -317,7 +334,7 @@ describe(useObjectTableData, () => {
       },
     );
 
-    expect(lastOsdkObjectsOptions()?.withProperties).toEqual({
+    expect(lastObjectSetOptions()?.withProperties).toEqual({
       rdp1: mockRdpCreator1,
     });
 
@@ -331,12 +348,12 @@ describe(useObjectTableData, () => {
 
     rerender({ colDefs: updatedColumnDefinitions as ColDefs });
 
-    expect(lastOsdkObjectsOptions()?.withProperties).toEqual({
+    expect(lastObjectSetOptions()?.withProperties).toEqual({
       rdp2: mockRdpCreator2,
     });
   });
 
-  it("returns useOsdkObjects result structure", () => {
+  it("returns useObjectSet result structure", () => {
     const { result } = renderHook(
       () => useObjectTableData({ objectOrInterfaceType: TestObjectType }),
       {
@@ -350,22 +367,24 @@ describe(useObjectTableData, () => {
     expect(result.current).toHaveProperty("fetchMore");
   });
 
-  it("when no objectSet provided, only enables useOsdkObjects", () => {
+  it("when no objectSet provided, derives one from the type and only enables useObjectSet", () => {
     renderHook(
       () => useObjectTableData({ objectOrInterfaceType: TestObjectType }),
       { wrapper },
     );
 
-    expect(useOsdkObjects).toHaveBeenCalledWith(
-      TestObjectType,
+    expect(clientFn).toHaveBeenCalledWith(TestObjectType);
+
+    expect(useObjectSet).toHaveBeenCalledWith(
+      derivedObjectSet,
       expect.objectContaining({
         enabled: true,
         pageSize: 50,
       }),
     );
 
-    expect(useObjectSet).toHaveBeenCalledWith(
-      undefined,
+    expect(useOsdkObjects).toHaveBeenCalledWith(
+      TestObjectType,
       expect.objectContaining({
         enabled: false,
         pageSize: 50,
@@ -392,7 +411,7 @@ describe(useObjectTableData, () => {
     );
 
     expect(useObjectSet).toHaveBeenCalledWith(
-      expect.anything(),
+      mockObjectSet,
       expect.objectContaining({
         enabled: true,
         pageSize: 50,
@@ -456,7 +475,7 @@ describe(useObjectTableData, () => {
     );
 
     expect(useObjectSet).toHaveBeenCalledWith(
-      expect.anything(),
+      mockObjectSet,
       expect.objectContaining({
         enabled: true,
         pageSize: 50,
@@ -475,7 +494,7 @@ describe(useObjectTableData, () => {
       { $primaryKey: "2", $apiName: "TestObject", name: "Object 2" },
     ];
 
-    vi.mocked(useOsdkObjects).mockReturnValue({
+    vi.mocked(useObjectSet).mockReturnValue({
       data: mockBaseData,
       isLoading: false,
       error: undefined,
@@ -644,7 +663,7 @@ describe(useObjectTableData, () => {
   });
 
   describe("streamUpdates", () => {
-    it("forwards streamUpdates to useOsdkObjects when no objectSet is provided", () => {
+    it("forwards streamUpdates to useObjectSet when no objectSet is provided", () => {
       renderHook(
         () =>
           useObjectTableData({
@@ -654,8 +673,8 @@ describe(useObjectTableData, () => {
         { wrapper },
       );
 
-      expect(useOsdkObjects).toHaveBeenCalledWith(
-        TestObjectType,
+      expect(useObjectSet).toHaveBeenCalledWith(
+        derivedObjectSet,
         expect.objectContaining({ streamUpdates: true }),
       );
     });
@@ -672,7 +691,7 @@ describe(useObjectTableData, () => {
       );
 
       expect(useObjectSet).toHaveBeenCalledWith(
-        expect.anything(),
+        mockObjectSet,
         expect.objectContaining({ streamUpdates: true }),
       );
     });
@@ -688,7 +707,7 @@ describe(useObjectTableData, () => {
         expect.objectContaining({ streamUpdates: undefined }),
       );
       expect(useObjectSet).toHaveBeenCalledWith(
-        undefined,
+        derivedObjectSet,
         expect.objectContaining({ streamUpdates: undefined }),
       );
     });

--- a/packages/react-components/src/object-table/hooks/useFunctionColumnsData.ts
+++ b/packages/react-components/src/object-table/hooks/useFunctionColumnsData.ts
@@ -94,8 +94,8 @@ export function useFunctionColumnsData<
   );
 
   // Construct an object set per page (base set filtered to each page's
-  // primary keys). `buildPagedObjectSets` returns `[]` for interfaces and
-  // when there's no work to do, which short-circuits the downstream queries.
+  // primary keys). Empty when there are no rows, which short-circuits the
+  // downstream queries.
   //
   // When a new page loads, only that page's queries fire — old pages hit the
   // dedupeIntervalMs cache since their params are unchanged.

--- a/packages/react-components/src/object-table/hooks/useObjectTableData.ts
+++ b/packages/react-components/src/object-table/hooks/useObjectTableData.ts
@@ -25,6 +25,7 @@ import type {
 } from "@osdk/api";
 import {
   useObjectSet,
+  useOsdkClient,
   type UseOsdkListResult,
   useOsdkObjects,
 } from "@osdk/react";
@@ -92,8 +93,9 @@ export interface UseObjectTableDataResult<
   RDPs extends Record<string, SimplePropertyDef> = Record<string, never>,
 > extends Omit<UseOsdkListResult<Q, RDPs>, "isOptimistic"> {}
 /**
- * This hook is a wrapper that conditionally uses either useObjectSet or useOsdkObjects
- * based on whether an objectSet prop is provided.
+ * Loads the rows for an ObjectTable via `useObjectSet`, using the `objectSet`
+ * prop when supplied and otherwise an object set derived from
+ * `objectOrInterfaceType`.
  * It extracts RDP locators from columnDefinitions and applies withProperties
  * to return data containing the derived properties.
  */
@@ -118,6 +120,7 @@ export function useObjectTableData<
   Q,
   RDPs
 > {
+  const client = useOsdkClient();
   const orderBy = useMemo(() => {
     if (!sorting || sorting.length === 0) {
       return undefined;
@@ -159,24 +162,37 @@ export function useObjectTableData<
     );
   }, [columnDefinitions]);
 
-  // Use the caller's objectSet whenever provided (object or interface types), else fetch
-  // by type. For an interface objectSet, rows carry interface-declared props (+ withProperties)
-  // only, not the full underlying object — see the objectSet prop docs.
-  const shouldUseObjectSet = !!objectSet;
+  /**
+   * All data fetching now goes through `useObjectSet`; when no `objectSet` prop
+   * is supplied we derive one from the type.
+   * TODO: Remove `shouldUseObjectSet` and the `useOsdkObjects` call below.
+   */
+  const shouldUseObjectSet = true;
 
-  const objectSetResult = useObjectSet(
-    shouldUseObjectSet ? (objectSet as ObjectSet<Q, RDPs>) : (undefined as any),
-    {
-      ...(objectSetOptions as ObjectSetOptions<Q>),
-      withProperties: withProperties as WithProperties<Q, RDPs>,
-      where: filter,
-      orderBy,
-      pageSize,
-      enabled: shouldUseObjectSet,
-      dedupeIntervalMs,
-      streamUpdates,
-    },
-  );
+  /**
+   * `client()` is overloaded on ObjectTypeDefinition / InterfaceDefinition and
+   * does not accept the ObjectOrInterfaceDefinition union, so narrow before
+   * calling it. Both branches build the same base object set.
+   * TODO: Fix type def of client() param and its return types.
+   */
+  const objectSetFromObjectType = (
+    objectOrInterfaceType.type === "object"
+      ? client(objectOrInterfaceType)
+      : client(objectOrInterfaceType)
+  ) as ObjectSet<Q>;
+
+  const os: ObjectSet<Q> = objectSet ?? objectSetFromObjectType;
+
+  const objectSetResult = useObjectSet(os, {
+    ...(objectSetOptions as ObjectSetOptions<Q>),
+    withProperties: withProperties as WithProperties<Q, RDPs>,
+    where: filter,
+    orderBy,
+    pageSize,
+    enabled: shouldUseObjectSet,
+    dedupeIntervalMs,
+    streamUpdates,
+  });
 
   const osdkObjectsResult = useOsdkObjects<Q, RDPs>(objectOrInterfaceType, {
     withProperties,

--- a/packages/react-components/src/object-table/utils/functionColumns.ts
+++ b/packages/react-components/src/object-table/utils/functionColumns.ts
@@ -68,9 +68,6 @@ export function extractFunctionLocators<
  * values for `objects`. Builds an unfiltered base set from
  * `objectOrInterfaceType` (so pages are scoped purely by primary key) and
  * narrows each page via `{ $primaryKey: { $in: pageKeys } }`.
- *
- * Returns `[]` when the type is an interface (no base set can be built) or
- * when no primary-key apiName is available and the input is empty.
  */
 export function buildPagedObjectSets<
   Q extends ObjectOrInterfaceDefinition,
@@ -81,15 +78,15 @@ export function buildPagedObjectSets<
   objects: Osdk.Instance<Q, "$allBaseProperties", PropertyKeys<Q>, RDPs>[],
   pageSize: number,
 ): PagedObjects<Q, RDPs>[] {
-  const isObjectType = objectOrInterfaceType.type === "object";
-
-  const baseObjectSet = isObjectType
-    ? (client(objectOrInterfaceType) as ObjectSet<Q, RDPs>)
-    : undefined;
-
-  if (!baseObjectSet) {
-    return [];
-  }
+  // `client()` is overloaded on ObjectTypeDefinition / InterfaceDefinition and
+  // does not accept the ObjectOrInterfaceDefinition union, so narrow before
+  // calling it. Both branches build the same unfiltered base set.
+  // TODO: Fix type def of client() param and its return types.
+  const baseObjectSet = (
+    objectOrInterfaceType.type === "object"
+      ? client(objectOrInterfaceType)
+      : client(objectOrInterfaceType)
+  ) as ObjectSet<Q, RDPs>;
 
   return chunk(objects, pageSize).map((page) => {
     const whereClause = {


### PR DESCRIPTION
ObjectTable was using two hooks to do data fetching. This PR consolidates the data fetching of ObjectTable into a single path, i.e. useObjectSet.

The function column data fetching returns [] previously when useObjectSet did not support interface type. Removed it now that useObjectSet added support for interface.