### PR TITLE
MultiColumnSortDialog sort icon on the column's property type

### DIFF
--- a/.changeset/multi-sort-dialog-type-aware-sort-icons.md
+++ b/.changeset/multi-sort-dialog-type-aware-sort-icons.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react-components": minor
+---
+
+Show type-aware sort icons in the ObjectTable multi-column sort dialog

--- a/packages/react-components-storybook/src/stories/ObjectTable/MultiColumnSortDialog.stories.tsx
+++ b/packages/react-components-storybook/src/stories/ObjectTable/MultiColumnSortDialog.stories.tsx
@@ -19,13 +19,21 @@ import { MultiColumnSortDialog } from "@osdk/react-components/experimental/objec
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { fn } from "storybook/test";
 
+// `dataType` drives the sort icon shown next to each selected column: A→Z for
+// text, 1→9 for numbers, plain arrows for dates and everything else.
 const SAMPLE_COLUMNS: MultiColumnSortDialogProps["columnOptions"] = [
-  { id: "fullName", name: "Full Name", canSort: true },
-  { id: "email", name: "Email", canSort: true },
-  { id: "jobTitle", name: "Job Title", canSort: true },
-  { id: "department", name: "Department", canSort: true },
-  { id: "startDate", name: "Start Date", canSort: true },
-  { id: "location", name: "Location", canSort: false },
+  { id: "fullName", name: "Full Name", canSort: true, dataType: "string" },
+  { id: "email", name: "Email", canSort: true, dataType: "string" },
+  { id: "jobTitle", name: "Job Title", canSort: true, dataType: "string" },
+  { id: "department", name: "Department", canSort: true, dataType: "string" },
+  { id: "startDate", name: "Start Date", canSort: true, dataType: "timestamp" },
+  {
+    id: "yearsOfService",
+    name: "Years of Service",
+    canSort: true,
+    dataType: "integer",
+  },
+  { id: "location", name: "Location", canSort: false, dataType: "string" },
 ];
 
 const meta: Meta<MultiColumnSortDialogProps> = {
@@ -40,6 +48,8 @@ const meta: Meta<MultiColumnSortDialogProps> = {
     currentSorting: [
       { id: "fullName", desc: false },
       { id: "department", desc: true },
+      { id: "yearsOfService", desc: true },
+      { id: "startDate", desc: false },
     ],
   },
   argTypes: {
@@ -60,7 +70,7 @@ const meta: Meta<MultiColumnSortDialogProps> = {
     },
     columnOptions: {
       description:
-        "Available columns to sort by. Only columns with `canSort: true` appear in the add menu.",
+        "Available columns to sort by. Only columns with `canSort: true` appear in the add menu. `dataType` (the column's OSDK property type) selects the sort icon: `sort-alphabetical` for text, `sort-numerical` for numbers, plain arrows otherwise.",
       control: false,
     },
     currentSorting: {
@@ -93,13 +103,14 @@ const [isOpen, setIsOpen] = useState(false);
   isOpen={isOpen}
   onClose={() => setIsOpen(false)}
   columnOptions={[
-    { id: "fullName", name: "Full Name", canSort: true },
-    { id: "email", name: "Email", canSort: true },
-    { id: "department", name: "Department", canSort: true },
+    { id: "fullName", name: "Full Name", canSort: true, dataType: "string" },
+    { id: "email", name: "Email", canSort: true, dataType: "string" },
+    { id: "yearsOfService", name: "Years of Service", canSort: true, dataType: "integer" },
+    { id: "startDate", name: "Start Date", canSort: true, dataType: "timestamp" },
   ]}
   currentSorting={[
     { id: "fullName", desc: false },
-    { id: "department", desc: true },
+    { id: "yearsOfService", desc: true },
   ]}
   onApply={(sorting) => console.log("Applied:", sorting)}
 />`,

--- a/packages/react-components-storybook/src/stories/ObjectTable/MultiColumnSortDialog.stories.tsx
+++ b/packages/react-components-storybook/src/stories/ObjectTable/MultiColumnSortDialog.stories.tsx
@@ -19,8 +19,6 @@ import { MultiColumnSortDialog } from "@osdk/react-components/experimental/objec
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { fn } from "storybook/test";
 
-// `dataType` drives the sort icon shown next to each selected column: A→Z for
-// text, 1→9 for numbers, plain arrows for dates and everything else.
 const SAMPLE_COLUMNS: MultiColumnSortDialogProps["columnOptions"] = [
   { id: "fullName", name: "Full Name", canSort: true, dataType: "string" },
   { id: "email", name: "Email", canSort: true, dataType: "string" },
@@ -70,8 +68,7 @@ const meta: Meta<MultiColumnSortDialogProps> = {
     },
     columnOptions: {
       description:
-        "Available columns to sort by. Only columns with `canSort: true` appear in the add menu. `dataType` (the column's OSDK property type) selects the sort icon: `sort-alphabetical` for text, `sort-numerical` for numbers, plain arrows otherwise.",
-      control: false,
+        "Available columns to sort by. Only columns with `canSort: true` appear in the add menu.",
     },
     currentSorting: {
       description: "Current sorting state from TanStack Table",

--- a/packages/react-components/src/object-table/MultiColumnSortDialog.tsx
+++ b/packages/react-components/src/object-table/MultiColumnSortDialog.tsx
@@ -15,13 +15,7 @@
  */
 
 import { Button } from "@base-ui/react/button";
-import {
-  Add,
-  CaretDown,
-  Cog,
-  SortAlphabetical,
-  SortAlphabeticalDesc,
-} from "@blueprintjs/icons";
+import { Add, CaretDown, Cog } from "@blueprintjs/icons";
 import { arrayMove } from "@dnd-kit/sortable";
 import type { SortingState } from "@tanstack/react-table";
 import classNames from "classnames";
@@ -36,6 +30,7 @@ import {
   withObjectTableLabels,
 } from "./ObjectTableLabels.js";
 import { type SortableItem, SortableItemsList } from "./SortableItemsList.js";
+import { getSortIcons } from "./utils/getSortIcons.js";
 import type { ColumnOption } from "./utils/types.js";
 
 import styles from "./MultiColumnSortDialog.module.css";
@@ -154,28 +149,39 @@ function MultiColumnSortDialogInner({
   );
 
   const sortableItems: SortableItem[] = useMemo(() => {
-    return selectedSortColumns.map((item) => ({
-      id: item.id,
-      label: item.name,
-      content: (
-        <div className={styles.sortColumnItem}>
-          <span className={classNames(styles.sortColumnName, styles.truncate)}>
-            {item.name}
-          </span>
-          <Button
-            className={styles.sortDirectionButton}
-            onClick={() => handleToggleSortDirection(item.id)}
-            aria-label={labels.sortDialogToggleDirection(item.name)}
-          >
-            {item.direction === "asc" ? (
-              <SortAlphabetical className={styles.sortIcon} />
-            ) : (
-              <SortAlphabeticalDesc className={styles.sortIcon} />
-            )}
-          </Button>
-        </div>
-      ),
-    }));
+    return selectedSortColumns.map((item) => {
+      // Match the direction glyphs to the column's property type the same way
+      // the table header does: A→Z for text, 1→9 for numbers, plain
+      // ascending/descending arrows for dates and everything else.
+      const { asc: SortAscendingIcon, desc: SortDescendingIcon } = getSortIcons(
+        item.dataType
+      );
+
+      return {
+        id: item.id,
+        label: item.name,
+        content: (
+          <div className={styles.sortColumnItem}>
+            <span
+              className={classNames(styles.sortColumnName, styles.truncate)}
+            >
+              {item.name}
+            </span>
+            <Button
+              className={styles.sortDirectionButton}
+              onClick={() => handleToggleSortDirection(item.id)}
+              aria-label={labels.sortDialogToggleDirection(item.name)}
+            >
+              {item.direction === "asc" ? (
+                <SortAscendingIcon className={styles.sortIcon} />
+              ) : (
+                <SortDescendingIcon className={styles.sortIcon} />
+              )}
+            </Button>
+          </div>
+        ),
+      };
+    });
   }, [selectedSortColumns, handleToggleSortDirection, labels]);
 
   const footer = useMemo(

--- a/packages/react-components/src/object-table/MultiColumnSortDialog.tsx
+++ b/packages/react-components/src/object-table/MultiColumnSortDialog.tsx
@@ -150,9 +150,6 @@ function MultiColumnSortDialogInner({
 
   const sortableItems: SortableItem[] = useMemo(() => {
     return selectedSortColumns.map((item) => {
-      // Match the direction glyphs to the column's property type the same way
-      // the table header does: A→Z for text, 1→9 for numbers, plain
-      // ascending/descending arrows for dates and everything else.
       const { asc: SortAscendingIcon, desc: SortDescendingIcon } = getSortIcons(
         item.dataType
       );

--- a/packages/react-components/src/object-table/MultiColumnSortDialog.tsx
+++ b/packages/react-components/src/object-table/MultiColumnSortDialog.tsx
@@ -151,7 +151,7 @@ function MultiColumnSortDialogInner({
   const sortableItems: SortableItem[] = useMemo(() => {
     return selectedSortColumns.map((item) => {
       const { asc: SortAscendingIcon, desc: SortDescendingIcon } = getSortIcons(
-        item.dataType
+        item.dataType,
       );
 
       return {

--- a/packages/react-components/src/object-table/TableHeader.tsx
+++ b/packages/react-components/src/object-table/TableHeader.tsx
@@ -135,6 +135,7 @@ export function TableHeader<TData extends RowData>({
           id: column.id,
           name: getHeaderName(column, allHeaders),
           canSort: column.getCanSort(),
+          dataType: column.columnDef.meta?.dataType,
         };
       });
   }, [table]);

--- a/packages/react-components/src/object-table/__tests__/MultiColumnSortDialog.test.tsx
+++ b/packages/react-components/src/object-table/__tests__/MultiColumnSortDialog.test.tsx
@@ -14,13 +14,19 @@
  * limitations under the License.
  */
 
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import React from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { MultiColumnSortDialog } from "../MultiColumnSortDialog.js";
 
 const COLUMN_OPTIONS = [{ id: "a", name: "Col A", canSort: true }];
+
+function getSortToggle(columnName: string): HTMLElement {
+  return screen.getByRole("button", {
+    name: `Toggle sort direction for ${columnName}`,
+  });
+}
 
 describe(MultiColumnSortDialog, () => {
   afterEach(() => {
@@ -63,5 +69,105 @@ describe(MultiColumnSortDialog, () => {
     expect(screen.getByText("Add another column")).toBeTruthy();
     expect(screen.getByRole("button", { name: "Apply" })).toBeTruthy();
     expect(screen.getByRole("button", { name: "Cancel" })).toBeTruthy();
+  });
+
+  describe("sort direction icon", () => {
+    it.each([
+      ["string", false, "sort-alphabetical"],
+      ["string", true, "sort-alphabetical-desc"],
+      ["marking", false, "sort-alphabetical"],
+      ["double", false, "sort-numerical"],
+      ["integer", true, "sort-numerical-desc"],
+      ["timestamp", false, "sort-asc"],
+      ["datetime", true, "sort-desc"],
+      ["boolean", false, "sort-asc"],
+      [undefined, false, "sort-asc"],
+    ] as const)(
+      "renders a %s column sorted desc=%s with the %s icon",
+      (dataType, desc, expectedIcon) => {
+        render(
+          <MultiColumnSortDialog
+            isOpen={true}
+            onClose={vi.fn()}
+            onApply={vi.fn()}
+            currentSorting={[{ id: "a", desc }]}
+            columnOptions={[
+              { id: "a", name: "Col A", canSort: true, dataType },
+            ]}
+          />
+        );
+
+        expect(
+          getSortToggle("Col A").querySelector(
+            `svg[data-icon="${expectedIcon}"]`
+          )
+        ).toBeTruthy();
+      }
+    );
+
+    it("keeps the type's icon family when toggling direction", () => {
+      render(
+        <MultiColumnSortDialog
+          isOpen={true}
+          onClose={vi.fn()}
+          onApply={vi.fn()}
+          currentSorting={[{ id: "a", desc: false }]}
+          columnOptions={[
+            { id: "a", name: "Col A", canSort: true, dataType: "integer" },
+          ]}
+        />
+      );
+
+      expect(
+        getSortToggle("Col A").querySelector('svg[data-icon="sort-numerical"]')
+      ).toBeTruthy();
+
+      fireEvent.click(getSortToggle("Col A"));
+
+      expect(
+        getSortToggle("Col A").querySelector(
+          'svg[data-icon="sort-numerical-desc"]'
+        )
+      ).toBeTruthy();
+    });
+
+    it("gives each column the icon for its own type", () => {
+      render(
+        <MultiColumnSortDialog
+          isOpen={true}
+          onClose={vi.fn()}
+          onApply={vi.fn()}
+          currentSorting={[
+            { id: "name", desc: false },
+            { id: "age", desc: true },
+            { id: "hiredAt", desc: false },
+          ]}
+          columnOptions={[
+            { id: "name", name: "Name", canSort: true, dataType: "string" },
+            { id: "age", name: "Age", canSort: true, dataType: "integer" },
+            {
+              id: "hiredAt",
+              name: "Hired At",
+              canSort: true,
+              dataType: "timestamp",
+            },
+          ]}
+        />
+      );
+
+      expect(
+        getSortToggle("Name").querySelector(
+          'svg[data-icon="sort-alphabetical"]'
+        )
+      ).toBeTruthy();
+      expect(
+        getSortToggle("Age").querySelector(
+          'svg[data-icon="sort-numerical-desc"]'
+        )
+      ).toBeTruthy();
+      expect(
+        getSortToggle("Hired At").querySelector('svg[data-icon="sort-asc"]')
+      ).toBeTruthy();
+    });
   });
 });

--- a/packages/react-components/src/object-table/__tests__/MultiColumnSortDialog.test.tsx
+++ b/packages/react-components/src/object-table/__tests__/MultiColumnSortDialog.test.tsx
@@ -94,15 +94,15 @@ describe(MultiColumnSortDialog, () => {
             columnOptions={[
               { id: "a", name: "Col A", canSort: true, dataType },
             ]}
-          />
+          />,
         );
 
         expect(
           getSortToggle("Col A").querySelector(
-            `svg[data-icon="${expectedIcon}"]`
-          )
+            `svg[data-icon="${expectedIcon}"]`,
+          ),
         ).toBeTruthy();
-      }
+      },
     );
 
     it("keeps the type's icon family when toggling direction", () => {
@@ -115,19 +115,19 @@ describe(MultiColumnSortDialog, () => {
           columnOptions={[
             { id: "a", name: "Col A", canSort: true, dataType: "integer" },
           ]}
-        />
+        />,
       );
 
       expect(
-        getSortToggle("Col A").querySelector('svg[data-icon="sort-numerical"]')
+        getSortToggle("Col A").querySelector('svg[data-icon="sort-numerical"]'),
       ).toBeTruthy();
 
       fireEvent.click(getSortToggle("Col A"));
 
       expect(
         getSortToggle("Col A").querySelector(
-          'svg[data-icon="sort-numerical-desc"]'
-        )
+          'svg[data-icon="sort-numerical-desc"]',
+        ),
       ).toBeTruthy();
     });
 
@@ -152,21 +152,21 @@ describe(MultiColumnSortDialog, () => {
               dataType: "timestamp",
             },
           ]}
-        />
+        />,
       );
 
       expect(
         getSortToggle("Name").querySelector(
-          'svg[data-icon="sort-alphabetical"]'
-        )
+          'svg[data-icon="sort-alphabetical"]',
+        ),
       ).toBeTruthy();
       expect(
         getSortToggle("Age").querySelector(
-          'svg[data-icon="sort-numerical-desc"]'
-        )
+          'svg[data-icon="sort-numerical-desc"]',
+        ),
       ).toBeTruthy();
       expect(
-        getSortToggle("Hired At").querySelector('svg[data-icon="sort-asc"]')
+        getSortToggle("Hired At").querySelector('svg[data-icon="sort-asc"]'),
       ).toBeTruthy();
     });
   });

--- a/packages/react-components/src/object-table/__tests__/TableHeader.test.tsx
+++ b/packages/react-components/src/object-table/__tests__/TableHeader.test.tsx
@@ -89,17 +89,17 @@ async function openMultiSortDialog(columnId: string): Promise<void> {
   fireEvent.click(
     screen.getByRole("button", {
       name: `Open header menu for column with id=${columnId}`,
-    })
+    }),
   );
 
   const multiSortItem = await waitFor(() =>
-    screen.getByRole("menuitem", { name: "Sort on multiple columns" })
+    screen.getByRole("menuitem", { name: "Sort on multiple columns" }),
   );
 
   fireEvent.click(multiSortItem);
 
   await waitFor(() =>
-    expect(screen.getByText("Sort on Multiple Columns")).toBeTruthy()
+    expect(screen.getByText("Sort on Multiple Columns")).toBeTruthy(),
   );
 }
 
@@ -122,19 +122,21 @@ describe(TableHeader, () => {
           { id: "age", desc: true },
           { id: "hiredAt", desc: false },
         ]}
-      />
+      />,
     );
 
     await openMultiSortDialog("name");
 
     expect(
-      getSortToggle("Name").querySelector('svg[data-icon="sort-alphabetical"]')
+      getSortToggle("Name").querySelector('svg[data-icon="sort-alphabetical"]'),
     ).toBeTruthy();
     expect(
-      getSortToggle("Age").querySelector('svg[data-icon="sort-numerical-desc"]')
+      getSortToggle("Age").querySelector(
+        'svg[data-icon="sort-numerical-desc"]',
+      ),
     ).toBeTruthy();
     expect(
-      getSortToggle("Hired At").querySelector('svg[data-icon="sort-asc"]')
+      getSortToggle("Hired At").querySelector('svg[data-icon="sort-asc"]'),
     ).toBeTruthy();
   });
 });

--- a/packages/react-components/src/object-table/__tests__/TableHeader.test.tsx
+++ b/packages/react-components/src/object-table/__tests__/TableHeader.test.tsx
@@ -114,9 +114,6 @@ describe(TableHeader, () => {
     cleanup();
   });
 
-  // The multi-sort dialog only knows a column's property type because
-  // `columnOptions` forwards `meta.dataType`; without that the dialog falls back
-  // to directional icons for every column.
   it("forwards each column's data type to the multi-sort dialog's icons", async () => {
     render(
       <TestTableHeader

--- a/packages/react-components/src/object-table/__tests__/TableHeader.test.tsx
+++ b/packages/react-components/src/object-table/__tests__/TableHeader.test.tsx
@@ -1,0 +1,143 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { ColumnDef, SortingState } from "@tanstack/react-table";
+import { getCoreRowModel, useReactTable } from "@tanstack/react-table";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import React, { useState } from "react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { TableHeader } from "../TableHeader.js";
+
+interface TestRow {
+  name: string;
+  age: number;
+  hiredAt: string;
+}
+
+const COLUMNS: ColumnDef<TestRow>[] = [
+  {
+    id: "name",
+    accessorKey: "name",
+    header: "Name",
+    meta: {
+      dataType: "string",
+    },
+  },
+  {
+    id: "age",
+    accessorKey: "age",
+    header: "Age",
+    meta: { dataType: "integer" },
+  },
+  {
+    id: "hiredAt",
+    accessorKey: "hiredAt",
+    header: "Hired At",
+    meta: { dataType: "timestamp" },
+  },
+];
+
+const ROWS: TestRow[] = [{ name: "Ada", age: 36, hiredAt: "2024-01-01" }];
+
+function TestTableHeader({
+  initialSorting = [],
+}: {
+  initialSorting?: SortingState;
+}): React.ReactElement {
+  const [sorting, setSorting] = useState<SortingState>(initialSorting);
+
+  const table = useReactTable<TestRow>({
+    data: ROWS,
+    columns: COLUMNS,
+    state: { sorting },
+    onSortingChange: setSorting,
+    enableSorting: true,
+    getCoreRowModel: getCoreRowModel(),
+  });
+
+  return (
+    <table>
+      <TableHeader
+        table={table}
+        headerMenuFeatureFlags={{ showSortingItems: true }}
+      />
+    </table>
+  );
+}
+
+async function openMultiSortDialog(columnId: string): Promise<void> {
+  fireEvent.click(
+    screen.getByRole("button", {
+      name: `Open header menu for column with id=${columnId}`,
+    })
+  );
+
+  const multiSortItem = await waitFor(() =>
+    screen.getByRole("menuitem", { name: "Sort on multiple columns" })
+  );
+
+  fireEvent.click(multiSortItem);
+
+  await waitFor(() =>
+    expect(screen.getByText("Sort on Multiple Columns")).toBeTruthy()
+  );
+}
+
+function getSortToggle(columnName: string): HTMLElement {
+  return screen.getByRole("button", {
+    name: `Toggle sort direction for ${columnName}`,
+  });
+}
+
+describe(TableHeader, () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  // The multi-sort dialog only knows a column's property type because
+  // `columnOptions` forwards `meta.dataType`; without that the dialog falls back
+  // to directional icons for every column.
+  it("forwards each column's data type to the multi-sort dialog's icons", async () => {
+    render(
+      <TestTableHeader
+        initialSorting={[
+          { id: "name", desc: false },
+          { id: "age", desc: true },
+          { id: "hiredAt", desc: false },
+        ]}
+      />
+    );
+
+    await openMultiSortDialog("name");
+
+    expect(
+      getSortToggle("Name").querySelector('svg[data-icon="sort-alphabetical"]')
+    ).toBeTruthy();
+    expect(
+      getSortToggle("Age").querySelector('svg[data-icon="sort-numerical-desc"]')
+    ).toBeTruthy();
+    expect(
+      getSortToggle("Hired At").querySelector('svg[data-icon="sort-asc"]')
+    ).toBeTruthy();
+  });
+});

--- a/packages/react-components/src/object-table/hooks/useColumnDefs.ts
+++ b/packages/react-components/src/object-table/hooks/useColumnDefs.ts
@@ -115,10 +115,7 @@ function getColumnsFromColumnDefinitions<
 
     const colKey = locator.id as string;
 
-    const dataType =
-      propertyMetadata?.type && typeof propertyMetadata.type === "string"
-        ? propertyMetadata.type
-        : undefined;
+    const dataType = getDataType(propertyMetadata);
 
     const markingType =
       propertyMetadata?.typeMetadata?.type === "marking"
@@ -191,11 +188,27 @@ function getDefaultColumns<
       accessorKey: key,
       header: property.displayName ?? key,
       meta: {
-        // Surfaced so type-aware rendering (e.g. the header's sort icons)
-        // works for default columns too, not just explicit columnDefinitions.
-        dataType: typeof property.type === "string" ? property.type : undefined,
+        // Surfaced so type-aware rendering works for default columns too, not
+        // just explicit columnDefinitions.
+        dataType: getDataType(property),
       },
     };
     return colDef;
   });
+}
+
+/**
+ * The property's `WirePropertyTypes` value, used for type-aware rendering such
+ * as the header's and multi-sort dialog's sort icons.
+ *
+ * Structured types (arrays, structs) carry an object rather than a wire type
+ * string, and a column may have no metadata at all (e.g. function-backed
+ * columns), so both yield `undefined`.
+ */
+function getDataType(
+  property: ObjectMetadata.Property | undefined
+): string | undefined {
+  return typeof property?.type === "string" && property.type.length > 0
+    ? property.type
+    : undefined;
 }

--- a/packages/react-components/src/object-table/hooks/useColumnDefs.ts
+++ b/packages/react-components/src/object-table/hooks/useColumnDefs.ts
@@ -204,7 +204,7 @@ function getDefaultColumns<
  * columns), so both yield `undefined`.
  */
 function getDataType(
-  property: ObjectMetadata.Property | undefined
+  property: ObjectMetadata.Property | undefined,
 ): string | undefined {
   return typeof property?.type === "string" && property.type.length > 0
     ? property.type

--- a/packages/react-components/src/object-table/hooks/useColumnDefs.ts
+++ b/packages/react-components/src/object-table/hooks/useColumnDefs.ts
@@ -188,8 +188,6 @@ function getDefaultColumns<
       accessorKey: key,
       header: property.displayName ?? key,
       meta: {
-        // Surfaced so type-aware rendering works for default columns too, not
-        // just explicit columnDefinitions.
         dataType: getDataType(property),
       },
     };

--- a/packages/react-components/src/object-table/utils/types.ts
+++ b/packages/react-components/src/object-table/utils/types.ts
@@ -25,6 +25,13 @@ export interface ColumnOption {
   id: string;
   name: string;
   canSort: boolean;
+  /**
+   * The column's underlying property type, i.e. an OSDK `WirePropertyTypes`
+   * value, mirroring the column definition's `meta.dataType`. Used to pick sort
+   * icons that match the type. Absent for columns whose type isn't known (e.g.
+   * function-backed columns), which fall back to directional icons.
+   */
+  dataType?: string;
 }
 
 export interface CellIdentifier {

--- a/packages/react-components/src/object-table/utils/types.ts
+++ b/packages/react-components/src/object-table/utils/types.ts
@@ -26,10 +26,7 @@ export interface ColumnOption {
   name: string;
   canSort: boolean;
   /**
-   * The column's underlying property type, i.e. an OSDK `WirePropertyTypes`
-   * value, mirroring the column definition's `meta.dataType`. Used to pick sort
-   * icons that match the type. Absent for columns whose type isn't known (e.g.
-   * function-backed columns), which fall back to directional icons.
+   * The column's underlying property type, i.e. an OSDK `WirePropertyTypes` value
    */
   dataType?: string;
 }


### PR DESCRIPTION
Follow-up to #3765, which made the ObjectTable header's sort indicator type-aware. The multi-column sort dialog still hardcoded the alphabetical pair, so a numeric column showed A→Z in the dialog next to a 1→9 header.

The dialog's direction toggle now calls `getSortIcons(dataType)`, the same helper the header uses:

| property type | ascending | descending |
| --- | --- | --- |
| `string`, `cipherText`, `marking` | `sort-alphabetical` | `sort-alphabetical-desc` |
| `byte` `decimal` `double` `float` `integer` `long` `short` | `sort-numerical` | `sort-numerical-desc` |
| `datetime`, `timestamp` | `sort-asc` | `sort-desc` |
| `boolean`, anything else, unknown | `sort-asc` | `sort-desc` |

`ColumnOption` gains an optional `dataType`; `TableHeader` populates it from `columnDef.meta.dataType` — the same field the header reads — so the dialog it renders picks up types with no caller changes.

<img width="801" height="630" alt="Screenshot 2026-07-30 at 12 56 55" src="https://github.com/user-attachments/assets/40597955-f98b-4dff-863e-d3b0f936c7ba" />

<img width="513" height="362" alt="Screenshot 2026-07-31 at 13 56 56" src="https://github.com/user-attachments/assets/0fb53376-4883-42be-9fa6-c95b7ee39507" />
