### PR TITLE
add alias utils for datasets, mediasets and streams

### DIFF
--- a/.changeset/dataset-mediaset-stream-alias-support.md
+++ b/.changeset/dataset-mediaset-stream-alias-support.md
@@ -1,0 +1,5 @@
+---
+"@osdk/functions": minor
+---
+
+Add `Aliases.dataset`, `Aliases.mediaset`, and `Aliases.stream` APIs for resolving dataset, media set, and stream aliases

--- a/etc/functions.report.api.md
+++ b/etc/functions.report.api.md
@@ -36,10 +36,16 @@ declare namespace Aliases {
     export {
         custom,
         Custom,
+        dataset,
+        Dataset,
+        mediaset,
+        Mediaset,
         model,
         Model,
         source,
-        Source
+        Source,
+        stream,
+        Stream
     }
 }
 
@@ -73,6 +79,15 @@ type Custom = string & {
 
 // @public (undocumented)
 function custom(alias: string): Custom;
+
+// @public (undocumented)
+interface Dataset {
+    	// (undocumented)
+    rid: string;
+}
+
+// @public (undocumented)
+function dataset(alias: string): Dataset;
 
 // @public (undocumented)
 export type DateISOString<T extends string = string> = T & {
@@ -201,6 +216,15 @@ export type MandatoryMarking<T extends string = string> = T & {
 
 export { MediaReference }
 
+// @public (undocumented)
+interface Mediaset {
+    	// (undocumented)
+    rid: string;
+}
+
+// @public (undocumented)
+function mediaset(alias: string): Mediaset;
+
 export { MediaUpload }
 
 // @public (undocumented)
@@ -292,6 +316,15 @@ interface Source {
 
 // @public (undocumented)
 function source(alias: string): Source;
+
+// @public (undocumented)
+interface Stream {
+    	// (undocumented)
+    rid: string;
+}
+
+// @public (undocumented)
+function stream(alias: string): Stream;
 
 export { ThreeDimensionalAggregation }
 

--- a/packages/functions/src/aliases/aliases.test.ts
+++ b/packages/functions/src/aliases/aliases.test.ts
@@ -19,14 +19,17 @@ import * as fs from "fs";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { custom } from "./custom.js";
+import { dataset } from "./dataset.js";
 import {
   ALIASES_JSON_FILE_ENV_VAR,
   detectEnvironment,
   RESOURCES_JSON_FILE_ENV_VAR,
 } from "./environment.js";
 import { resetPublishedCache } from "./loaders.js";
+import { mediaset } from "./mediaset.js";
 import { model } from "./model.js";
 import { source } from "./source.js";
+import { stream } from "./stream.js";
 import { AliasEnvironment } from "./types.js";
 
 // Read test data before mocking fs - use node:fs which is not affected by vi.mock("fs")
@@ -163,11 +166,92 @@ describe("published mode aliases", () => {
     });
   });
 
+  describe("dataset", () => {
+    it("loads alias successfully and returns rid", () => {
+      const result = dataset("myDatasetAlias");
+      expect(result).toEqual({
+        rid: "ri.foundry.main.dataset.11111111-1111-1111-1111-111111111111",
+      });
+    });
+
+    it("throws on nonexistent alias", () => {
+      expect(() => dataset("nonexistent")).toThrow(
+        "Dataset alias 'nonexistent' not found. Available aliases: [myDatasetAlias, anotherDatasetAlias]",
+      );
+    });
+
+    it("selects correct alias from multiple", () => {
+      const result1 = dataset("myDatasetAlias");
+      const result2 = dataset("anotherDatasetAlias");
+      expect(result1.rid).toBe(
+        "ri.foundry.main.dataset.11111111-1111-1111-1111-111111111111",
+      );
+      expect(result2.rid).toBe(
+        "ri.foundry.main.dataset.22222222-2222-2222-2222-222222222222",
+      );
+    });
+  });
+
+  describe("mediaset", () => {
+    it("loads alias successfully and returns rid", () => {
+      const result = mediaset("myMediasetAlias");
+      expect(result).toEqual({
+        rid: "ri.mio.main.media-set.11111111-1111-1111-1111-111111111111",
+      });
+    });
+
+    it("throws on nonexistent alias", () => {
+      expect(() => mediaset("nonexistent")).toThrow(
+        "Mediaset alias 'nonexistent' not found. Available aliases: [myMediasetAlias, anotherMediasetAlias]",
+      );
+    });
+
+    it("selects correct alias from multiple", () => {
+      const result1 = mediaset("myMediasetAlias");
+      const result2 = mediaset("anotherMediasetAlias");
+      expect(result1.rid).toBe(
+        "ri.mio.main.media-set.11111111-1111-1111-1111-111111111111",
+      );
+      expect(result2.rid).toBe(
+        "ri.mio.main.media-set.22222222-2222-2222-2222-222222222222",
+      );
+    });
+  });
+
+  describe("stream", () => {
+    it("loads alias successfully and returns rid", () => {
+      const result = stream("myStreamAlias");
+      expect(result).toEqual({
+        rid: "ri.foundry.main.dataset.33333333-3333-3333-3333-333333333333",
+      });
+    });
+
+    it("throws on nonexistent alias", () => {
+      expect(() => stream("nonexistent")).toThrow(
+        "Stream alias 'nonexistent' not found. Available aliases: [myStreamAlias, anotherStreamAlias]",
+      );
+    });
+
+    it("selects correct alias from multiple", () => {
+      const result1 = stream("myStreamAlias");
+      const result2 = stream("anotherStreamAlias");
+      expect(result1.rid).toBe(
+        "ri.foundry.main.dataset.33333333-3333-3333-3333-333333333333",
+      );
+      expect(result2.rid).toBe(
+        "ri.foundry.main.dataset.44444444-4444-4444-4444-444444444444",
+      );
+    });
+  });
+
   describe("caching", () => {
     it("reads file only once across multiple lookups", () => {
       custom("myCustomAlias");
       model("myModelAlias");
       source("mySourceAlias");
+      dataset("myDatasetAlias");
+      mediaset("myMediasetAlias");
+      stream("myStreamAlias");
       custom("anotherCustomAlias");
 
       expect(fs.readFileSync).toHaveBeenCalledTimes(1);
@@ -284,6 +368,102 @@ describe("live preview mode aliases", () => {
     it("excludes sources with null or missing alias", () => {
       expect(() => source("some-random-lookup")).toThrow(
         "Available aliases: [previewSourceAlias, anotherPreviewSource]",
+      );
+    });
+  });
+
+  describe("dataset", () => {
+    it("loads alias successfully and returns rid", () => {
+      const result = dataset("previewDatasetAlias");
+      expect(result).toEqual({
+        rid: "ri.foundry.main.dataset.aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+      });
+    });
+
+    it("throws on nonexistent alias", () => {
+      expect(() => dataset("nonexistent")).toThrow(
+        "Dataset alias 'nonexistent' not found. Available aliases: [previewDatasetAlias, anotherPreviewDataset]",
+      );
+    });
+
+    it("selects correct alias from multiple", () => {
+      const result1 = dataset("previewDatasetAlias");
+      const result2 = dataset("anotherPreviewDataset");
+      expect(result1.rid).toBe(
+        "ri.foundry.main.dataset.aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+      );
+      expect(result2.rid).toBe(
+        "ri.foundry.main.dataset.bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+      );
+    });
+
+    it("excludes datasets with null or missing alias", () => {
+      expect(() => dataset("some-random-lookup")).toThrow(
+        "Available aliases: [previewDatasetAlias, anotherPreviewDataset]",
+      );
+    });
+  });
+
+  describe("mediaset", () => {
+    it("loads alias successfully and returns rid", () => {
+      const result = mediaset("previewMediasetAlias");
+      expect(result).toEqual({
+        rid: "ri.mio.main.media-set.aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+      });
+    });
+
+    it("throws on nonexistent alias", () => {
+      expect(() => mediaset("nonexistent")).toThrow(
+        "Mediaset alias 'nonexistent' not found. Available aliases: [previewMediasetAlias, anotherPreviewMediaset]",
+      );
+    });
+
+    it("selects correct alias from multiple", () => {
+      const result1 = mediaset("previewMediasetAlias");
+      const result2 = mediaset("anotherPreviewMediaset");
+      expect(result1.rid).toBe(
+        "ri.mio.main.media-set.aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+      );
+      expect(result2.rid).toBe(
+        "ri.mio.main.media-set.bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb",
+      );
+    });
+
+    it("excludes mediasets with null or missing alias", () => {
+      expect(() => mediaset("some-random-lookup")).toThrow(
+        "Available aliases: [previewMediasetAlias, anotherPreviewMediaset]",
+      );
+    });
+  });
+
+  describe("stream", () => {
+    it("loads alias successfully and returns rid", () => {
+      const result = stream("previewStreamAlias");
+      expect(result).toEqual({
+        rid: "ri.foundry.main.dataset.eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee",
+      });
+    });
+
+    it("throws on nonexistent alias", () => {
+      expect(() => stream("nonexistent")).toThrow(
+        "Stream alias 'nonexistent' not found. Available aliases: [previewStreamAlias, anotherPreviewStream]",
+      );
+    });
+
+    it("selects correct alias from multiple", () => {
+      const result1 = stream("previewStreamAlias");
+      const result2 = stream("anotherPreviewStream");
+      expect(result1.rid).toBe(
+        "ri.foundry.main.dataset.eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee",
+      );
+      expect(result2.rid).toBe(
+        "ri.foundry.main.dataset.ffffffff-ffff-ffff-ffff-ffffffffffff",
+      );
+    });
+
+    it("excludes streams with null or missing alias", () => {
+      expect(() => stream("some-random-lookup")).toThrow(
+        "Available aliases: [previewStreamAlias, anotherPreviewStream]",
       );
     });
   });

--- a/packages/functions/src/aliases/dataset.ts
+++ b/packages/functions/src/aliases/dataset.ts
@@ -14,9 +14,21 @@
  * limitations under the License.
  */
 
-export * from "./custom.js";
-export * from "./dataset.js";
-export * from "./mediaset.js";
-export * from "./model.js";
-export * from "./source.js";
-export * from "./stream.js";
+import { loadResolvedAliases } from "./loaders.js";
+import type { Dataset } from "./types.js";
+export type { Dataset } from "./types.js";
+
+export function dataset(alias: string): Dataset {
+  const resolvedAliases = loadResolvedAliases();
+
+  if (!(alias in resolvedAliases.datasets)) {
+    const available = Object.keys(resolvedAliases.datasets);
+    throw new Error(
+      `Dataset alias '${alias}' not found. Available aliases: [${available.join(
+        ", ",
+      )}]`,
+    );
+  }
+
+  return resolvedAliases.datasets[alias];
+}

--- a/packages/functions/src/aliases/loaders.ts
+++ b/packages/functions/src/aliases/loaders.ts
@@ -24,14 +24,23 @@ import {
 import { AliasEnvironment } from "./types.js";
 import type {
   AliasesFile,
+  Dataset,
+  DatasetResource,
+  DatasetValue,
   EgressConnection,
   EgressConnectionValue,
+  Mediaset,
+  MediasetResource,
+  MediasetValue,
   Model,
   ModelResource,
   ModelValue,
   ResolvedAliases,
   ResourcesFile,
   Source,
+  Stream,
+  StreamResource,
+  StreamValue,
 } from "./types.js";
 
 let cachedPublishedAliases: ResolvedAliases | undefined;
@@ -52,6 +61,9 @@ function loadPublishedAliases(): ResolvedAliases {
     custom: loadCustom(aliasesFile.defaults.custom),
     models: loadPublishedModels(aliasesFile.defaults.models),
     sources: loadPublishedSources(aliasesFile.defaults.egressConnections),
+    datasets: loadPublishedDatasets(aliasesFile.defaults.datasets),
+    mediasets: loadPublishedMediasets(aliasesFile.defaults.mediasets),
+    streams: loadPublishedStreams(aliasesFile.defaults.streams),
   };
   return cachedPublishedAliases;
 }
@@ -69,6 +81,9 @@ function loadPreviewAliases(): ResolvedAliases {
     custom: loadCustom(resourcesFile.resources.custom),
     models: loadPreviewModels(resourcesFile.resources.models),
     sources: loadPreviewSources(resourcesFile.egress.connections),
+    datasets: loadPreviewDatasets(resourcesFile.resources.datasets),
+    mediasets: loadPreviewMediasets(resourcesFile.resources.mediasets),
+    streams: loadPreviewStreams(resourcesFile.resources.streams),
   };
 }
 
@@ -98,6 +113,39 @@ function loadPublishedSources(
   );
 }
 
+function loadPublishedDatasets(
+  datasets: Record<string, DatasetValue>,
+): Record<string, Dataset> {
+  return Object.fromEntries<Dataset>(
+    Object.entries(datasets).map(([alias, { id: identifier }]) => [
+      alias,
+      identifier,
+    ]),
+  );
+}
+
+function loadPublishedMediasets(
+  mediasets: Record<string, MediasetValue>,
+): Record<string, Mediaset> {
+  return Object.fromEntries<Mediaset>(
+    Object.entries(mediasets).map(([alias, { id: identifier }]) => [
+      alias,
+      identifier,
+    ]),
+  );
+}
+
+function loadPublishedStreams(
+  streams: Record<string, StreamValue>,
+): Record<string, Stream> {
+  return Object.fromEntries<Stream>(
+    Object.entries(streams).map(([alias, { id: identifier }]) => [
+      alias,
+      identifier,
+    ]),
+  );
+}
+
 function loadPreviewModels(models: ModelResource[]): Record<string, Model> {
   return Object.fromEntries<Model>(
     models
@@ -119,6 +167,43 @@ function loadPreviewSources(
           connection.alias != null,
       )
       .map(({ alias, rid }) => [alias, { rid }]),
+  );
+}
+
+function loadPreviewDatasets(
+  datasets: DatasetResource[],
+): Record<string, Dataset> {
+  return Object.fromEntries<Dataset>(
+    datasets
+      .filter(
+        (dataset): dataset is DatasetResource & { alias: string } =>
+          dataset.alias != null,
+      )
+      .map(({ alias, identifier }) => [alias, identifier]),
+  );
+}
+
+function loadPreviewMediasets(
+  mediasets: MediasetResource[],
+): Record<string, Mediaset> {
+  return Object.fromEntries<Mediaset>(
+    mediasets
+      .filter(
+        (mediaset): mediaset is MediasetResource & { alias: string } =>
+          mediaset.alias != null,
+      )
+      .map(({ alias, identifier }) => [alias, identifier]),
+  );
+}
+
+function loadPreviewStreams(streams: StreamResource[]): Record<string, Stream> {
+  return Object.fromEntries<Stream>(
+    streams
+      .filter(
+        (stream): stream is StreamResource & { alias: string } =>
+          stream.alias != null,
+      )
+      .map(({ alias, identifier }) => [alias, identifier]),
   );
 }
 

--- a/packages/functions/src/aliases/mediaset.ts
+++ b/packages/functions/src/aliases/mediaset.ts
@@ -14,9 +14,21 @@
  * limitations under the License.
  */
 
-export * from "./custom.js";
-export * from "./dataset.js";
-export * from "./mediaset.js";
-export * from "./model.js";
-export * from "./source.js";
-export * from "./stream.js";
+import { loadResolvedAliases } from "./loaders.js";
+import type { Mediaset } from "./types.js";
+export type { Mediaset } from "./types.js";
+
+export function mediaset(alias: string): Mediaset {
+  const resolvedAliases = loadResolvedAliases();
+
+  if (!(alias in resolvedAliases.mediasets)) {
+    const available = Object.keys(resolvedAliases.mediasets);
+    throw new Error(
+      `Mediaset alias '${alias}' not found. Available aliases: [${available.join(
+        ", ",
+      )}]`,
+    );
+  }
+
+  return resolvedAliases.mediasets[alias];
+}

--- a/packages/functions/src/aliases/stream.ts
+++ b/packages/functions/src/aliases/stream.ts
@@ -14,9 +14,21 @@
  * limitations under the License.
  */
 
-export * from "./custom.js";
-export * from "./dataset.js";
-export * from "./mediaset.js";
-export * from "./model.js";
-export * from "./source.js";
-export * from "./stream.js";
+import { loadResolvedAliases } from "./loaders.js";
+import type { Stream } from "./types.js";
+export type { Stream } from "./types.js";
+
+export function stream(alias: string): Stream {
+  const resolvedAliases = loadResolvedAliases();
+
+  if (!(alias in resolvedAliases.streams)) {
+    const available = Object.keys(resolvedAliases.streams);
+    throw new Error(
+      `Stream alias '${alias}' not found. Available aliases: [${available.join(
+        ", ",
+      )}]`,
+    );
+  }
+
+  return resolvedAliases.streams[alias];
+}

--- a/packages/functions/src/aliases/test-data/aliases.json
+++ b/packages/functions/src/aliases/test-data/aliases.json
@@ -27,6 +27,42 @@
           "rid": "ri.magritte..source.22222222-2222-2222-2222-222222222222"
         }
       }
+    },
+    "datasets": {
+      "myDatasetAlias": {
+        "id": {
+          "rid": "ri.foundry.main.dataset.11111111-1111-1111-1111-111111111111"
+        }
+      },
+      "anotherDatasetAlias": {
+        "id": {
+          "rid": "ri.foundry.main.dataset.22222222-2222-2222-2222-222222222222"
+        }
+      }
+    },
+    "mediasets": {
+      "myMediasetAlias": {
+        "id": {
+          "rid": "ri.mio.main.media-set.11111111-1111-1111-1111-111111111111"
+        }
+      },
+      "anotherMediasetAlias": {
+        "id": {
+          "rid": "ri.mio.main.media-set.22222222-2222-2222-2222-222222222222"
+        }
+      }
+    },
+    "streams": {
+      "myStreamAlias": {
+        "id": {
+          "rid": "ri.foundry.main.dataset.33333333-3333-3333-3333-333333333333"
+        }
+      },
+      "anotherStreamAlias": {
+        "id": {
+          "rid": "ri.foundry.main.dataset.44444444-4444-4444-4444-444444444444"
+        }
+      }
     }
   },
   "version": 1

--- a/packages/functions/src/aliases/test-data/resources.json
+++ b/packages/functions/src/aliases/test-data/resources.json
@@ -29,6 +29,93 @@
         "verbs": []
       }
     ],
+    "datasets": [
+      {
+        "identifier": {
+          "rid": "ri.foundry.main.dataset.aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+        },
+        "verbs": [],
+        "alias": "previewDatasetAlias"
+      },
+      {
+        "identifier": {
+          "rid": "ri.foundry.main.dataset.bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+        },
+        "verbs": [],
+        "alias": "anotherPreviewDataset"
+      },
+      {
+        "identifier": {
+          "rid": "ri.foundry.main.dataset.cccccccc-cccc-cccc-cccc-cccccccccccc"
+        },
+        "verbs": [],
+        "alias": null
+      },
+      {
+        "identifier": {
+          "rid": "ri.foundry.main.dataset.dddddddd-dddd-dddd-dddd-dddddddddddd"
+        },
+        "verbs": []
+      }
+    ],
+    "mediasets": [
+      {
+        "identifier": {
+          "rid": "ri.mio.main.media-set.aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa"
+        },
+        "verbs": [],
+        "alias": "previewMediasetAlias"
+      },
+      {
+        "identifier": {
+          "rid": "ri.mio.main.media-set.bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb"
+        },
+        "verbs": [],
+        "alias": "anotherPreviewMediaset"
+      },
+      {
+        "identifier": {
+          "rid": "ri.mio.main.media-set.cccccccc-cccc-cccc-cccc-cccccccccccc"
+        },
+        "verbs": [],
+        "alias": null
+      },
+      {
+        "identifier": {
+          "rid": "ri.mio.main.media-set.dddddddd-dddd-dddd-dddd-dddddddddddd"
+        },
+        "verbs": []
+      }
+    ],
+    "streams": [
+      {
+        "identifier": {
+          "rid": "ri.foundry.main.dataset.eeeeeeee-eeee-eeee-eeee-eeeeeeeeeeee"
+        },
+        "verbs": [],
+        "alias": "previewStreamAlias"
+      },
+      {
+        "identifier": {
+          "rid": "ri.foundry.main.dataset.ffffffff-ffff-ffff-ffff-ffffffffffff"
+        },
+        "verbs": [],
+        "alias": "anotherPreviewStream"
+      },
+      {
+        "identifier": {
+          "rid": "ri.foundry.main.dataset.99999999-9999-9999-9999-999999999999"
+        },
+        "verbs": [],
+        "alias": null
+      },
+      {
+        "identifier": {
+          "rid": "ri.foundry.main.dataset.88888888-8888-8888-8888-888888888888"
+        },
+        "verbs": []
+      }
+    ],
     "custom": {
       "previewCustomAlias": "previewCustomValue",
       "anotherPreviewCustom": "anotherPreviewValue"

--- a/packages/functions/src/aliases/types.ts
+++ b/packages/functions/src/aliases/types.ts
@@ -26,10 +26,25 @@ export interface Source {
   rid: string;
 }
 
+export interface Dataset {
+  rid: string;
+}
+
+export interface Mediaset {
+  rid: string;
+}
+
+export interface Stream {
+  rid: string;
+}
+
 export interface ResolvedAliases {
   custom: Record<string, string>;
   models: Record<string, Model>;
   sources: Record<string, Source>;
+  datasets: Record<string, Dataset>;
+  mediasets: Record<string, Mediaset>;
+  streams: Record<string, Stream>;
 }
 
 // Environment
@@ -52,9 +67,30 @@ export interface EgressConnection {
   alias?: string | null;
 }
 
+export interface DatasetResource {
+  identifier: DatasetIdentifier;
+  verbs: string[];
+  alias?: string | null;
+}
+
+export interface MediasetResource {
+  identifier: MediasetIdentifier;
+  verbs: string[];
+  alias?: string | null;
+}
+
+export interface StreamResource {
+  identifier: StreamIdentifier;
+  verbs: string[];
+  alias?: string | null;
+}
+
 export interface ResourceScopes {
   custom: Record<string, string>;
   models: ModelResource[];
+  datasets: DatasetResource[];
+  mediasets: MediasetResource[];
+  streams: StreamResource[];
 }
 
 export interface FunctionEgress {
@@ -84,10 +120,37 @@ export interface EgressConnectionValue {
   id: ConnectionIdentifier;
 }
 
+export interface DatasetIdentifier {
+  rid: string;
+}
+
+export interface DatasetValue {
+  id: DatasetIdentifier;
+}
+
+export interface MediasetIdentifier {
+  rid: string;
+}
+
+export interface MediasetValue {
+  id: MediasetIdentifier;
+}
+
+export interface StreamIdentifier {
+  rid: string;
+}
+
+export interface StreamValue {
+  id: StreamIdentifier;
+}
+
 export interface DefaultAliases {
   custom: Record<string, string>;
   models: Record<string, ModelValue>;
   egressConnections: Record<string, EgressConnectionValue>;
+  datasets: Record<string, DatasetValue>;
+  mediasets: Record<string, MediasetValue>;
+  streams: Record<string, StreamValue>;
 }
 
 export interface AliasesFile {


### PR DESCRIPTION
## Overview
This PR adds utils for datasets, mediasets and streams - identical to models and sources (ex: https://github.com/palantir/osdk-ts/pull/3113).

```ts
import { Aliases } from "@osdk/functions";

const dataset = Aliases.dataset("myDatasetAlias");
const mediaset = Aliases.mediaset("myMediasetAlias");
const stream = Aliases.stream("myStreamAlias");

console.log(dataset.rid);
```

## Testing
Unit tests