### PR TITLE
Support interface links in runtime derived properties

### DIFF
--- a/.changeset/dry-camels-burn.md
+++ b/.changeset/dry-camels-burn.md
@@ -1,0 +1,5 @@
+---
+"@osdk/client": minor
+---
+
+Add support to fetch interface links

--- a/packages/api/src/objectSet/ObjectSet.test.ts
+++ b/packages/api/src/objectSet/ObjectSet.test.ts
@@ -285,6 +285,43 @@ describe("ObjectSet", () => {
       >().toEqualTypeOf<number>();
     });
 
+    test("interface types", async () => {
+      const fauxInterfaceObjectSet = createMockObjectSet<FooInterfaceApiTest>();
+
+      const withInterfaceProperty = fauxInterfaceObjectSet.withProperties({
+        derivedProp: (base) => base.selectProperty("name"),
+      });
+
+      expectTypeOf(withInterfaceProperty).toEqualTypeOf<
+        $ObjectSet<
+          FooInterfaceApiTest,
+          {
+            derivedProp: "string" | undefined;
+          }
+        >
+      >();
+
+      const withInterfacePropertyResults =
+        await withInterfaceProperty.fetchPage();
+
+      expectTypeOf<
+        (typeof withInterfacePropertyResults)["data"][0]
+      >().toEqualTypeOf<
+        Osdk.Instance<
+          FooInterfaceApiTest,
+          never,
+          PropertyKeys<FooInterfaceApiTest>,
+          {
+            derivedProp: "string" | undefined;
+          }
+        >
+      >();
+
+      expectTypeOf<
+        (typeof withInterfacePropertyResults)["data"][0]["derivedProp"]
+      >().toEqualTypeOf<string | undefined>();
+    });
+
     it("can be sub-selected", () => {
       const objectWithUndefinedRdp = fauxObjectSet
         .withProperties({

--- a/packages/client/src/derivedProperties/createWithPropertiesObjectSet.test.ts
+++ b/packages/client/src/derivedProperties/createWithPropertiesObjectSet.test.ts
@@ -15,7 +15,7 @@
  */
 
 import type { DerivedProperty } from "@osdk/api";
-import { Employee } from "@osdk/client.test.ontology";
+import { BarInterface, Employee } from "@osdk/client.test.ontology";
 import type { DerivedPropertyDefinition } from "@osdk/foundry.ontologies";
 import { describe, expect, it } from "vitest";
 
@@ -55,6 +55,43 @@ describe(createWithPropertiesObjectSet, () => {
           "type": "selection",
         }
       `);
+  });
+
+  it("correctly creates interface link search around for interface types", () => {
+    const map = new Map<any, DerivedPropertyDefinition>();
+    const deriveObjectSet = createWithPropertiesObjectSet(
+      BarInterface,
+      {
+        type: "methodInput",
+      },
+      map,
+    );
+
+    const clause = {
+      derivedPropertyName: (base) =>
+        base.pivotTo("toFoo").aggregate("fooIdp:collectList"),
+    } satisfies DerivedProperty.Clause<BarInterface>;
+
+    const result = clause["derivedPropertyName"](deriveObjectSet);
+    const definition = map.get(result);
+
+    expect(definition).toMatchInlineSnapshot(`
+      {
+        "objectSet": {
+          "interfaceLink": "toFoo",
+          "objectSet": {
+            "type": "methodInput",
+          },
+          "type": "interfaceLinkSearchAround",
+        },
+        "operation": {
+          "limit": 100,
+          "selectedPropertyApiName": "fooIdp",
+          "type": "collectList",
+        },
+        "type": "selection",
+      }
+    `);
   });
 
   it("correctly allows select property off the base object set", () => {

--- a/packages/client/src/derivedProperties/createWithPropertiesObjectSet.ts
+++ b/packages/client/src/derivedProperties/createWithPropertiesObjectSet.ts
@@ -38,11 +38,17 @@ export function createWithPropertiesObjectSet<
     pivotTo: (link) => {
       return createWithPropertiesObjectSet(
         objectType,
-        {
-          type: "searchAround",
-          objectSet,
-          link,
-        },
+        objectType.type === "object"
+          ? {
+              type: "searchAround",
+              objectSet,
+              link,
+            }
+          : {
+              type: "interfaceLinkSearchAround",
+              objectSet,
+              interfaceLink: link,
+            },
         definitionMap,
       );
     },

--- a/packages/client/src/object/convertWireToOsdkObjects/BaseHolder.ts
+++ b/packages/client/src/object/convertWireToOsdkObjects/BaseHolder.ts
@@ -24,6 +24,7 @@ import type {
 import type { FormatPropertyOptions } from "../formatting/applyPropertyFormatter.js";
 import type { InterfaceHolder } from "./InterfaceHolder.js";
 import type {
+  DerivedPropertiesRef,
   PropertySecuritiesRef,
   UnderlyingOsdkObject,
 } from "./InternalSymbols.js";
@@ -36,6 +37,7 @@ export interface BaseHolder {
   readonly [PropertySecuritiesRef]:
     | { [propName: string]: PropertySecurity[] }
     | undefined;
+  readonly [DerivedPropertiesRef]?: ReadonlyArray<string>;
 
   readonly $apiName: string;
   readonly $objectType: string;

--- a/packages/client/src/object/convertWireToOsdkObjects/InternalSymbols.ts
+++ b/packages/client/src/object/convertWireToOsdkObjects/InternalSymbols.ts
@@ -42,6 +42,11 @@ export const PropertySecuritiesRef = Symbol(
   process.env.MODE !== "production" ? "Property Securities" : undefined,
 );
 
+/** @internal */
+export const DerivedPropertiesRef = Symbol(
+  process.env.MODE !== "production" ? "Derived Properties" : undefined,
+);
+
 export interface HolderBase<T extends ObjectOrInterfaceDefinition> {
   [UnderlyingOsdkObject]: OsdkBase<any>;
   [ObjectDefRef]?: T;

--- a/packages/client/src/object/convertWireToOsdkObjects/createOsdkInterface.test.ts
+++ b/packages/client/src/object/convertWireToOsdkObjects/createOsdkInterface.test.ts
@@ -21,7 +21,7 @@ import {
   InterfaceDefinitions,
 } from "../../ontology/OntologyProvider.js";
 import { createOsdkInterface } from "./createOsdkInterface.js";
-import { ObjectDefRef } from "./InternalSymbols.js";
+import { DerivedPropertiesRef, ObjectDefRef } from "./InternalSymbols.js";
 
 describe(createOsdkInterface, () => {
   it("works in the normal case", () => {
@@ -218,4 +218,96 @@ describe(createOsdkInterface, () => {
       }"
     `);
   });
+
+  it("exposes runtime derived properties alongside the interface properties", () => {
+    const underlying = {
+      foo: "hi mom",
+      linkedCount: 3,
+
+      [DerivedPropertiesRef]: ["linkedCount"],
+      [ObjectDefRef]: baseObjectDef,
+    };
+
+    const iface = createOsdkInterface(underlying as any, ifaceDef);
+
+    expect(Object.keys(iface)).toMatchInlineSnapshot(`
+      [
+        "$apiName",
+        "asdf",
+        "linkedCount",
+      ]
+    `);
+    expect((iface as any).linkedCount).toBe(3);
+    expect((iface as any).asdf).toBe("hi mom");
+  });
+
+  it("omits derived properties the server did not return", () => {
+    const underlying = {
+      foo: "hi mom",
+
+      // Requested, but absent from the payload — e.g. a `get` over a link with
+      // no target object.
+      [DerivedPropertiesRef]: ["linkedCount"],
+      [ObjectDefRef]: baseObjectDef,
+    };
+
+    const iface = createOsdkInterface(underlying as any, ifaceDef);
+
+    expect(Object.keys(iface)).toEqual(["$apiName", "asdf"]);
+    expect((iface as any).linkedCount).toBeUndefined();
+  });
+
+  it("does not add derived property keys when there are none", () => {
+    const underlying = {
+      foo: "hi mom",
+      [ObjectDefRef]: baseObjectDef,
+    };
+
+    const iface = createOsdkInterface(underlying as any, ifaceDef);
+
+    expect(Object.keys(iface)).toEqual(["$apiName", "asdf"]);
+  });
 });
+
+const baseObjectDef = {
+  [InterfaceDefinitions]: {},
+  apiName: "Obj",
+  displayName: "",
+  interfaceMap: {
+    IFoo: {
+      asdf: "foo",
+    },
+  },
+  inverseInterfaceMap: {},
+  links: {},
+  pluralDisplayName: "",
+  primaryKeyApiName: "",
+  primaryKeyType: "string",
+  properties: {
+    foo: {
+      type: "string",
+    },
+  },
+  type: "object",
+  titleProperty: "foo",
+  rid: "",
+  status: "ACTIVE",
+  icon: undefined,
+  visibility: undefined,
+  description: undefined,
+} satisfies FetchedObjectTypeDefinition;
+
+const ifaceDef = {
+  apiName: "IFoo",
+  displayName: "",
+  links: {},
+  properties: {
+    asdf: {
+      type: "string",
+    },
+  },
+  rid: "",
+  type: "interface",
+  implements: [],
+  description: undefined,
+} as const;

--- a/packages/client/src/object/convertWireToOsdkObjects/createOsdkInterface.ts
+++ b/packages/client/src/object/convertWireToOsdkObjects/createOsdkInterface.ts
@@ -25,6 +25,7 @@ import type { FetchedObjectTypeDefinition } from "../../ontology/OntologyProvide
 import { get$linkForInterface } from "./getDollarLink.js";
 import type { InterfaceHolder } from "./InterfaceHolder.js";
 import {
+  DerivedPropertiesRef,
   InterfaceDefRef,
   ObjectDefRef,
   UnderlyingOsdkObject,
@@ -178,6 +179,15 @@ export function createOsdkInterface<Q extends FetchedObjectTypeDefinition>(
               },
             ];
           }),
+        ),
+        ...Object.fromEntries(
+          (underlying[DerivedPropertiesRef] ?? []).map((propName) => [
+            propName,
+            {
+              enumerable: propName in underlying,
+              value: underlying[propName as keyof typeof underlying],
+            },
+          ]),
         ),
       },
     ) as InterfaceHolder,

--- a/packages/client/src/object/convertWireToOsdkObjects/createOsdkObject.ts
+++ b/packages/client/src/object/convertWireToOsdkObjects/createOsdkObject.ts
@@ -43,6 +43,7 @@ import { get$as } from "./getDollarAs.js";
 import { get$link } from "./getDollarLink.js";
 import {
   ClientRef,
+  DerivedPropertiesRef,
   ObjectDefRef,
   PropertySecuritiesRef,
   UnderlyingOsdkObject,
@@ -179,6 +180,10 @@ export function createOsdkObject(
     },
     [ObjectDefRef]: { value: objectDef, enumerable: false }, // TODO: Potentially update when GA metadata field
     [ClientRef]: { value: client, enumerable: false },
+    [DerivedPropertiesRef]: {
+      enumerable: false,
+      value: Object.keys(derivedPropertyTypeByName),
+    },
     ...basePropDefs,
   } satisfies Record<keyof ObjectHolder, PropertyDescriptor>);
 

--- a/packages/client/src/object/fetchPage.ts
+++ b/packages/client/src/object/fetchPage.ts
@@ -380,12 +380,17 @@ async function fetchInterfacePage<
     },
   );
 
+  const derivedPropertyTypeByName = await extractRdpDefinition(
+    client,
+    resolvedInterfaceObjectSet,
+  );
+
   return Promise.resolve({
     data: await client.objectFactory(
       client,
       result.data,
       extractedInterfaceTypeApiName,
-      {},
+      derivedPropertyTypeByName,
       shouldLoadPropertySecurities ? result.propertySecurities : undefined,
       !args.$includeRid,
       args.$select,

--- a/packages/client/src/object/fetchPage.ts
+++ b/packages/client/src/object/fetchPage.ts
@@ -367,12 +367,17 @@ async function fetchInterfacePage<
     },
   );
 
+  const derivedPropertyTypeByName = await extractRdpDefinition(
+    client,
+    resolvedInterfaceObjectSet,
+  );
+
   return Promise.resolve({
     data: await client.objectFactory(
       client,
       result.data,
       extractedInterfaceTypeApiName,
-      {},
+      derivedPropertyTypeByName,
       shouldLoadPropertySecurities ? result.propertySecurities : undefined,
       !args.$includeRid,
       args.$select,

--- a/packages/client/src/util/extractRdpDefinition.test.ts
+++ b/packages/client/src/util/extractRdpDefinition.test.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import type { ObjectMetadata } from "@osdk/api";
+import type { InterfaceMetadata, ObjectMetadata } from "@osdk/api";
 import type { ObjectSet } from "@osdk/foundry.ontologies";
 import { describe, expect, it } from "vitest";
 
@@ -69,9 +69,21 @@ describe("extractRdpDefinition", () => {
             links: {
               testInterfaceLink: {
                 targetTypeApiName: "SecondType",
+                targetType: "object",
                 multiplicity: false,
-              },
+              } satisfies InterfaceMetadata.Link<any, any>,
+              testInterfaceToInterfaceLink: {
+                targetTypeApiName: "OtherTestInterface",
+                targetType: "interface",
+                multiplicity: false,
+              } satisfies InterfaceMetadata.Link<any, any>,
             },
+          };
+        } else if (interfaceType === "OtherTestInterface") {
+          return {
+            type: "interface",
+            apiName: "OtherTestInterface",
+            links: {},
           };
         } else {
           throw new Error(
@@ -507,6 +519,34 @@ describe("extractRdpDefinition", () => {
         },
       }
     `,
+    );
+  });
+
+  it("throws when a selected property is across an interface-to-interface link", async () => {
+    const interfaceToInterfaceObjectSet: ObjectSet = {
+      type: "withProperties",
+      objectSet: { type: "base", objectType: "TestInterface" },
+      derivedProperties: {
+        myRdp: {
+          type: "selection",
+          objectSet: {
+            type: "interfaceLinkSearchAround",
+            objectSet: { type: "methodInput" },
+            interfaceLink: "testInterfaceToInterfaceLink",
+          },
+          operation: {
+            type: "collectList",
+            selectedPropertyApiName: "testProperty",
+            limit: 100,
+          },
+        },
+      },
+    };
+
+    await expect(
+      extractRdpDefinition(mockClientCtx, interfaceToInterfaceObjectSet),
+    ).rejects.toThrowErrorMatchingInlineSnapshot(
+      `[Error: Invariant failed: Runtime Derived Properties are not supported for a property selected across a link that targets an interface ('OtherTestInterface')]`,
     );
   });
 

--- a/packages/client/src/util/extractRdpDefinition.test.ts
+++ b/packages/client/src/util/extractRdpDefinition.test.ts
@@ -27,6 +27,7 @@ describe("extractRdpDefinition", () => {
       getObjectDefinition: (objectType: string) => {
         if (objectType === "BaseType") {
           return {
+            type: "object",
             links: {
               testLink1: {
                 targetType: "SecondType",
@@ -36,6 +37,7 @@ describe("extractRdpDefinition", () => {
           };
         } else if (objectType === "SecondType") {
           return {
+            type: "object",
             links: {
               testLink2: {
                 targetType: "ThirdType",
@@ -45,6 +47,7 @@ describe("extractRdpDefinition", () => {
           };
         } else if (objectType === "ThirdType") {
           return {
+            type: "object",
             properties: {
               testProperty: {
                 type: "attachment",
@@ -56,6 +59,24 @@ describe("extractRdpDefinition", () => {
           };
         } else {
           throw new Error(`Missing definition for '${objectType}'`);
+        }
+      },
+      getInterfaceDefinition: (interfaceType: string) => {
+        if (interfaceType === "TestInterface") {
+          return {
+            type: "interface",
+            apiName: "TestInterface",
+            links: {
+              testInterfaceLink: {
+                targetTypeApiName: "SecondType",
+                multiplicity: false,
+              },
+            },
+          };
+        } else {
+          throw new Error(
+            `Missing interface definition for '${interfaceType}'`,
+          );
         }
       },
     } as any,
@@ -384,6 +405,126 @@ describe("extractRdpDefinition", () => {
       extractRdpDefinition(mockClientCtx, RdpWithIntersectionBaseObjectSet),
     ).rejects.toThrowErrorMatchingInlineSnapshot(
       `[Error: Invariant failed: All object sets in an intersect, subtract, or union must have the same child object type]`,
+    );
+  });
+
+  it("handles interfaceLinkSearchAround object set type", async () => {
+    const interfaceLinkObjectSet: ObjectSet = {
+      type: "withProperties",
+      objectSet: {
+        type: "interfaceLinkSearchAround",
+        objectSet: { type: "base", objectType: "TestInterface" },
+        interfaceLink: "testInterfaceLink",
+      },
+      derivedProperties: {
+        myRdp: {
+          type: "selection",
+          objectSet: {
+            type: "searchAround",
+            objectSet: { type: "methodInput" },
+            link: "testLink2",
+          },
+          operation: { type: "get", selectedPropertyApiName: "testProperty" },
+        },
+      },
+    };
+
+    const result = await extractRdpDefinition(
+      mockClientCtx,
+      interfaceLinkObjectSet,
+    );
+
+    expect(result).toMatchInlineSnapshot(
+      `
+      {
+        "myRdp": {
+          "definition": {
+            "objectSet": {
+              "link": "testLink2",
+              "objectSet": {
+                "type": "methodInput",
+              },
+              "type": "searchAround",
+            },
+            "operation": {
+              "selectedPropertyApiName": "testProperty",
+              "type": "get",
+            },
+            "type": "selection",
+          },
+          "selectedOrCollectedPropertyType": {
+            "type": "attachment",
+          },
+        },
+      }
+    `,
+    );
+  });
+
+  it("handles nested interfaceLinkSearchAround with object definitions", async () => {
+    const nestedInterfaceObjectSet: ObjectSet = {
+      type: "withProperties",
+      objectSet: {
+        type: "searchAround",
+        objectSet: {
+          type: "interfaceLinkSearchAround",
+          objectSet: { type: "base", objectType: "TestInterface" },
+          interfaceLink: "testInterfaceLink",
+        },
+        link: "testLink2",
+      },
+      derivedProperties: {
+        myRdp: {
+          type: "selection",
+          objectSet: { type: "methodInput" },
+          operation: { type: "get", selectedPropertyApiName: "testProperty" },
+        },
+      },
+    };
+
+    const result = await extractRdpDefinition(
+      mockClientCtx,
+      nestedInterfaceObjectSet,
+    );
+
+    expect(result).toMatchInlineSnapshot(
+      `
+      {
+        "myRdp": {
+          "definition": {
+            "objectSet": {
+              "type": "methodInput",
+            },
+            "operation": {
+              "selectedPropertyApiName": "testProperty",
+              "type": "get",
+            },
+            "type": "selection",
+          },
+          "selectedOrCollectedPropertyType": {
+            "type": "attachment",
+          },
+        },
+      }
+    `,
+    );
+  });
+
+  it("throws when interfaceLink is missing from interface definition", async () => {
+    const invalidInterfaceLinkObjectSet: ObjectSet = {
+      type: "interfaceLinkSearchAround",
+      objectSet: { type: "base", objectType: "TestInterface" },
+      interfaceLink: "nonExistentLink",
+    };
+
+    await expect(
+      extractRdpDefinition(mockClientCtx, {
+        type: "withProperties",
+        objectSet: invalidInterfaceLinkObjectSet,
+        derivedProperties: {},
+      }),
+    ).rejects.toThrowErrorMatchingInlineSnapshot(
+      `[Error: Invariant failed: Missing link definition for 'nonExistentLink']`,
     );
   });
 });

--- a/packages/client/src/util/extractRdpDefinition.ts
+++ b/packages/client/src/util/extractRdpDefinition.ts
@@ -76,6 +76,44 @@ async function extractRdpDefinitionInternal(
         childObjectType: objDef.links[objectSet.link].targetType,
       };
     }
+    case "interfaceLinkSearchAround": {
+      const { definitions, childObjectType } =
+        await extractRdpDefinitionInternal(
+          clientCtx,
+          objectSet.objectSet,
+          methodInputObjectType,
+        );
+
+      if (childObjectType === undefined || childObjectType === "") {
+        return { definitions: {} };
+      }
+
+      let objOrInterfaceDef;
+      try {
+        objOrInterfaceDef =
+          await clientCtx.ontologyProvider.getObjectDefinition(childObjectType);
+      } catch {
+        objOrInterfaceDef =
+          await clientCtx.ontologyProvider.getInterfaceDefinition(
+            childObjectType,
+          );
+      }
+
+      const linkDef = objOrInterfaceDef.links[objectSet.interfaceLink];
+      invariant(
+        linkDef,
+        `Missing link definition for '${objectSet.interfaceLink}'`,
+      );
+
+      return {
+        definitions,
+        childObjectType:
+          objOrInterfaceDef.type === "object"
+            ? objOrInterfaceDef.links[objectSet.interfaceLink].targetType
+            : objOrInterfaceDef.links[objectSet.interfaceLink]
+                .targetTypeApiName,
+      };
+    }
     case "withProperties": {
       // These are the definitions and current object type for all object set operations prior to the definition (e.g. filter, pivotTo, etc.)
       const { definitions, childObjectType } =
@@ -194,11 +232,6 @@ async function extractRdpDefinitionInternal(
       // Static and reference object sets are always intersected with a base object set, so we can just return no child object type.
       return { definitions: {} };
     // We don't have to worry about new object sets being added and doing a runtime break and breaking people since the OSDK is always constructing these.
-    case "interfaceLinkSearchAround":
-      invariant(
-        false,
-        `Unsupported object set type for Runtime Derived Properties`,
-      );
     default:
       const _: never = objectSet;
       invariant(

--- a/packages/client/src/util/extractRdpDefinition.ts
+++ b/packages/client/src/util/extractRdpDefinition.ts
@@ -45,6 +45,33 @@ export function hasWithProperties(objectSet: ObjectSet): boolean {
 }
 
 /* @internal
+ * An interface link can target another interface, so the type a pivotTo chain lands on is not
+ * guaranteed to be an object type. Selecting a property across such a link is unsupported, so say
+ * that outright instead of surfacing it as a missing object definition.
+ */
+async function getSelectedPropertyObjectDefinition(
+  clientCtx: MinimalClient,
+  apiName: string,
+) {
+  try {
+    return await clientCtx.ontologyProvider.getObjectDefinition(apiName);
+  } catch (e) {
+    let isInterface = false;
+    try {
+      await clientCtx.ontologyProvider.getInterfaceDefinition(apiName);
+      isInterface = true;
+    } catch {
+      // Not an interface either, so the original lookup failure is the real error.
+    }
+    invariant(
+      !isInterface,
+      `Runtime Derived Properties are not supported for a property selected across a link that targets an interface ('${apiName}')`,
+    );
+    throw e;
+  }
+}
+
+/* @internal
  * Returns a tuple of the derived property definitions and the object type that the derived property is defined on.
  */
 async function extractRdpDefinitionInternal(
@@ -156,7 +183,8 @@ async function extractRdpDefinitionInternal(
             ) {
               return { definitions: {} };
             }
-            const objDef = await clientCtx.ontologyProvider.getObjectDefinition(
+            const objDef = await getSelectedPropertyObjectDefinition(
+              clientCtx,
               operationLevelObjectType,
             );
 

--- a/packages/e2e.generated.catchall/ontology.json
+++ b/packages/e2e.generated.catchall/ontology.json
@@ -7249,8 +7249,8 @@
           "cardinality": "MANY",
           "required": false
         },
-         "esongIssues": {
-          "rid":"ri.ontology.main.interface-link.a0e8988e-a36b-4ac8-9d62-cdb5d826c742",
+        "esongIssues": {
+          "rid": "ri.ontology.main.interface-link.a0e8988e-a36b-4ac8-9d62-cdb5d826c742",
           "apiName": "esongIssues",
           "displayName": "[esong] Issues",
           "description": "",

--- a/packages/e2e.generated.catchall/ontology.json
+++ b/packages/e2e.generated.catchall/ontology.json
@@ -7531,8 +7531,8 @@
           "cardinality": "MANY",
           "required": false
         },
-         "esongIssues": {
-          "rid":"ri.ontology.main.interface-link.a0e8988e-a36b-4ac8-9d62-cdb5d826c742",
+        "esongIssues": {
+          "rid": "ri.ontology.main.interface-link.a0e8988e-a36b-4ac8-9d62-cdb5d826c742",
           "apiName": "esongIssues",
           "displayName": "[esong] Issues",
           "description": "",

--- a/packages/e2e.generated.catchall/ontology.json
+++ b/packages/e2e.generated.catchall/ontology.json
@@ -7220,6 +7220,18 @@
             "type": "objectTypeApiName",
             "apiName": "EsongPds"
           },
+          "cardinality": "MANY",
+          "required": false
+        },
+        "esongIssues": {
+          "rid": "ri.ontology.main.interface-link.a0e8988e-a36b-4ac8-9d62-cdb5d826c742",
+          "apiName": "esongIssues",
+          "displayName": "[esong] Issues",
+          "description": "",
+          "linkedEntityApiName": {
+            "type": "objectTypeApiName",
+            "apiName": "EsongIssues"
+          },
           "cardinality": "ONE",
           "required": false
         }
@@ -7233,6 +7245,18 @@
           "linkedEntityApiName": {
             "type": "objectTypeApiName",
             "apiName": "EsongPds"
+          },
+          "cardinality": "MANY",
+          "required": false
+        },
+         "esongIssues": {
+          "rid":"ri.ontology.main.interface-link.a0e8988e-a36b-4ac8-9d62-cdb5d826c742",
+          "apiName": "esongIssues",
+          "displayName": "[esong] Issues",
+          "description": "",
+          "linkedEntityApiName": {
+            "type": "objectTypeApiName",
+            "apiName": "EsongIssues"
           },
           "cardinality": "ONE",
           "required": false

--- a/packages/e2e.generated.catchall/ontology.json
+++ b/packages/e2e.generated.catchall/ontology.json
@@ -7502,6 +7502,18 @@
             "type": "objectTypeApiName",
             "apiName": "EsongPds"
           },
+          "cardinality": "MANY",
+          "required": false
+        },
+        "esongIssues": {
+          "rid": "ri.ontology.main.interface-link.a0e8988e-a36b-4ac8-9d62-cdb5d826c742",
+          "apiName": "esongIssues",
+          "displayName": "[esong] Issues",
+          "description": "",
+          "linkedEntityApiName": {
+            "type": "objectTypeApiName",
+            "apiName": "EsongIssues"
+          },
           "cardinality": "ONE",
           "required": false
         }
@@ -7515,6 +7527,18 @@
           "linkedEntityApiName": {
             "type": "objectTypeApiName",
             "apiName": "EsongPds"
+          },
+          "cardinality": "MANY",
+          "required": false
+        },
+         "esongIssues": {
+          "rid":"ri.ontology.main.interface-link.a0e8988e-a36b-4ac8-9d62-cdb5d826c742",
+          "apiName": "esongIssues",
+          "displayName": "[esong] Issues",
+          "description": "",
+          "linkedEntityApiName": {
+            "type": "objectTypeApiName",
+            "apiName": "EsongIssues"
           },
           "cardinality": "ONE",
           "required": false

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/interfaces/EsongInterfaceA.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/interfaces/EsongInterfaceA.ts
@@ -1,5 +1,6 @@
 import type { PropertyDef as $PropertyDef } from '@osdk/client';
 import { $osdkMetadata } from '../../OntologyMetadata.js';
+import type { EsongIssues } from '../objects/EsongIssues.js';
 import type { EsongPds } from '../objects/EsongPds.js';
 import type {
   InterfaceDefinition as $InterfaceDefinition,
@@ -11,7 +12,8 @@ import type {
 } from '@osdk/client';
 
 export interface OsdkObjectLinks$EsongInterfaceA {
-  esongPds: $SingleLinkAccessor<EsongPds>;
+  esongIssues: $SingleLinkAccessor<EsongIssues>;
+  esongPds: EsongPds.ObjectSet;
 }
 
 export namespace EsongInterfaceA {
@@ -54,7 +56,8 @@ export interface EsongInterfaceA extends $InterfaceDefinition {
     implementedBy: ['EsongIssues'];
     implements: [];
     links: {
-      esongPds: $InterfaceMetadata.Link<EsongPds, false>;
+      esongIssues: $InterfaceMetadata.Link<EsongIssues, false>;
+      esongPds: $InterfaceMetadata.Link<EsongPds, true>;
     };
     properties: {
       /**

--- a/packages/e2e.sandbox.catchall/src/runInterfacesTest2.ts
+++ b/packages/e2e.sandbox.catchall/src/runInterfacesTest2.ts
@@ -132,7 +132,8 @@ export async function runInterfacesTest2(): Promise<void> {
     interfaceAFilteredByPk,
   );
 
-  const huh3 = await interfaceA.data[0].$link.esongPds.fetchOne();
+  const huh3 = await interfaceA.data[0].$link.esongIssues.fetchOne();
+  const huh4 = await interfaceA.data[0].$link.esongPds.fetchPage();
 
   const implementObjectTypeAAndB = await client(NihalbCastingInterfaceTypeA)
     .narrowToType(NihalbCastingInterfaceB)

--- a/packages/e2e.sandbox.catchall/src/runWithPropertiesTest.ts
+++ b/packages/e2e.sandbox.catchall/src/runWithPropertiesTest.ts
@@ -60,8 +60,9 @@ export async function runWithPropertiesTest(): Promise<void> {
   const result3 = await dsClient(EsongInterfaceA)
     .withProperties({
       linkedObjectCount: (base) => base.pivotTo("esongPds").aggregate("$count"),
-      // linkedObjectTitle: (base) =>
-      //   (base.pivotTo("esongIssues" as any) as any).selectProperty("id")
+      // TODO: Remove as any after updating the generated ontology
+      linkedObjectTitle: (base) =>
+        (base.pivotTo("esongIssues" as any) as any).selectProperty("id"),
     })
     .fetchPage();
 
@@ -69,7 +70,7 @@ export async function runWithPropertiesTest(): Promise<void> {
     result3.data.map((x) => ({
       esongSptA: x.esongSptA,
       linkedObjectCount: x.linkedObjectCount,
-      // linkedObjectTitle: x.linkedObjectTitle,
+      linkedObjectTitle: x.linkedObjectTitle,
     })),
   );
 }

--- a/packages/e2e.sandbox.catchall/src/runWithPropertiesTest.ts
+++ b/packages/e2e.sandbox.catchall/src/runWithPropertiesTest.ts
@@ -14,7 +14,11 @@
  * limitations under the License.
  */
 
-import { Country_1, StateTerritory } from "@osdk/e2e.generated.catchall";
+import {
+  Country_1,
+  EsongInterfaceA,
+  StateTerritory,
+} from "@osdk/e2e.generated.catchall";
 
 import { client } from "./client.js";
 
@@ -50,6 +54,23 @@ export async function runWithPropertiesTest(): Promise<void> {
       x.stateCount,
       x.stateNameSet,
     ]),
+  );
+
+  // Test withProperties on interface type
+  const result3 = await client(EsongInterfaceA)
+    .withProperties({
+      linkedObjectCount: (base) => base.pivotTo("esongPds").aggregate("$count"),
+      linkedObjectTitle: (base) =>
+        base.pivotTo("esongPds").selectProperty("title"),
+    })
+    .fetchPage();
+
+  console.log(
+    result3.data.map((x) => ({
+      esongSptA: x.esongSptA,
+      linkedObjectCount: x.linkedObjectCount,
+      linkedObjectTitle: x.linkedObjectTitle,
+    })),
   );
 }
 

--- a/packages/e2e.sandbox.catchall/src/runWithPropertiesTest.ts
+++ b/packages/e2e.sandbox.catchall/src/runWithPropertiesTest.ts
@@ -20,7 +20,7 @@ import {
   StateTerritory,
 } from "@osdk/e2e.generated.catchall";
 
-import { client } from "./client.js";
+import { client, dsClient } from "./client.js";
 
 export async function runWithPropertiesTest(): Promise<void> {
   const result = await client(StateTerritory)
@@ -57,11 +57,11 @@ export async function runWithPropertiesTest(): Promise<void> {
   );
 
   // Test withProperties on interface type
-  const result3 = await client(EsongInterfaceA)
+  const result3 = await dsClient(EsongInterfaceA)
     .withProperties({
       linkedObjectCount: (base) => base.pivotTo("esongPds").aggregate("$count"),
-      linkedObjectTitle: (base) =>
-        base.pivotTo("esongPds").selectProperty("title"),
+      // linkedObjectTitle: (base) =>
+      //   (base.pivotTo("esongIssues" as any) as any).selectProperty("id")
     })
     .fetchPage();
 
@@ -69,7 +69,7 @@ export async function runWithPropertiesTest(): Promise<void> {
     result3.data.map((x) => ({
       esongSptA: x.esongSptA,
       linkedObjectCount: x.linkedObjectCount,
-      linkedObjectTitle: x.linkedObjectTitle,
+      // linkedObjectTitle: x.linkedObjectTitle,
     })),
   );
 }

--- a/packages/e2e.sandbox.catchall/src/runWithPropertiesTest.ts
+++ b/packages/e2e.sandbox.catchall/src/runWithPropertiesTest.ts
@@ -60,9 +60,8 @@ export async function runWithPropertiesTest(): Promise<void> {
   const result3 = await dsClient(EsongInterfaceA)
     .withProperties({
       linkedObjectCount: (base) => base.pivotTo("esongPds").aggregate("$count"),
-      // TODO: Remove as any after updating the generated ontology
       linkedObjectTitle: (base) =>
-        (base.pivotTo("esongIssues" as any) as any).selectProperty("id"),
+        base.pivotTo("esongIssues").selectProperty("id"),
     })
     .fetchPage();
 


### PR DESCRIPTION
This PR is scoped to the ObservableClient only. Added support for interface withProperties method, and always construct InterfaceHolder with RDPs.

## What changes

- `extractRdpDefinition` handles `interfaceLinkSearchAround` object sets: it resolves the link on the child type's definition, falling back to interface metadata when the child is not an object type.
- `createWithPropertiesObjectSet` emits `interfaceLinkSearchAround` instead of `searchAround` when the pivot source is an interface.
- `fetchInterfacePage` to be called with extracted RDPs
- `DerivedPropertiesRef` is added to the BaseHolder so both InterfaceHolder and ObjectHolder has access to the RDP. 

<img width="569" height="408" alt="Screenshot 2026-07-31 at 11 41 27" src="https://github.com/user-attachments/assets/b8ac3cad-09d1-40e1-9831-35bfce33e97c" />


## Test evidence 

runWithPropertiesTest:

<img width="781" height="242" alt="Screenshot 2026-07-31 at 11 32 01" src="https://github.com/user-attachments/assets/1456ff80-5f95-40c9-863e-fbe80a537ada" />

