### PR TITLE
ci: restore Node-24 build cache on test-matrix legs so codegen is a hit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -301,6 +301,12 @@ jobs:
             turbo-${{ runner.os }}-build-${{ github.sha }}
             turbo-${{ runner.os }}-build-
 
+      - name: Restore Node-24 build artifacts (make codegen a cache hit)
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: .turbo/cache
+          key: turbo-${{ runner.os }}-build-${{ github.sha }}
+
       - name: Install dependencies
         run: pnpm install
 


### PR DESCRIPTION
`typescript-sdk-docs-examples#codegen` runs on every test-matrix leg (Node 18-24): a generator depends on it, so it can't be filtered out per leg. Its script ends in `pnpm run format`.

The per-node Turbo cache step stops at the first matching `restore-key`, so a stale `test-node<N>-*` cache gets picked ahead of this SHA's build cache. When codegen's inputs change, its hash misses on the leg and it re-executes (re-running `format`) instead of being restored from the Node-24 build job.

Fix: add a restore-only overlay of `turbo-<os>-build-<sha>` after the warming cache. Turbo cache entries are hash-named, so this SHA's build artifacts (codegen included, and node-independent) are present regardless of which stale cache matched, making codegen a guaranteed hit. Per-node test warming still coexists, and the build cache holds no `test` entries so it can't mask a per-node test result.
