### PR TITLE
Introduce experimental branching features to create-app templates and CLI

### DIFF
--- a/.changeset/create-app-branch-sync.md
+++ b/.changeset/create-app-branch-sync.md
@@ -1,0 +1,5 @@
+---
+"@osdk/create-app": minor
+---
+
+Add an opt-in `--unstableFeatures` flag. When enabled, apps generated from the 2.x/beta templates (React, Vue, Expo, and the to-do tutorials) are wired for Foundry branch support.

--- a/packages/create-app.template.expo.v2/templates/foundry/client.ts.hbs
+++ b/packages/create-app.template.expo.v2/templates/foundry/client.ts.hbs
@@ -6,6 +6,11 @@ import {
 } from "@osdk/client";
 import { FOUNDRY_URL{{#if osdkPackage}}, ONTOLOGY_RID{{/if}} } from "./osdkConst";
 import { getValidAuthToken } from "./Auth";
+{{#if osdkPackage}}
+{{#if unstableFeatures}}
+import { $branch } from "{{osdkPackage}}";
+{{/if}}
+{{/if}}
 
 {{#if osdkPackage}}
 /**
@@ -15,6 +20,11 @@ export const client: Client = createClient(
     FOUNDRY_URL, 
     ONTOLOGY_RID, 
     getValidAuthToken,
+{{#if unstableFeatures}}
+    {
+      UNSTABLE_DO_NOT_USE_BRANCH: $branch,
+    },
+{{/if}}
 );
 {{else}}
 /**

--- a/packages/create-app.template.react.beta/templates/src/client.ts.hbs
+++ b/packages/create-app.template.react.beta/templates/src/client.ts.hbs
@@ -1,5 +1,8 @@
 {{#if osdkPackage}}
 import { createClient, type Client } from "@osdk/client";
+{{#if unstableFeatures}}
+import { $branch } from "{{osdkPackage}}";
+{{/if}}
 {{else}}
 import { createPlatformClient, type PlatformClient } from "@osdk/client";
 {{/if}}
@@ -51,7 +54,9 @@ export const auth: PublicOauthClient = createPublicOauthClient(
 /**
  * Initialize the client to interact with the Ontology and Platform SDKs
  */
-export const client: Client = createClient(foundryUrl, ontologyRid, auth);
+export const client: Client = createClient(foundryUrl, ontologyRid, auth{{#if unstableFeatures}}, {
+  UNSTABLE_DO_NOT_USE_BRANCH: $branch,
+}{{/if}});
 {{else}}
 /**
  * Initialize the client to interact with the Platform SDK

--- a/packages/create-app.template.tutorial-todo-aip-app.beta/templates/src/client.ts.hbs
+++ b/packages/create-app.template.tutorial-todo-aip-app.beta/templates/src/client.ts.hbs
@@ -1,5 +1,8 @@
 import { createClient, type Client } from "@osdk/client";
 import { createPublicOauthClient, type PublicOauthClient } from "@osdk/oauth";
+{{#if unstableFeatures}}
+import { $branch } from "{{osdkPackage}}";
+{{/if}}
 
 function getMetaTagContent(tagName: string): string {
   const elements = document.querySelectorAll(`meta[name="${tagName}"]`);
@@ -44,6 +47,8 @@ export const auth: PublicOauthClient = createPublicOauthClient(
 /**
  * Initialize the client to interact with the Ontology and Platform SDKs
  */
-const client: Client = createClient(foundryUrl, ontologyRid, auth);
+const client: Client = createClient(foundryUrl, ontologyRid, auth{{#if unstableFeatures}}, {
+  UNSTABLE_DO_NOT_USE_BRANCH: $branch,
+}{{/if}});
 
 export default client;

--- a/packages/create-app.template.tutorial-todo-app.beta/templates/src/client.ts.hbs
+++ b/packages/create-app.template.tutorial-todo-app.beta/templates/src/client.ts.hbs
@@ -1,5 +1,8 @@
 import { createClient, type Client } from "@osdk/client";
 import { createPublicOauthClient, type PublicOauthClient } from "@osdk/oauth";
+{{#if unstableFeatures}}
+import { $branch } from "{{osdkPackage}}";
+{{/if}}
 
 function getMetaTagContent(tagName: string): string {
   const elements = document.querySelectorAll(`meta[name="${tagName}"]`);
@@ -44,6 +47,8 @@ export const auth: PublicOauthClient = createPublicOauthClient(
 /**
  * Initialize the client to interact with the Ontology and Platform SDKs
  */
-const client: Client = createClient(foundryUrl, ontologyRid, auth);
+const client: Client = createClient(foundryUrl, ontologyRid, auth{{#if unstableFeatures}}, {
+  UNSTABLE_DO_NOT_USE_BRANCH: $branch,
+}{{/if}});
 
 export default client;

--- a/packages/create-app.template.vue.v2/templates/src/client.ts.hbs
+++ b/packages/create-app.template.vue.v2/templates/src/client.ts.hbs
@@ -1,5 +1,8 @@
 {{#if osdkPackage}}
 import { createClient, type Client } from "@osdk/client";
+{{#if unstableFeatures}}
+import { $branch } from "{{osdkPackage}}";
+{{/if}}
 {{else}}
 import { createPlatformClient, type PlatformClient } from "@osdk/client";
 {{/if}}
@@ -51,7 +54,9 @@ export const auth: PublicOauthClient = createPublicOauthClient(
 /**
  * Initialize the client to interact with the Ontology and Platform SDKs
  */
-export const client: Client = createClient(foundryUrl, ontologyRid, auth);
+export const client: Client = createClient(foundryUrl, ontologyRid, auth{{#if unstableFeatures}}, {
+  UNSTABLE_DO_NOT_USE_BRANCH: $branch,
+}{{/if}});
 {{else}}
 /**
  * Initialize the client to interact with the Platform SDK

--- a/packages/create-app/src/cli.test.ts
+++ b/packages/create-app/src/cli.test.ts
@@ -246,11 +246,11 @@ describe("--unstableFeatures flag", () => {
 
   const readProject = (project: string) => {
     const root = path.join(process.cwd(), project);
+    const pkgPath = path.join(root, "package.json");
+    const clientPath = path.join(root, "src", "client.ts");
     return {
-      packageJson: JSON.parse(
-        fs.readFileSync(path.join(root, "package.json"), "utf-8")
-      ),
-      clientTs: fs.readFileSync(path.join(root, "src", "client.ts"), "utf-8"),
+      packageJson: JSON.parse(fs.readFileSync(pkgPath, "utf-8")),
+      clientTs: fs.readFileSync(clientPath, "utf-8"),
     };
   };
 

--- a/packages/create-app/src/cli.test.ts
+++ b/packages/create-app/src/cli.test.ts
@@ -212,3 +212,69 @@ async function runTest({
     expect(packageJson.dependencies["@osdk/client"]).toBe(undefined);
   }
 }
+
+describe("--unstableFeatures flag", () => {
+  const argsFor = (project: string, extra: string[]): string[] => [
+    "npx",
+    "@osdk/create-app",
+    project,
+    "--overwrite",
+    "--template",
+    "template-react",
+    "--foundryUrl",
+    "https://example.palantirfoundry.com",
+    "--applicationUrl",
+    "https://app.example.palantirfoundry.com",
+    "--application",
+    "ri.third-party-applications.main.application.fake",
+    "--clientId",
+    "123",
+    "--corsProxy",
+    "false",
+    "--sdkVersion",
+    "2.x",
+    "--scopes",
+    "api:read-data",
+    "--ontology",
+    "ri.ontology.main.ontology.fake",
+    "--osdkPackage",
+    "@fake/sdk",
+    "--osdkRegistryUrl",
+    "https://example.palantirfoundry.com/artifacts/api/repositories/ri.artifacts.main.repository.fake/contents/release/npm",
+    ...extra,
+  ];
+
+  const readProject = (project: string) => {
+    const root = path.join(process.cwd(), project);
+    return {
+      packageJson: JSON.parse(
+        fs.readFileSync(path.join(root, "package.json"), "utf-8")
+      ),
+      clientTs: fs.readFileSync(path.join(root, "src", "client.ts"), "utf-8"),
+    };
+  };
+
+  test("wires Foundry branch support when enabled", async () => {
+    const project = "expected-unstable-on";
+    await cli(argsFor(project, ["--unstableFeatures", "true"]));
+    const { packageJson, clientTs } = readProject(project);
+
+    expect(packageJson.scripts.postinstall).toBe(
+      "./node_modules/.bin/osdk unstable branch sync"
+    );
+    expect(packageJson.devDependencies["@osdk/cli"]).toBe("latest");
+    expect(clientTs).toContain('import { $branch } from "@fake/sdk";');
+    expect(clientTs).toContain("UNSTABLE_DO_NOT_USE_BRANCH: $branch");
+  });
+
+  test("omits Foundry branch support by default", async () => {
+    const project = "expected-unstable-off";
+    await cli(argsFor(project, []));
+    const { packageJson, clientTs } = readProject(project);
+
+    expect(packageJson.scripts.postinstall).toBeUndefined();
+    expect(packageJson.devDependencies?.["@osdk/cli"]).toBeUndefined();
+    expect(clientTs).not.toContain("UNSTABLE_DO_NOT_USE_BRANCH");
+    expect(clientTs).not.toContain("$branch");
+  });
+});

--- a/packages/create-app/src/cli.test.ts
+++ b/packages/create-app/src/cli.test.ts
@@ -259,9 +259,8 @@ describe("--unstableFeatures flag", () => {
     await cli(argsFor(project, ["--unstableFeatures", "true"]));
     const { packageJson, clientTs } = readProject(project);
 
-    expect(packageJson.scripts.postinstall).toBe(
-      "./node_modules/.bin/osdk unstable branch sync"
-    );
+    const postinstall = "./node_modules/.bin/osdk unstable branch sync";
+    expect(packageJson.scripts.postinstall).toBe(postinstall);
     expect(packageJson.devDependencies["@osdk/cli"]).toBe("latest");
     expect(clientTs).toContain('import { $branch } from "@fake/sdk";');
     expect(clientTs).toContain("UNSTABLE_DO_NOT_USE_BRANCH: $branch");

--- a/packages/create-app/src/cli.ts
+++ b/packages/create-app/src/cli.ts
@@ -36,6 +36,7 @@ interface CliArgs {
   project?: string;
   overwrite?: boolean;
   beta?: boolean;
+  unstableFeatures?: boolean;
   template?: string;
   sdkVersion?: string;
   foundryUrl?: string;
@@ -73,6 +74,11 @@ export async function cli(args: string[] = process.argv): Promise<void> {
             type: "boolean",
             describe:
               "Use templates compatible with the Beta version of the SDK",
+          })
+          .option("unstableFeatures", {
+            type: "boolean",
+            describe:
+              "Enable unstable/experimental features in the generated app.",
           })
           .option("template", {
             type: "string",
@@ -180,5 +186,6 @@ export async function cli(args: string[] = process.argv): Promise<void> {
     corsProxy,
     scopes,
     ontology,
+    unstableFeatures: parsed.unstableFeatures ?? false,
   });
 }

--- a/packages/create-app/src/run.ts
+++ b/packages/create-app/src/run.ts
@@ -46,6 +46,7 @@ interface RunArgs {
   osdkRegistryUrl: string | undefined;
   corsProxy: boolean;
   scopes: string[] | undefined;
+  unstableFeatures: boolean;
 }
 
 export async function run({
@@ -62,6 +63,7 @@ export async function run({
   osdkRegistryUrl,
   corsProxy,
   scopes,
+  unstableFeatures,
 }: RunArgs): Promise<void> {
   consola.log("");
   consola.start(
@@ -131,9 +133,10 @@ export async function run({
     corsProxy,
     clientVersion: changeVersionPrefix(clientVersion, "^"),
     scopes,
+    unstableFeatures,
   };
   const processFiles = function (dir: string) {
-    fs.readdirSync(dir).forEach(function (file) {
+    fs.readdirSync(dir).forEach((file) => {
       let fullPath = dir + "/" + file;
       const stat = fs.statSync(fullPath);
       if (stat.isDirectory()) {
@@ -180,6 +183,23 @@ export async function run({
     });
   };
   processFiles(root);
+
+  if (unstableFeatures && osdkPackage != null) {
+    const packageJsonPath = path.join(root, "package.json");
+    const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, "utf-8"));
+    packageJson.scripts = {
+      ...packageJson.scripts,
+      postinstall: "./node_modules/.bin/osdk unstable branch sync",
+    };
+    packageJson.devDependencies = {
+      "@osdk/cli": "latest",
+      ...packageJson.devDependencies,
+    };
+    fs.writeFileSync(
+      packageJsonPath,
+      JSON.stringify(packageJson, undefined, 2)
+    );
+  }
 
   const npmRc = generateNpmRc({ osdkPackage, osdkRegistryUrl, foundryUrl });
   fs.writeFileSync(path.join(root, ".npmrc"), npmRc);

--- a/packages/create-app/src/run.ts
+++ b/packages/create-app/src/run.ts
@@ -196,10 +196,7 @@ export async function run({
       "@osdk/cli": "latest",
       ...packageJson.devDependencies,
     };
-    fs.writeFileSync(
-      packageJsonPath,
-      JSON.stringify(packageJson, undefined, 2)
-    );
+    fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2));
   }
 
   const npmRc = generateNpmRc({ osdkPackage, osdkRegistryUrl, foundryUrl });

--- a/packages/create-app/src/run.ts
+++ b/packages/create-app/src/run.ts
@@ -46,7 +46,8 @@ interface RunArgs {
   osdkRegistryUrl: string | undefined;
   corsProxy: boolean;
   scopes: string[] | undefined;
-  unstableFeatures: boolean;
+  /** Opt-in gate for unstable/experimental features; defaults to `false`. */
+  unstableFeatures?: boolean;
 }
 
 export async function run({
@@ -63,7 +64,7 @@ export async function run({
   osdkRegistryUrl,
   corsProxy,
   scopes,
-  unstableFeatures,
+  unstableFeatures = false,
 }: RunArgs): Promise<void> {
   consola.log("");
   consola.start(

--- a/packages/create-app/src/templates.ts
+++ b/packages/create-app/src/templates.ts
@@ -49,4 +49,5 @@ export interface TemplateContext {
   clientVersion: string;
   corsProxy: boolean;
   scopes: string[] | undefined;
+  unstableFeatures: boolean;
 }


### PR DESCRIPTION
1. Add --unstableFeatures arg to the create-app CLI which acts as a gate for introducing experimental/unstable functionality to the generated apps
2. Modifies branching-supported templates with unstable branching functionality gated behind the new unstableFeatures flag