### PR TITLE
Support synchronous token providers

### DIFF
--- a/.changeset/synchronous-token-providers.md
+++ b/.changeset/synchronous-token-providers.md
@@ -1,0 +1,6 @@
+---
+"@osdk/client": patch
+"@osdk/shared.client.impl": patch
+---
+
+Allow client token providers to return tokens synchronously.

--- a/etc/client.report.api.md
+++ b/etc/client.report.api.md
@@ -122,7 +122,7 @@ export { CompileTimeMetadata }
 export function createAttachmentUpload(data: Blob, name: string): AttachmentUpload;
 
 // @public
-export const createClient: (baseUrl: string, ontologyRid: string | Promise<string>, tokenProvider: () => Promise<string>, options?: {
+export const createClient: (baseUrl: string, ontologyRid: string | Promise<string>, tokenProvider: () => string | Promise<string>, options?: {
     	logger?: Logger
     	UNSTABLE_DO_NOT_USE_BRANCH?: string
     	headers?: Record<string, string>
@@ -132,7 +132,7 @@ export const createClient: (baseUrl: string, ontologyRid: string | Promise<strin
 export function createObjectSpecifierFromPrimaryKey<Q extends ObjectTypeDefinition>(objectDef: Q, primaryKey: PrimaryKeyType<Q>): ObjectSpecifier<Q>;
 
 // @public
-export function createPlatformClient(baseUrl: string, tokenProvider: () => Promise<string>, options?: undefined, fetchFn?: typeof globalThis.fetch): PlatformClient;
+export function createPlatformClient(baseUrl: string, tokenProvider: () => string | Promise<string>, options?: undefined, fetchFn?: typeof globalThis.fetch): PlatformClient;
 
 export { DerivedProperty }
 

--- a/packages/client/src/createClient.ts
+++ b/packages/client/src/createClient.ts
@@ -111,7 +111,7 @@ export function createClientInternal(
   subscribeConnectionFn: CreateSubscriptionConnectionFn | undefined,
   baseUrl: string,
   ontologyRid: string | Promise<string>,
-  tokenProvider: () => Promise<string>,
+  tokenProvider: () => string | Promise<string>,
   options:
     | {
         logger?: Logger;
@@ -408,7 +408,7 @@ export function createClientFromContext(clientCtx: MinimalClient) {
  * @param baseUrl - The base URL of the Foundry stack (e.g. `"https://example.palantirfoundry.com"`).
  * @param ontologyRid - The ontology RID to scope the client to. May be provided directly or as a `Promise`
  *   that resolves to the RID. Typically the generated `$ontologyRid` export from your generated SDK is passed here.
- * @param tokenProvider - A function returning a `Promise` that resolves to a bearer token used to authenticate
+ * @param tokenProvider - A function returning a bearer token or a `Promise` that resolves to one, used to authenticate
  *   requests. Typically the OAuth client returned by `createPublicOauthClient` or `createConfidentialOauthClient`
  *   from `@osdk/oauth`, which handles caching and refresh; you can also provide a custom function if you
  *   manage tokens yourself.
@@ -438,7 +438,7 @@ export function createClientFromContext(clientCtx: MinimalClient) {
 export const createClient: (
   baseUrl: string,
   ontologyRid: string | Promise<string>,
-  tokenProvider: () => Promise<string>,
+  tokenProvider: () => string | Promise<string>,
   options?:
     | {
         logger?: Logger;

--- a/packages/client/src/createClientFromWriteableClient.ts
+++ b/packages/client/src/createClientFromWriteableClient.ts
@@ -32,7 +32,7 @@ export function createClientFromWriteableClient(
     transactionId?: string;
     baseUrl?: string;
     ontologyRid?: string | Promise<string>;
-    tokenProvider?: () => Promise<string>;
+    tokenProvider?: () => string | Promise<string>;
   },
 ): Client {
   const ctx = writeableClient[additionalContext];

--- a/packages/client/src/createMinimalClient.ts
+++ b/packages/client/src/createMinimalClient.ts
@@ -37,7 +37,7 @@ import { USER_AGENT } from "./util/UserAgent.js";
 export function createMinimalClient(
   metadata: MinimalClientParams["metadata"],
   baseUrl: string,
-  tokenProvider: () => Promise<string>,
+  tokenProvider: () => string | Promise<string>,
   options: OntologyCachingOptions & {
     logger?: Logger;
     transactionId?: string;

--- a/packages/client/src/createMinimalClientHelper.ts
+++ b/packages/client/src/createMinimalClientHelper.ts
@@ -22,11 +22,11 @@ import type { MinimalClientParams } from "./MinimalClientContext.js";
 export function createMinimalClientHelper(
   baseUrl: string,
   ontologyRid: string | Promise<string>,
-  tokenProvider: () => Promise<string>,
+  tokenProvider: () => string | Promise<string>,
   ...args: typeof createMinimalClient extends (
     metadata: MinimalClientParams["metadata"],
     baseUrl: string,
-    tokenProvider: () => Promise<string>,
+    tokenProvider: () => string | Promise<string>,
     ...args: infer A
   ) => any
     ? A

--- a/packages/client/src/createPlatformClient.test.ts
+++ b/packages/client/src/createPlatformClient.test.ts
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { expect, it } from "vitest";
+
+import { createPlatformClient } from "./createPlatformClient.js";
+
+it.each([
+  ["synchronous", () => "sync-token", "sync-token"],
+  ["asynchronous", () => Promise.resolve("async-token"), "async-token"],
+])(
+  "accepts an %s token provider and normalizes it to a promise",
+  async (_providerType, tokenProvider, expectedToken) => {
+    const client = createPlatformClient("https://example.com", tokenProvider);
+
+    await expect(client.tokenProvider()).resolves.toBe(expectedToken);
+  },
+);

--- a/packages/client/src/createPlatformClient.ts
+++ b/packages/client/src/createPlatformClient.ts
@@ -31,7 +31,7 @@ export interface PlatformClient extends SharedClientContext {}
  */
 export function createPlatformClient(
   baseUrl: string,
-  tokenProvider: () => Promise<string>,
+  tokenProvider: () => string | Promise<string>,
   options: undefined = undefined,
   fetchFn: typeof globalThis.fetch = fetch,
 ): PlatformClient {

--- a/packages/shared.client.impl/src/createSharedClientContext.ts
+++ b/packages/shared.client.impl/src/createSharedClientContext.ts
@@ -28,7 +28,7 @@ export const USER_AGENT_HEADER = "Fetch-User-Agent";
 
 export function createSharedClientContext(
   baseUrl: string,
-  tokenProvider: () => Promise<string>,
+  tokenProvider: () => string | Promise<string>,
   userAgent: string,
   fetchFn: typeof globalThis.fetch = fetch,
   customHeaders?: Record<string, string>,
@@ -42,6 +42,8 @@ export function createSharedClientContext(
     parsedBaseUrl.pathname += "/";
   }
   const normalizedBaseUrl = parsedBaseUrl.toString();
+  const asyncTokenProvider = (): Promise<string> =>
+    Promise.resolve().then(tokenProvider);
 
   const retryingFetchWithAuthOrThrow = createFetchHeaderMutator(
     createRetryingFetch(createFetchOrThrow(fetchFn)),
@@ -54,7 +56,7 @@ export function createSharedClientContext(
         }
       }
 
-      const token = await tokenProvider();
+      const token = await asyncTokenProvider();
       headers.set("Authorization", `Bearer ${token}`);
 
       const customUserAgent = customHeaders
@@ -104,6 +106,6 @@ export function createSharedClientContext(
   return {
     baseUrl: normalizedBaseUrl,
     fetch: fetchWrapper,
-    tokenProvider,
+    tokenProvider: asyncTokenProvider,
   };
 }


### PR DESCRIPTION
Currently `createPlatformClient` and related constructors only support `() => Promise<string>` token providers. This is a bit annoying when you already have a token handy, like when you already got an OAuth token or have a long-lived user token.

https://github.com/palantir/osdk-ts/blob/fd00f48adf2cf8cfc916d9ecb942bd3795ef7931/packages/client/src/createPlatformClient.ts#L34

This PR widens the type to `() => string | Promise<string>` to support both sync and async token providers.