### PR TITLE
Add experimental $defaultLoadLevel fetch arg

### DIFF
--- a/.changeset/default-load-level.md
+++ b/.changeset/default-load-level.md
@@ -1,0 +1,6 @@
+---
+"@osdk/api": patch
+"@osdk/client": patch
+---
+
+Add experimental `$defaultLoadLevel` fetch arg that applies reducers and struct main values to every property without listing property IDs. Wired through the object and static-rid load paths.

--- a/etc/api.report.api.md
+++ b/etc/api.report.api.md
@@ -854,6 +854,8 @@ export interface FetchPageArgs<
 > extends AsyncIterArgs<Q, K, R, A, S, T, RDP_KEYS, ORDER_BY_OPTIONS, PROPERTY_SECURITIES, MODIFIERS> {
     	// (undocumented)
     $applyModifiers?: ApplyModifiersArg<Q> & MODIFIERS & { [P in Exclude<keyof MODIFIERS, PropertyKeys<Q>>] : never };
+    	// Warning: (ae-forgotten-export) The symbol "PropertyModifierValue" needs to be exported by the entry point index.d.ts
+    $defaultLoadLevel?: PropertyModifierValue;
     	// (undocumented)
     $nextPageToken?: string;
     	// (undocumented)

--- a/packages/api/src/object/FetchPageArgs.ts
+++ b/packages/api/src/object/FetchPageArgs.ts
@@ -19,7 +19,10 @@ import type {
   PropertyKeys,
 } from "../ontology/ObjectOrInterface.js";
 import type { CompileTimeMetadata } from "../ontology/ObjectTypeDefinition.js";
-import type { ApplyModifiersArg } from "../ontology/PropertyModifiers.js";
+import type {
+  ApplyModifiersArg,
+  PropertyModifierValue,
+} from "../ontology/PropertyModifiers.js";
 
 export type NullabilityAdherence = false | "throw" | "drop";
 export namespace NullabilityAdherence {
@@ -127,6 +130,14 @@ export interface FetchPageArgs<
   $pageSize?: number;
   $applyModifiers?: ApplyModifiersArg<Q> &
     MODIFIERS & { [P in Exclude<keyof MODIFIERS, PropertyKeys<Q>>]: never };
+  /**
+   * Best-effort load level applied to every property without listing them:
+   * reducers and struct main values where defined, other properties unchanged.
+   * A per-property `$applyModifiers` entry wins. Does not narrow the result type.
+   *
+   * @experimental
+   */
+  $defaultLoadLevel?: PropertyModifierValue;
   /**
    * Ensures paging consistency by freezing the view at the time of query to prevent duplicate or missing items. Setting $snapshot to false ensures that you will always get the latest results.
    * @default false

--- a/packages/client/src/object/fetchPage.ts
+++ b/packages/client/src/object/fetchPage.ts
@@ -249,9 +249,9 @@ export async function fetchStaticRidPage<
     {
       objectSet: {
         type: "static",
-        objects: [...rids],
+        objects: rids as string[],
       },
-      select: args?.$select ? [...args.$select] : [],
+      select: (args?.$select as string[] | undefined) ?? [],
       selectV2: [],
       excludeRid: !args?.$includeRid,
       snapshot: args.$snapshot ?? false,

--- a/packages/client/src/object/fetchPage.ts
+++ b/packages/client/src/object/fetchPage.ts
@@ -37,6 +37,7 @@ import type {
   LoadObjectSetV2MultipleObjectTypesRequest,
   ObjectSet,
   OntologyObjectV2,
+  PropertyLoadLevel,
   SearchJsonQueryV2,
   SearchOrderByV2,
 } from "@osdk/foundry.ontologies";
@@ -51,29 +52,37 @@ import { extractRdpDefinition } from "../util/extractRdpDefinition.js";
 import { resolveBaseObjectSetType } from "../util/objectSetUtils.js";
 
 /**
- * Converts a PropertyModifierValue to the corresponding wire format loadLevel type.
+ * Builds the wire `defaultLoadLevel` for a request from the experimental
+ * `$defaultLoadLevel` arg, or `undefined` when it is not set. Applied to every
+ * property server-side (best-effort) without listing property IDs.
  */
-function modifierToLoadLevelType(
+function buildDefaultLoadLevel(
+  defaultLoadLevel: PropertyModifierValue | undefined,
+): PropertyLoadLevel | undefined {
+  return defaultLoadLevel != null
+    ? modifierToLoadLevel(defaultLoadLevel)
+    : undefined;
+}
+
+/**
+ * Converts a PropertyModifierValue to the corresponding wire format loadLevel.
+ */
+function modifierToLoadLevel(
   modifier: PropertyModifierValue,
-): LoadLevelType {
+): PropertyLoadLevel {
   switch (modifier) {
     case "applyMainValue":
-      return "extractMainValue";
+      return { type: "extractMainValue" };
     case "applyReducers":
-      return "applyReducers";
+      return { type: "applyReducers" };
     case "applyReducersAndExtractMainValue":
-      return "applyReducersAndExtractMainValue";
+      return { type: "applyReducersAndExtractMainValue" };
     default: {
       const _exhaustiveCheck: never = modifier;
       throw new Error(`Unknown modifier: ${_exhaustiveCheck}`);
     }
   }
 }
-
-type LoadLevelType =
-  | "extractMainValue"
-  | "applyReducers"
-  | "applyReducersAndExtractMainValue";
 
 interface SelectV2SimpleProperty {
   type: "property";
@@ -83,7 +92,7 @@ interface SelectV2SimpleProperty {
 interface SelectV2PropertyWithLoadLevel {
   type: "propertyWithLoadLevel";
   propertyIdentifier: SelectV2SimpleProperty;
-  loadLevel: { type: LoadLevelType };
+  loadLevel: PropertyLoadLevel;
 }
 
 type SelectV2Entry = SelectV2SimpleProperty | SelectV2PropertyWithLoadLevel;
@@ -111,7 +120,7 @@ export function buildSelectV2(
         entries.push({
           type: "propertyWithLoadLevel",
           propertyIdentifier: { type: "property", apiName: prop },
-          loadLevel: { type: modifierToLoadLevelType(modifiersMap[prop]) },
+          loadLevel: modifierToLoadLevel(modifiersMap[prop]),
         });
       } else {
         entries.push({ type: "property", apiName: prop });
@@ -123,7 +132,7 @@ export function buildSelectV2(
         entries.push({
           type: "propertyWithLoadLevel",
           propertyIdentifier: { type: "property", apiName: prop },
-          loadLevel: { type: modifierToLoadLevelType(modifiersMap[prop]) },
+          loadLevel: modifierToLoadLevel(modifiersMap[prop]),
         });
       } else {
         entries.push({ type: "property", apiName: prop });
@@ -240,13 +249,15 @@ export async function fetchStaticRidPage<
     {
       objectSet: {
         type: "static",
-        objects: rids as string[],
+        objects: [...rids],
       },
-      select: (args?.$select as string[] | undefined) ?? [],
+      select: args?.$select ? [...args.$select] : [],
+      selectV2: [],
       excludeRid: !args?.$includeRid,
       snapshot: args.$snapshot ?? false,
       loadPropertySecurities: shouldLoadPropertySecurities,
-    } as LoadObjectSetV2MultipleObjectTypesRequest,
+      defaultLoadLevel: buildDefaultLoadLevel(args.$defaultLoadLevel),
+    } satisfies LoadObjectSetV2MultipleObjectTypesRequest,
     client,
     { type: "object", apiName: "" },
   );
@@ -735,6 +746,7 @@ export async function fetchObjectPage<
       loadPropertySecurities: shouldLoadPropertySecurities,
       excludeRid: !args?.$includeRid,
       snapshot: args.$snapshot ?? false,
+      defaultLoadLevel: buildDefaultLoadLevel(args.$defaultLoadLevel),
     },
     client,
     objectType,

--- a/packages/client/src/objectSet/ObjectSet.test.ts
+++ b/packages/client/src/objectSet/ObjectSet.test.ts
@@ -52,7 +52,7 @@ import { beforeAll, describe, expect, expectTypeOf, it } from "vitest";
 
 import type { Client } from "../Client.js";
 import { createClient } from "../createClient.js";
-import { fetchPage } from "../object/fetchPage.js";
+import { fetchPage, fetchStaticRidPage } from "../object/fetchPage.js";
 import {
   createMockCaptureClient,
   getLastObjectSetRequest,
@@ -1351,6 +1351,56 @@ describe("ObjectSet", () => {
       expect(
         getLastObjectSetRequest(fetchFn) as { snapshot: boolean },
       ).not.toHaveProperty("$snapshot");
+    });
+  });
+
+  describe("$defaultLoadLevel", () => {
+    it("exposes $defaultLoadLevel to client (type)", () => {
+      expectTypeOf<FetchPageArgs<Employee>>().toHaveProperty(
+        "$defaultLoadLevel",
+      );
+    });
+
+    it("omits defaultLoadLevel from the wire request body by default", async () => {
+      const { client, fetchFn } = createMockCaptureClient();
+      await fetchPage(client, Employee, {});
+      expect(getLastObjectSetRequest(fetchFn)).not.toHaveProperty(
+        "defaultLoadLevel",
+      );
+    });
+
+    it("sends defaultLoadLevel for fetchObjectPage with an empty selection", async () => {
+      const { client, fetchFn } = createMockCaptureClient();
+      await fetchPage(client, Employee, {
+        $defaultLoadLevel: "applyReducersAndExtractMainValue",
+      });
+      // No $select => empty selection so the server applies the level to all properties.
+      expect(getLastObjectSetRequest(fetchFn)).toMatchObject({
+        select: [],
+        selectV2: [],
+        defaultLoadLevel: { type: "applyReducersAndExtractMainValue" },
+      });
+    });
+
+    it("maps applyMainValue to the extractMainValue wire discriminant", async () => {
+      const { client, fetchFn } = createMockCaptureClient();
+      await fetchPage(client, Employee, {
+        $defaultLoadLevel: "applyMainValue",
+      });
+      expect(getLastObjectSetRequest(fetchFn)).toMatchObject({
+        defaultLoadLevel: { type: "extractMainValue" },
+      });
+    });
+
+    it("sends defaultLoadLevel for fetchStaticRidPage", async () => {
+      const { client, fetchFn } = createMockCaptureClient();
+      await fetchStaticRidPage(client, [stubData.employee1.__rid], {
+        $defaultLoadLevel: "applyReducers",
+      });
+      expect(getLastObjectSetRequest(fetchFn)).toMatchObject({
+        objectSet: { type: "static" },
+        defaultLoadLevel: { type: "applyReducers" },
+      });
     });
   });
 


### PR DESCRIPTION
Adds an experimental `$defaultLoadLevel` fetch arg that applies reducers / struct main values to every property without listing property IDs. Wired through the object and static-rid load paths.

The generated `defaultLoadLevel` field arrives with the `2.70.0` catalog bump in the base branch, so the request body carries it without a cast. `fetchStaticRidPage`'s pre-existing `as LoadObjectSetV2MultipleObjectTypesRequest` is gone too — it only existed because the literal omitted the required `selectV2` and had readonly→mutable array casts.