### PR TITLE
Write direct OAC imports to metadata file

### DIFF
--- a/.changeset/light-foxes-glow.md
+++ b/.changeset/light-foxes-glow.md
@@ -1,0 +1,5 @@
+---
+"@osdk/maker-experimental": patch
+---
+
+Write direct oac imports to metadata file

--- a/packages/maker-experimental/src/cli/main.ts
+++ b/packages/maker-experimental/src/cli/main.ts
@@ -223,13 +223,14 @@ export default async function main(
     await fs.promises.mkdir(commandLineOpts.buildDir, { recursive: true });
   }
 
-  const importedLinkTypeIdsByApiName = commandLineOpts.importJson
-    ? getImportedLinkTypeIdsByApiName(
-        JSON.parse(
-          await fs.promises.readFile(commandLineOpts.importJson, "utf-8"),
-        ) as ImportedOntologyMetadata,
-      )
-    : undefined;
+  const importedLinkTypeIdsByApiName =
+    commandLineOpts.importJson && fs.existsSync(commandLineOpts.importJson)
+      ? getImportedLinkTypeIdsByApiName(
+          JSON.parse(
+            await fs.promises.readFile(commandLineOpts.importJson, "utf-8"),
+          ) as ImportedOntologyMetadata,
+        )
+      : undefined;
 
   const {
     ontologyIr,
@@ -265,13 +266,20 @@ export default async function main(
       undefined,
       ontologyIr.transitiveImportedOntology,
     );
+  const directlyImportedInterfaceTypes = Object.values(
+    ontologyIr.importedOntology.interfaceTypes,
+  ).map(({ interfaceType }) => interfaceType.apiName);
   const importedMetadataPath = path.join(
     commandLineOpts.buildDir,
     "oac-imported-metadata.json",
   );
   await fs.promises.writeFile(
     importedMetadataPath,
-    JSON.stringify(importedMetadata, null, 2),
+    JSON.stringify(
+      { ...importedMetadata, directlyImportedInterfaceTypes },
+      null,
+      2,
+    ),
   );
   consola.info(`Wrote oac-imported-metadata.json to ${importedMetadataPath}`);
 


### PR DESCRIPTION
OAC imports bring in transitive interfaces that should not be declared as inputs to other ontology consuming integrations in the foundry CLI