### PR TITLE
Add ObservableClient paging

### DIFF
--- a/packages/client/src/observable/ObservableClient.ts
+++ b/packages/client/src/observable/ObservableClient.ts
@@ -57,6 +57,12 @@ import type {
 } from "./ObservableClient/MediaObservableTypes.js";
 import type { MediaPropertyLocation } from "./ObservableClient/MediaTypes.js";
 import type { ObserveLinks } from "./ObservableClient/ObserveLink.js";
+import type {
+  GetObjectsOptions,
+  GetObjectsResult,
+  RetainHandle,
+  StoreObjectsOptions,
+} from "./ObservableClient/PageTypes.js";
 import type { OptimisticBuilder } from "./OptimisticBuilder.js";
 
 export namespace ObservableClient {
@@ -566,6 +572,28 @@ export interface ObservableClient extends ObserveLinks {
     action: Q,
     args: Parameters<ActionSignatureFromDef<Q>["applyAction"]>[0],
   ) => Promise<ActionValidationResponse>;
+
+  /**
+   * Cache-first bulk read by primary key. Cached objects are returned without
+   * a request; misses are batched through the bulk loader and then cached.
+   *
+   * Missing objects resolve to `undefined` in their slot rather than rejecting
+   * the whole call.
+   */
+  getObjects<T extends ObjectOrInterfaceDefinition>(
+    apiName: T["apiName"] | T,
+    primaryKeys: ReadonlyArray<PrimaryKeyType<T>>,
+    options?: GetObjectsOptions<T>,
+  ): Promise<GetObjectsResult<T>>;
+
+  /**
+   * Writes instances the caller already holds into the object cache without
+   * fetching. For callers keeping their own transport.
+   */
+  storeObjects<T extends ObjectOrInterfaceDefinition>(
+    instances: ReadonlyArray<Osdk.Instance<T, any, any, any>>,
+    options?: StoreObjectsOptions<T>,
+  ): RetainHandle;
 
   /**
    * Invalidates the entire cache, forcing all queries to refetch.

--- a/packages/client/src/observable/ObservableClient.ts
+++ b/packages/client/src/observable/ObservableClient.ts
@@ -58,8 +58,10 @@ import type {
 import type { MediaPropertyLocation } from "./ObservableClient/MediaTypes.js";
 import type { ObserveLinks } from "./ObservableClient/ObserveLink.js";
 import type {
+  FetchObjectSetPageOptions,
   GetObjectsOptions,
   GetObjectsResult,
+  ObjectSetPageResult,
   RetainHandle,
   StoreObjectsOptions,
 } from "./ObservableClient/PageTypes.js";
@@ -572,6 +574,27 @@ export interface ObservableClient extends ObserveLinks {
     action: Q,
     args: Parameters<ActionSignatureFromDef<Q>["applyAction"]>[0],
   ) => Promise<ActionValidationResponse>;
+
+  /**
+   * Reads a single page of an object set and returns it as a promise, writing
+   * the returned objects into the object cache.
+   *
+   * Unlike `observeObjectSet` this creates no collection entry and holds no
+   * cursor: the server page token is passed through untouched in both
+   * directions. It exists for callers whose own contract is a
+   * cursor-paginated request/response pair -- who therefore own list
+   * membership themselves -- but who still want one shared object cache.
+   *
+   * Exactly one server request is issued per call; there is no implicit
+   * multi-page draining.
+   */
+  fetchObjectSetPage<
+    T extends ObjectOrInterfaceDefinition,
+    RDPs extends Record<string, any> = {},
+  >(
+    baseObjectSet: ObjectSet<T>,
+    options?: FetchObjectSetPageOptions<T, RDPs>,
+  ): Promise<ObjectSetPageResult<T, RDPs>>;
 
   /**
    * Cache-first bulk read by primary key. Cached objects are returned without

--- a/packages/client/src/observable/ObservableClient/PageTypes.ts
+++ b/packages/client/src/observable/ObservableClient/PageTypes.ts
@@ -15,19 +15,64 @@
  */
 
 import type {
+  DerivedProperty,
+  LinkNames,
   ObjectOrInterfaceDefinition,
+  ObjectSet,
   Osdk,
   PropertyKeys,
+  WhereClause,
 } from "@osdk/api";
 
 /**
  * Keeps cache entries alive without a subscription. Entries created by
- * `getObjects` or `storeObjects` start at a zero reference count and are
- * collected once the keep-alive window elapses, so callers holding data across
- * turns must retain and later release it.
+ * `fetchObjectSetPage`, `getObjects` or `storeObjects` start at a zero
+ * reference count and are collected once the keep-alive window elapses, so
+ * callers holding data across turns must retain and later release it.
  */
 export interface RetainHandle {
   release: () => void;
+}
+
+export interface FetchObjectSetPageOptions<
+  T extends ObjectOrInterfaceDefinition,
+  RDPs extends Record<string, any> = {},
+> {
+  where?: WhereClause<T>;
+  orderBy?: { [K in PropertyKeys<T>]?: "asc" | "desc" };
+  select?: readonly PropertyKeys<T>[];
+  withProperties?: { [K in keyof RDPs]: DerivedProperty.Creator<T, RDPs[K]> };
+  pivotTo?: LinkNames<T>;
+  union?: ObjectSet<T>[];
+  intersect?: ObjectSet<T>[];
+  subtract?: ObjectSet<T>[];
+
+  pageSize?: number;
+
+  /**
+   * Opaque server cursor returned by a previous call. Omit to read the first
+   * page. Passed to the server unmodified.
+   */
+  pageToken?: string;
+
+  $loadPropertySecurityMetadata?: boolean;
+  $includeAllBaseObjectProperties?: boolean;
+}
+
+export interface ObjectSetPageResult<
+  T extends ObjectOrInterfaceDefinition,
+  RDPs extends Record<string, any> = {},
+> {
+  data: Array<Osdk.Instance<T, "$allBaseProperties", PropertyKeys<T>, RDPs>>;
+
+  /** The server's cursor. Undefined when no further pages exist. */
+  nextPageToken?: string;
+
+  /** Total matching objects, when the server computed it. Wire-encoded. */
+  totalCount?: string;
+
+  /** Pins the objects written by this call. */
+  retain: () => RetainHandle;
 }
 
 export interface GetObjectsOptions<T extends ObjectOrInterfaceDefinition> {

--- a/packages/client/src/observable/ObservableClient/PageTypes.ts
+++ b/packages/client/src/observable/ObservableClient/PageTypes.ts
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type {
+  ObjectOrInterfaceDefinition,
+  Osdk,
+  PropertyKeys,
+} from "@osdk/api";
+
+/**
+ * Keeps cache entries alive without a subscription. Entries created by
+ * `getObjects` or `storeObjects` start at a zero reference count and are
+ * collected once the keep-alive window elapses, so callers holding data across
+ * turns must retain and later release it.
+ */
+export interface RetainHandle {
+  release: () => void;
+}
+
+export interface GetObjectsOptions<T extends ObjectOrInterfaceDefinition> {
+  select?: readonly PropertyKeys<T>[];
+  $loadPropertySecurityMetadata?: boolean;
+  $includeAllBaseObjectProperties?: boolean;
+}
+
+export interface GetObjectsResult<T extends ObjectOrInterfaceDefinition> {
+  /**
+   * Resolved objects in the order the primary keys were supplied. Objects that
+   * could not be found are `undefined` in their slot.
+   */
+  data: Array<Osdk.Instance<T, any, any, any> | undefined>;
+
+  /** Pins the objects written by this call. */
+  retain: () => RetainHandle;
+}
+
+export interface StoreObjectsOptions<T extends ObjectOrInterfaceDefinition> {
+  select?: readonly PropertyKeys<T>[];
+  withProperties?: Record<string, unknown>;
+  $includeAllBaseObjectProperties?: boolean;
+}

--- a/packages/client/src/observable/internal/ObservableClientImpl.ts
+++ b/packages/client/src/observable/internal/ObservableClientImpl.ts
@@ -69,8 +69,10 @@ import type {
 import type { MediaPropertyLocation } from "../ObservableClient/MediaTypes.js";
 import type { ObserveLinks } from "../ObservableClient/ObserveLink.js";
 import type {
+  FetchObjectSetPageOptions,
   GetObjectsOptions,
   GetObjectsResult,
+  ObjectSetPageResult,
   RetainHandle,
   StoreObjectsOptions,
 } from "../ObservableClient/PageTypes.js";
@@ -81,6 +83,7 @@ import {
   retainCacheKeys,
   storeInstances,
 } from "./object/storeInstances.js";
+import { fetchObjectSetPage } from "./objectset/fetchObjectSetPage.js";
 import type { ObserveObjectSetOptions } from "./objectset/ObjectSetQueryOptions.js";
 import type { Rdp } from "./RdpCanonicalizer.js";
 import type { Store } from "./Store.js";
@@ -293,6 +296,16 @@ export class ObservableClientImpl implements ObservableClient {
       // cast to cross typed to untyped barrier
       subFn as unknown as Observer<ObjectSetPayload>,
     );
+  }
+
+  public fetchObjectSetPage<
+    T extends ObjectOrInterfaceDefinition,
+    RDPs extends Record<string, any> = {},
+  >(
+    baseObjectSet: ObjectSet<T>,
+    options?: FetchObjectSetPageOptions<T, RDPs>,
+  ): Promise<ObjectSetPageResult<T, RDPs>> {
+    return fetchObjectSetPage(this.__experimentalStore, baseObjectSet, options);
   }
 
   public getObjects<T extends ObjectOrInterfaceDefinition>(

--- a/packages/client/src/observable/internal/ObservableClientImpl.ts
+++ b/packages/client/src/observable/internal/ObservableClientImpl.ts
@@ -68,8 +68,19 @@ import type {
 } from "../ObservableClient/MediaObservableTypes.js";
 import type { MediaPropertyLocation } from "../ObservableClient/MediaTypes.js";
 import type { ObserveLinks } from "../ObservableClient/ObserveLink.js";
+import type {
+  GetObjectsOptions,
+  GetObjectsResult,
+  RetainHandle,
+  StoreObjectsOptions,
+} from "../ObservableClient/PageTypes.js";
 import type { AggregationPayloadBase } from "./aggregation/AggregationQuery.js";
 import type { Canonical } from "./Canonical.js";
+import { getObjectsByPrimaryKey } from "./object/getObjectsByPrimaryKey.js";
+import {
+  retainCacheKeys,
+  storeInstances,
+} from "./object/storeInstances.js";
 import type { ObserveObjectSetOptions } from "./objectset/ObjectSetQueryOptions.js";
 import type { Rdp } from "./RdpCanonicalizer.js";
 import type { Store } from "./Store.js";
@@ -282,6 +293,27 @@ export class ObservableClientImpl implements ObservableClient {
       // cast to cross typed to untyped barrier
       subFn as unknown as Observer<ObjectSetPayload>,
     );
+  }
+
+  public getObjects<T extends ObjectOrInterfaceDefinition>(
+    apiName: T["apiName"] | T,
+    primaryKeys: ReadonlyArray<PrimaryKeyType<T>>,
+    options?: GetObjectsOptions<T>,
+  ): Promise<GetObjectsResult<T>> {
+    return getObjectsByPrimaryKey(
+      this.__experimentalStore,
+      apiName,
+      primaryKeys,
+      options,
+    );
+  }
+
+  public storeObjects<T extends ObjectOrInterfaceDefinition>(
+    instances: ReadonlyArray<Osdk.Instance<T, any, any, any>>,
+    options?: StoreObjectsOptions<T>,
+  ): RetainHandle {
+    const keys = storeInstances(this.__experimentalStore, instances, options);
+    return retainCacheKeys(this.__experimentalStore, keys);
   }
 
   public invalidateAll(): Promise<void> {

--- a/packages/client/src/observable/internal/object/getObjectsByPrimaryKey.ts
+++ b/packages/client/src/observable/internal/object/getObjectsByPrimaryKey.ts
@@ -1,0 +1,151 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type {
+  ObjectOrInterfaceDefinition,
+  Osdk,
+  PrimaryKeyType,
+  PropertyKeys,
+} from "@osdk/api";
+
+import type {
+  GetObjectsOptions,
+  GetObjectsResult,
+} from "../../ObservableClient/PageTypes.js";
+import { getBulkObjectLoader } from "../BulkObjectLoader.js";
+import { retainCacheKeys, storeInstances } from "./storeInstances.js";
+import type { Store } from "../Store.js";
+import type { ObjectCacheKey } from "./ObjectCacheKey.js";
+
+/**
+ * Promise-based, cache-first bulk read by primary key.
+ *
+ * Cached objects are returned without a request; misses are fetched through
+ * `BulkObjectLoader`, so concurrent calls coalesce into batched requests, and
+ * the results are written into the object cache.
+ *
+ * Objects that do not exist resolve to `undefined` in the corresponding slot
+ * rather than rejecting the whole call -- callers loading by rid routinely
+ * tolerate absent objects and report them individually.
+ */
+export async function getObjectsByPrimaryKey<
+  T extends ObjectOrInterfaceDefinition,
+>(
+  store: Store,
+  apiName: T["apiName"] | T,
+  primaryKeys: ReadonlyArray<PrimaryKeyType<T>>,
+  options: GetObjectsOptions<T> = {},
+): Promise<GetObjectsResult<T>> {
+  const resolvedApiName =
+    typeof apiName === "string" ? apiName : apiName.apiName;
+  const defType =
+    typeof apiName === "string"
+      ? "object"
+      : apiName.type === "interface"
+        ? "interface"
+        : "object";
+
+  const cached = new Map<PrimaryKeyType<T>, Osdk.Instance<T, any, any, any>>();
+  const misses: Array<PrimaryKeyType<T>> = [];
+
+  for (const pk of primaryKeys) {
+    const hit = peekObject<T>(store, resolvedApiName, pk, options);
+    if (hit != null) {
+      cached.set(pk, hit);
+    } else {
+      misses.push(pk);
+    }
+  }
+
+  const loader = getBulkObjectLoader(store.client);
+  const fetched = await Promise.all(
+    misses.map(async (pk) => {
+      try {
+        const object = await loader.fetch(
+          resolvedApiName,
+          pk as string | number | boolean,
+          defType,
+          options.select as readonly string[] | undefined,
+          options.$loadPropertySecurityMetadata,
+          options.$includeAllBaseObjectProperties,
+        );
+        return { pk, object };
+      } catch {
+        return { pk, object: undefined };
+      }
+    }),
+  );
+
+  const newlyFetched = fetched
+    .map((x) => x.object)
+    .filter((x): x is NonNullable<typeof x> => x != null);
+
+  const cacheKeys = storeInstances(
+    store,
+    newlyFetched as unknown as Array<Osdk.Instance<T, any, any, any>>,
+    options,
+  );
+
+  const fetchedByPk = new Map(fetched.map((x) => [x.pk, x.object]));
+
+  return {
+    data: primaryKeys.map(
+      (pk) =>
+        cached.get(pk) ??
+        (fetchedByPk.get(pk) as Osdk.Instance<T, any, any, any> | undefined),
+    ),
+    retain: () => retainCacheKeys(store, cacheKeys),
+  };
+}
+
+/**
+ * Synchronous cache read. Does not create a query, register a reference, or
+ * trigger a fetch.
+ */
+export function peekObject<T extends ObjectOrInterfaceDefinition>(
+  store: Store,
+  apiName: string,
+  pk: PrimaryKeyType<T>,
+  options: GetObjectsOptions<T> = {},
+): Osdk.Instance<T, any, any, any> | undefined {
+  const canonSelect =
+    options.select != null && options.select.length > 0
+      ? store.selectCanonicalizer.canonicalize(
+          options.select as readonly string[],
+        )
+      : undefined;
+
+  const cacheKey = store.cacheKeys.peek<ObjectCacheKey>(
+    "object",
+    apiName,
+    pk as PrimaryKeyType<any>,
+    undefined,
+    canonSelect,
+    options.$loadPropertySecurityMetadata === true ? true : undefined,
+    options.$includeAllBaseObjectProperties === true ? true : undefined,
+  );
+
+  if (cacheKey == null) {
+    return undefined;
+  }
+
+  const entry = store.layers.top.get(cacheKey);
+  if (entry?.status !== "loaded" || entry.value == null) {
+    return undefined;
+  }
+
+  return entry.value as unknown as Osdk.Instance<T, any, any, any>;
+}

--- a/packages/client/src/observable/internal/object/storeInstances.ts
+++ b/packages/client/src/observable/internal/object/storeInstances.ts
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { ObjectOrInterfaceDefinition, Osdk } from "@osdk/api";
+
+import type {
+  RetainHandle,
+  StoreObjectsOptions,
+} from "../../ObservableClient/PageTypes.js";
+import type { Store } from "../Store.js";
+import type { ObjectCacheKey } from "./ObjectCacheKey.js";
+
+/**
+ * Writes instances the caller already holds into the object cache without
+ * fetching anything. For callers that keep their own transport but still want
+ * one shared object store.
+ */
+export function storeInstances<T extends ObjectOrInterfaceDefinition>(
+  store: Store,
+  instances: ReadonlyArray<Osdk.Instance<T, any, any, any>>,
+  options: StoreObjectsOptions<any> = {},
+): ObjectCacheKey[] {
+  if (instances.length === 0) {
+    return [];
+  }
+
+  // A partially selected object must not be written under the all-properties
+  // key, or readers of that key get an object with silently missing values.
+  const selectFieldSet = options.select != null && options.select.length > 0
+    ? new Set<string>(options.select as readonly string[])
+    : undefined;
+
+  const rdpConfig = options.withProperties != null
+    ? store.rdpCanonicalizer.canonicalize(options.withProperties as any)
+    : undefined;
+
+  const { retVal } = store.batch({}, (batch) => {
+    return store.objects.storeOsdkInstances(
+      instances as Array<Osdk.Instance<any, any, any>>,
+      batch,
+      rdpConfig,
+      selectFieldSet,
+      options.$includeAllBaseObjectProperties === true ? true : undefined,
+    );
+  });
+
+  return retVal;
+}
+
+/**
+ * Pins cache entries so they survive without a subscription. Entries written
+ * by `storeInstances` start at a zero reference count and would otherwise be
+ * collected once the keep-alive window elapses.
+ */
+export function retainCacheKeys(
+  store: Store,
+  keys: ReadonlyArray<ObjectCacheKey>,
+): RetainHandle {
+  for (const key of keys) {
+    store.cacheKeys.retain(key);
+  }
+
+  let released = false;
+  return {
+    release: () => {
+      if (released) {
+        return;
+      }
+      released = true;
+      for (const key of keys) {
+        store.cacheKeys.release(key);
+      }
+    },
+  };
+}

--- a/packages/client/src/observable/internal/objectset/fetchObjectSetPage.ts
+++ b/packages/client/src/observable/internal/objectset/fetchObjectSetPage.ts
@@ -1,0 +1,130 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type {
+  ObjectOrInterfaceDefinition,
+  ObjectSet,
+  Osdk,
+  PropertyKeys,
+} from "@osdk/api";
+
+import { additionalContext } from "../../../Client.js";
+import type {
+  FetchObjectSetPageOptions,
+  ObjectSetPageResult,
+} from "../../ObservableClient/PageTypes.js";
+import {
+  retainCacheKeys,
+  storeInstances,
+} from "../object/storeInstances.js";
+import type { Store } from "../Store.js";
+
+/**
+ * Single-page, promise-based read of an object set that participates in the
+ * object cache but deliberately creates no collection entry.
+ *
+ * This exists for callers whose own API contract is a server-cursor-paginated
+ * request/response pair (conjure `getTopObjectsInitialPage` /
+ * `getTopObjectsNextPage` and friends). Those callers own list membership and
+ * cannot express it as a long-lived subscription, so `observeObjectSet` is not
+ * usable for them. What they can share is the object cache, so that objects
+ * loaded through a page become visible to -- and invalidated alongside --
+ * everything observing those same objects.
+ *
+ * The server's page token is passed through untouched in both directions. No
+ * offset arithmetic and no synthesized cursors: replaying a token behaves
+ * exactly as replaying it against the server would.
+ */
+export async function fetchObjectSetPage<
+  T extends ObjectOrInterfaceDefinition,
+  RDPs extends Record<string, any> = {},
+>(
+  store: Store,
+  baseObjectSet: ObjectSet<T>,
+  options: FetchObjectSetPageOptions<T, RDPs> = {},
+): Promise<ObjectSetPageResult<T, RDPs>> {
+  const client = store.client[additionalContext];
+  if (client.flushEdits != null) {
+    await client.flushEdits();
+  }
+
+  const composed = composeObjectSet(baseObjectSet, options);
+
+  const resp = await composed.fetchPage({
+    $nextPageToken: options.pageToken,
+    ...(options.pageSize != null ? { $pageSize: options.pageSize } : {}),
+    // Consumers converting back to a wire format generally need the rid, and
+    // it is what the object cache keys links against.
+    $includeRid: true,
+    ...(options.select != null && options.select.length > 0
+      ? { $select: options.select }
+      : {}),
+    ...(options.orderBy != null && Object.keys(options.orderBy).length > 0
+      ? { $orderBy: options.orderBy }
+      : {}),
+    ...(options.$loadPropertySecurityMetadata === true
+      ? { $loadPropertySecurityMetadata: true }
+      : {}),
+  } as any);
+
+  const data = resp.data as Array<
+    Osdk.Instance<T, "$allBaseProperties", PropertyKeys<T>, RDPs>
+  >;
+
+  const cacheKeys = storeInstances(
+    store,
+    data as unknown as ReadonlyArray<Osdk.Instance<T, any, any, any>>,
+    options,
+  );
+
+  return {
+    data,
+    nextPageToken: resp.nextPageToken ?? undefined,
+    totalCount: (resp as { totalCount?: string }).totalCount,
+    retain: () => retainCacheKeys(store, cacheKeys),
+  };
+}
+
+function composeObjectSet<
+  T extends ObjectOrInterfaceDefinition,
+  RDPs extends Record<string, any>,
+>(
+  baseObjectSet: ObjectSet<T>,
+  options: FetchObjectSetPageOptions<T, RDPs>,
+): ObjectSet<any, any> {
+  let result: any = baseObjectSet;
+
+  if (options.withProperties != null) {
+    result = result.withProperties(options.withProperties);
+  }
+  if (options.where != null) {
+    result = result.where(options.where);
+  }
+  if (options.union != null && options.union.length > 0) {
+    result = result.union(...options.union);
+  }
+  if (options.intersect != null && options.intersect.length > 0) {
+    result = result.intersect(...options.intersect);
+  }
+  if (options.subtract != null && options.subtract.length > 0) {
+    result = result.subtract(...options.subtract);
+  }
+  if (options.pivotTo != null) {
+    result = result.pivotTo(options.pivotTo);
+  }
+
+  return result as ObjectSet<any, any>;
+}

--- a/packages/client/src/public/observable.ts
+++ b/packages/client/src/public/observable.ts
@@ -35,8 +35,10 @@ export type {
 export type { Observer } from "../observable/ObservableClient/common.js";
 export type { ObserveLinks } from "../observable/ObservableClient/ObserveLink.js";
 export type {
+  FetchObjectSetPageOptions,
   GetObjectsOptions,
   GetObjectsResult,
+  ObjectSetPageResult,
   RetainHandle,
   StoreObjectsOptions,
 } from "../observable/ObservableClient/PageTypes.js";

--- a/packages/client/src/public/observable.ts
+++ b/packages/client/src/public/observable.ts
@@ -34,4 +34,10 @@ export type {
 } from "../observable/ObservableClient.js";
 export type { Observer } from "../observable/ObservableClient/common.js";
 export type { ObserveLinks } from "../observable/ObservableClient/ObserveLink.js";
+export type {
+  GetObjectsOptions,
+  GetObjectsResult,
+  RetainHandle,
+  StoreObjectsOptions,
+} from "../observable/ObservableClient/PageTypes.js";
 export type { QueryParameterType, QueryReturnType } from "../queries/types.js";


### PR DESCRIPTION
Add a way to load objects into cache while propagating page tokens for stable list refs