### PR TITLE
Drop the __EXPERIMENTAL__NOT_SUPPORTED_YET__ prefix from transformAndWait

### DIFF
--- a/.changeset/rename-transform-and-wait.md
+++ b/.changeset/rename-transform-and-wait.md
@@ -4,4 +4,4 @@
 "@osdk/react-components": patch
 ---
 
-Rename the experimental `__EXPERIMENTAL__NOT_SUPPORTED_YET__transformAndWait` export to `transformAndWait`. It is still only exported from `@osdk/api/unstable` and its call signature is unchanged.
+Rename the experimental `__EXPERIMENTAL__NOT_SUPPORTED_YET__transformAndWait` export to `transformAndWait`, and change its argument from `mediaReference: MediaReference` to `media: Media`. It is still only exported from `@osdk/api/unstable`. Callers holding a media property can now pass it straight through instead of unwrapping it with `getMediaReference()` first.

--- a/.changeset/rename-transform-and-wait.md
+++ b/.changeset/rename-transform-and-wait.md
@@ -1,0 +1,8 @@
+---
+"@osdk/api": minor
+"@osdk/client": minor
+"@osdk/react-components": patch
+"@osdk/e2e.sandbox.catchall": patch
+---
+
+Rename the experimental `__EXPERIMENTAL__NOT_SUPPORTED_YET__transformAndWait` export to `transformAndWait`. It is still only exported from `@osdk/api/unstable` and its call signature is unchanged.

--- a/.changeset/rename-transform-and-wait.md
+++ b/.changeset/rename-transform-and-wait.md
@@ -2,7 +2,6 @@
 "@osdk/api": minor
 "@osdk/client": minor
 "@osdk/react-components": patch
-"@osdk/e2e.sandbox.catchall": patch
 ---
 
 Rename the experimental `__EXPERIMENTAL__NOT_SUPPORTED_YET__transformAndWait` export to `transformAndWait`. It is still only exported from `@osdk/api/unstable` and its call signature is unchanged.

--- a/packages/api/src/experimental/transformAndWait.ts
+++ b/packages/api/src/experimental/transformAndWait.ts
@@ -42,18 +42,18 @@ export interface TransformOptions {
  *
  * @returns The transformed media content as a Response
  */
-type transformAndWait = (args: {
+type TransformAndWaitFn = (args: {
   mediaReference: MediaReference;
   transformation: MediaTransformation;
   options?: TransformOptions;
 }) => Promise<Response>;
 
-export const __EXPERIMENTAL__NOT_SUPPORTED_YET__transformAndWait: Experiment<
+export const transformAndWait: Experiment<
   "2.8.0",
-  "__EXPERIMENTAL__NOT_SUPPORTED_YET__transformAndWait",
-  { transformAndWait: transformAndWait }
+  "transformAndWait",
+  { transformAndWait: TransformAndWaitFn }
 > = {
-  name: "__EXPERIMENTAL__NOT_SUPPORTED_YET__transformAndWait",
+  name: "transformAndWait",
   type: "experiment",
   version: "2.8.0",
 };

--- a/packages/api/src/experimental/transformAndWait.ts
+++ b/packages/api/src/experimental/transformAndWait.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import type { MediaReference } from "../object/Media.js";
+import type { Media } from "../object/Media.js";
 import type { Experiment } from "./Experiment.js";
 import type { MediaTransformation } from "./MediaTransformation.js";
 
@@ -36,14 +36,14 @@ export interface TransformOptions {
  * Submits a transformation job for a media item, polls until completion,
  * and returns the transformed content.
  *
- * @param args.mediaReference - The media reference to transform
+ * @param args.media - The media item to transform
  * @param args.transformation - The {@link MediaTransformation} to apply
  * @param args.options - Polling options (interval and timeout)
  *
  * @returns The transformed media content as a Response
  */
 type TransformAndWaitFn = (args: {
-  mediaReference: MediaReference;
+  media: Media;
   transformation: MediaTransformation;
   options?: TransformOptions;
 }) => Promise<Response>;

--- a/packages/api/src/public/unstable.ts
+++ b/packages/api/src/public/unstable.ts
@@ -65,7 +65,7 @@ export type {
 } from "../experimental/MediaTransformation.js";
 export { __EXPERIMENTAL__NOT_SUPPORTED_YET__subscribeToNoTypeObjectSet } from "../experimental/subscribeToNoTypeObjectSet.js";
 export {
-  __EXPERIMENTAL__NOT_SUPPORTED_YET__transformAndWait,
+  transformAndWait,
   type TransformOptions,
 } from "../experimental/transformAndWait.js";
 export {

--- a/packages/client/src/createClient.ts
+++ b/packages/client/src/createClient.ts
@@ -45,7 +45,7 @@ import {
   __EXPERIMENTAL__NOT_SUPPORTED_YET__fetchPageByRid,
   __EXPERIMENTAL__NOT_SUPPORTED_YET__getBulkLinks,
   __EXPERIMENTAL__NOT_SUPPORTED_YET__subscribeToNoTypeObjectSet,
-  __EXPERIMENTAL__NOT_SUPPORTED_YET__transformAndWait,
+  transformAndWait,
 } from "@osdk/api/unstable";
 import type { ObjectSet as WireObjectSet } from "@osdk/foundry.ontologies";
 import { symbolClientContext as oldSymbolClientContext } from "@osdk/shared.client";
@@ -350,7 +350,7 @@ export function createClientFromContext(clientCtx: MinimalClient) {
             },
           } as any;
 
-        case __EXPERIMENTAL__NOT_SUPPORTED_YET__transformAndWait.name:
+        case transformAndWait.name:
           return {
             transformAndWait: async (args: {
               mediaReference: MediaReference;

--- a/packages/client/src/createClient.ts
+++ b/packages/client/src/createClient.ts
@@ -19,7 +19,7 @@ import type {
   FetchPageArgs,
   InterfaceDefinition,
   Logger,
-  MediaReference,
+  Media,
   NullabilityAdherence,
   ObjectOrInterfaceDefinition,
   ObjectSet,
@@ -353,14 +353,14 @@ export function createClientFromContext(clientCtx: MinimalClient) {
         case transformAndWait.name:
           return {
             transformAndWait: async (args: {
-              mediaReference: MediaReference;
+              media: Media;
               transformation: MediaTransformation;
               options?: TransformOptions;
             }) => {
               const { transformAndWaitInternal } =
                 await import("./util/transformAndWaitInternal.js");
               const { mediaSetRid, mediaItemRid, token } =
-                args.mediaReference.reference.mediaSetViewItem;
+                args.media.getMediaReference().reference.mediaSetViewItem;
               return transformAndWaitInternal(
                 clientCtx,
                 mediaSetRid,

--- a/packages/e2e.sandbox.catchall/src/runMediaTest.ts
+++ b/packages/e2e.sandbox.catchall/src/runMediaTest.ts
@@ -22,8 +22,8 @@ import type {
 } from "@osdk/api";
 import {
   __EXPERIMENTAL__NOT_SUPPORTED_YET__createMediaReference,
-  __EXPERIMENTAL__NOT_SUPPORTED_YET__transformAndWait,
   type MediaTransformation,
+  transformAndWait,
 } from "@osdk/api/unstable";
 import {
   $Actions,
@@ -401,9 +401,7 @@ async function runTransformAndWaitTest(
   const transformation = imageResize;
 
   console.log("Input transformation:", JSON.stringify(transformation, null, 2));
-  const result = await client(
-    __EXPERIMENTAL__NOT_SUPPORTED_YET__transformAndWait,
-  ).transformAndWait({
+  const result = await client(transformAndWait).transformAndWait({
     mediaReference,
     transformation,
   });

--- a/packages/e2e.sandbox.catchall/src/runMediaTest.ts
+++ b/packages/e2e.sandbox.catchall/src/runMediaTest.ts
@@ -395,14 +395,12 @@ const slicePdf: MediaTransformation = {
   },
 };
 
-async function runTransformAndWaitTest(
-  mediaReference: MediaReference,
-): Promise<void> {
+async function runTransformAndWaitTest(media: Media): Promise<void> {
   const transformation = imageResize;
 
   console.log("Input transformation:", JSON.stringify(transformation, null, 2));
   const result = await client(transformAndWait).transformAndWait({
-    mediaReference,
+    media,
     transformation,
   });
 
@@ -466,7 +464,7 @@ export async function runMediaTest(): Promise<void> {
   console.log("SUCCESS: Testing Media Query");
 
   console.log("Testing transformAndWait");
-  await runTransformAndWaitTest(result.mediaReference.getMediaReference());
+  await runTransformAndWaitTest(result.mediaReference);
   console.log("SUCCESS: Testing transformAndWait");
 }
 

--- a/packages/react-components/src/document-viewer/hooks/useTiffToPdf.ts
+++ b/packages/react-components/src/document-viewer/hooks/useTiffToPdf.ts
@@ -96,9 +96,8 @@ export function useTiffToPdf(
       }
 
       // Step 2: Multi-page TIFF — convert to PDF via MIO transform
-      const mediaReference = currentMedia.getMediaReference();
       const pdfResponse = await client(transformAndWait).transformAndWait({
-        mediaReference,
+        media: currentMedia,
         transformation: {
           $imageToDocument: { $operation: { $createPdf: {} } },
         },

--- a/packages/react-components/src/document-viewer/hooks/useTiffToPdf.ts
+++ b/packages/react-components/src/document-viewer/hooks/useTiffToPdf.ts
@@ -17,7 +17,7 @@
 /* cspell:words ifds */
 
 import type { Media } from "@osdk/api";
-import { __EXPERIMENTAL__NOT_SUPPORTED_YET__transformAndWait } from "@osdk/api/unstable";
+import { transformAndWait } from "@osdk/api/unstable";
 import { useOsdkClient } from "@osdk/react";
 import { useEffect, useRef, useState } from "react";
 import * as UTIF from "utif";
@@ -97,9 +97,7 @@ export function useTiffToPdf(
 
       // Step 2: Multi-page TIFF — convert to PDF via MIO transform
       const mediaReference = currentMedia.getMediaReference();
-      const pdfResponse = await client(
-        __EXPERIMENTAL__NOT_SUPPORTED_YET__transformAndWait,
-      ).transformAndWait({
+      const pdfResponse = await client(transformAndWait).transformAndWait({
         mediaReference,
         transformation: {
           $imageToDocument: { $operation: { $createPdf: {} } },


### PR DESCRIPTION
## Changes in this PR
Rename the export to `transformAndWait` and change the input type from MediaReference to Media.

## Out of scope
- The `MediaTransformation` payload shape, which wants its own audit.
- Graduating the export out of `unstable`.

## FLUP
- expose internal helper `createMediaFromReference`