### PR TITLE
Version Packages

### DIFF
--- a/.changeset/brave-pandas-wander.md
+++ b/.changeset/brave-pandas-wander.md
@@ -1,5 +1,0 @@
----
-"@osdk/react-components": minor
----
-
-Rename `ExcelViewer` to `SpreadsheetViewer`. Breaking: the `experimental/excel-viewer` subpath is now `experimental/spreadsheet-viewer`, `ExcelViewer`/`BaseExcelViewer` and their prop types are renamed, `DocumentViewer`'s `excelViewerProps` is now `spreadsheetViewerProps`, `ViewerType.Excel` is now `ViewerType.Spreadsheet` and its value changed from `"excel"` to `"spreadsheet"`, and the `--osdk-excel-viewer-*` CSS tokens are now `--osdk-spreadsheet-viewer-*`. No deprecated aliases are kept.

--- a/packages/react-components/CHANGELOG.md
+++ b/packages/react-components/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/react-components
 
+## 0.46.0
+
+### Minor Changes
+
+- c64be50: Rename `ExcelViewer` to `SpreadsheetViewer`. Breaking: the `experimental/excel-viewer` subpath is now `experimental/spreadsheet-viewer`, `ExcelViewer`/`BaseExcelViewer` and their prop types are renamed, `DocumentViewer`'s `excelViewerProps` is now `spreadsheetViewerProps`, `ViewerType.Excel` is now `ViewerType.Spreadsheet` and its value changed from `"excel"` to `"spreadsheet"`, and the `--osdk-excel-viewer-*` CSS tokens are now `--osdk-spreadsheet-viewer-*`. No deprecated aliases are kept.
+
 ## 0.45.0
 
 ### Minor Changes

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/react-components",
-  "version": "0.45.0",
+  "version": "0.46.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR was opened by automation. When you're ready to do a release, you can merge this and publish to npm yourself.
     If you're not ready to do a release yet, that's fine, whenever you re-run the release script in main, this PR will be updated.


# Releases
## @osdk/react-components@0.46.0

### Minor Changes

-   c64be50: Rename `ExcelViewer` to `SpreadsheetViewer`. Breaking: the `experimental/excel-viewer` subpath is now `experimental/spreadsheet-viewer`, `ExcelViewer`/`BaseExcelViewer` and their prop types are renamed, `DocumentViewer`'s `excelViewerProps` is now `spreadsheetViewerProps`, `ViewerType.Excel` is now `ViewerType.Spreadsheet` and its value changed from `"excel"` to `"spreadsheet"`, and the `--osdk-excel-viewer-*` CSS tokens are now `--osdk-spreadsheet-viewer-*`. No deprecated aliases are kept.
