### PR TITLE
Generate widget set manifest authorizations defined in a resources.json file

### DIFF
--- a/.changeset/gentle-wasps-count.md
+++ b/.changeset/gentle-wasps-count.md
@@ -1,0 +1,6 @@
+---
+"@osdk/widget.vite-plugin": minor
+"@osdk/widget.api": minor
+---
+
+Generate widget set manifest authorizations defined in a resources.json file

--- a/packages/widget.api/src/index.ts
+++ b/packages/widget.api/src/index.ts
@@ -28,6 +28,7 @@ export { defineConfig } from "./config.js";
 export type {
   OntologySdkInputSpecV1 as OntologySdkInputSpec,
   WidgetManifestConfigV1 as WidgetManifestConfig,
+  WidgetSetAuthorizationsInputSpecV1 as WidgetSetAuthorizationsInputSpec,
   WidgetSetDiscoveredInputSpecV1 as WidgetSetDiscoveredInputSpec,
   WidgetSetInputSpecV1 as WidgetSetInputSpec,
   WidgetSetManifestV1 as WidgetSetManifest,

--- a/packages/widget.api/src/manifest.ts
+++ b/packages/widget.api/src/manifest.ts
@@ -120,7 +120,7 @@ export interface WidgetManifestConfigV1 {
 
 export interface WidgetSetInputSpecV1 {
   /**
-   * The input specification for the widget set that was automatically discovered from the project's dependencies.
+   * The input specification for the widget set that was automatically discovered from the project.
    * @optional
    */
   discovered?: WidgetSetDiscoveredInputSpecV1;
@@ -131,6 +131,13 @@ export interface WidgetSetDiscoveredInputSpecV1 {
    * The discovered Ontology SDK packages in the project's dependencies.
    */
   sdks: Array<OntologySdkInputSpecV1>;
+
+  /**
+   * The widget set authorizations, read from the project's resources.json.
+   * Only present when resources.json exists with the expected format.
+   * @optional
+   */
+  authorizations?: WidgetSetAuthorizationsInputSpecV1;
 }
 
 export interface OntologySdkInputSpecV1 {
@@ -139,5 +146,19 @@ export interface OntologySdkInputSpecV1 {
   /** The Ontology SDK package version */
   version: string;
 }
+
+export interface WidgetSetAuthorizationsInputSpecV1 {
+  /**
+   * The widget set authorizations.
+   */
+  read?: WidgetSetAuthorizationV1;
+  requiredRead?: WidgetSetAuthorizationV1;
+  write?: WidgetSetAuthorizationV1;
+}
+
+/**
+ * A set of markings representing an authorization constraint, expressed in conjunctive normal form (CNF).
+ */
+type WidgetSetAuthorizationV1 = string[][];
 
 export const MANIFEST_FILE_LOCATION = ".palantir/widgets.config.json";

--- a/packages/widget.vite-plugin/src/build-plugin/FoundryWidgetBuildPlugin.ts
+++ b/packages/widget.vite-plugin/src/build-plugin/FoundryWidgetBuildPlugin.ts
@@ -87,6 +87,7 @@ export function FoundryWidgetBuildPlugin(
         );
         const widgetSetInputSpec = await getWidgetSetInputSpec(
           path.resolve(process.cwd(), "package.json"),
+          path.resolve(process.cwd(), "resources.json"),
         );
         const widgetSetManifest = buildWidgetSetManifest(
           foundryConfig.foundryConfig.widgetSet.rid,

--- a/packages/widget.vite-plugin/src/build-plugin/__tests__/buildWidgetSetManifest.test.ts
+++ b/packages/widget.vite-plugin/src/build-plugin/__tests__/buildWidgetSetManifest.test.ts
@@ -182,6 +182,7 @@ describe("buildWidgetSetManifest", () => {
     const widgetSetInputSpec: WidgetSetInputSpec = {
       discovered: {
         sdks: [{ rid: "ri.foundry.main.sdk.test-sdk", version: "2.0.0" }],
+        authorizations: {},
       },
     };
 

--- a/packages/widget.vite-plugin/src/build-plugin/__tests__/getWidgetSetInputSpec.test.ts
+++ b/packages/widget.vite-plugin/src/build-plugin/__tests__/getWidgetSetInputSpec.test.ts
@@ -14,15 +14,24 @@
  * limitations under the License.
  */
 
+import { readFile } from "fs/promises";
 import { resolve } from "path";
 
-import { expect, test, vi } from "vitest";
+import { beforeEach, expect, test, vi } from "vitest";
 
 import type { PackageJson } from "../../common/PackageJson.js";
 import { visitNpmPackages } from "../../common/visitNpmPackages.js";
 import { getWidgetSetInputSpec } from "../getWidgetSetInputSpec.js";
 
 vi.mock("../../common/visitNpmPackages.ts");
+vi.mock("fs/promises");
+
+const enoentError = Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+
+beforeEach(() => {
+  vi.mocked(readFile).mockReset();
+  vi.mocked(readFile).mockRejectedValue(enoentError);
+});
 
 test("getWidgetSetInputSpec successfully discovers OSDK packages", async () => {
   const packageJson1: PackageJson = {
@@ -97,6 +106,7 @@ test("getWidgetSetInputSpec successfully discovers OSDK packages", async () => {
   });
   const widgetSetInputSpec = await getWidgetSetInputSpec(
     "/path/to/package.json",
+    "/path/to/resources.json",
   );
 
   expect(widgetSetInputSpec).toEqual({
@@ -109,4 +119,99 @@ test("getWidgetSetInputSpec successfully discovers OSDK packages", async () => {
       ],
     },
   });
+});
+
+function mockSingleRootPackage(): void {
+  const rootPackageJson: PackageJson = { name: "root", version: "0.1.0" };
+  vi.mocked(visitNpmPackages).mockImplementation((packageJsonPath, onVisit) => {
+    onVisit(packageJsonPath, rootPackageJson);
+    return Promise.resolve();
+  });
+}
+
+test("getWidgetSetInputSpec reads authorizations from resources.json", async () => {
+  mockSingleRootPackage();
+  vi.mocked(readFile).mockResolvedValue(
+    JSON.stringify({
+      authorizations: {
+        read: [["OrgA", "OrgB"], ["PII"]],
+        requiredRead: [["OrgA"]],
+      },
+      version: 1,
+    }),
+  );
+
+  const widgetSetInputSpec = await getWidgetSetInputSpec(
+    "/path/to/package.json",
+    "/path/to/resources.json",
+  );
+
+  expect(readFile).toHaveBeenCalledWith("/path/to/resources.json", "utf-8");
+  expect(widgetSetInputSpec.discovered?.authorizations).toEqual({
+    read: [["OrgA", "OrgB"], ["PII"]],
+    requiredRead: [["OrgA"]],
+  });
+});
+
+test("getWidgetSetInputSpec ignores unknown properties in resources.json", async () => {
+  mockSingleRootPackage();
+  vi.mocked(readFile).mockResolvedValue(
+    JSON.stringify({
+      authorizations: {
+        read: [["OrgA"]],
+        // Not part of the declared schema and should be dropped.
+        write: [["PII"]],
+        unknownAuthorization: "ignored",
+      },
+      unknownTopLevel: 123,
+      _comment:
+        "EDITING THIS FILE MANUALLY MAY RESULT IN COMPILE ERRORS. DO NOT DELETE THIS FILE.",
+      version: 1,
+    }),
+  );
+
+  const widgetSetInputSpec = await getWidgetSetInputSpec(
+    "/path/to/package.json",
+    "/path/to/resources.json",
+  );
+
+  expect(widgetSetInputSpec.discovered?.authorizations).toEqual({
+    read: [["OrgA"]],
+  });
+});
+
+test("getWidgetSetInputSpec omits authorizations when resources.json is missing", async () => {
+  mockSingleRootPackage();
+  vi.mocked(readFile).mockRejectedValue(enoentError);
+
+  const widgetSetInputSpec = await getWidgetSetInputSpec(
+    "/path/to/package.json",
+    "/path/to/resources.json",
+  );
+
+  expect(widgetSetInputSpec.discovered?.authorizations).toBeUndefined();
+});
+
+test("getWidgetSetInputSpec rethrows non-ENOENT errors reading resources.json", async () => {
+  mockSingleRootPackage();
+  const permissionError = Object.assign(
+    new Error("EACCES: permission denied"),
+    {
+      code: "EACCES",
+    },
+  );
+  vi.mocked(readFile).mockRejectedValue(permissionError);
+
+  await expect(
+    getWidgetSetInputSpec("/path/to/package.json", "/path/to/resources.json"),
+  ).rejects.toThrow("EACCES");
+});
+
+test("getWidgetSetInputSpec throws when resources.json is invalid", async () => {
+  mockSingleRootPackage();
+  vi.mocked(readFile).mockResolvedValue("{ not valid json");
+
+  await expect(
+    getWidgetSetInputSpec("/path/to/package.json", "/path/to/resources.json"),
+  ).rejects.toThrow(/Failed to parse resources\.json/u);
 });

--- a/packages/widget.vite-plugin/src/build-plugin/getWidgetSetInputSpec.ts
+++ b/packages/widget.vite-plugin/src/build-plugin/getWidgetSetInputSpec.ts
@@ -88,7 +88,7 @@ async function parseResourcesJson(
     content = await readFile(resourcesJsonPath, "utf-8");
   } catch (err) {
     if ((err as { code?: string }).code === "ENOENT") {
-      // the file is not present in the repo; authorizations are optional.
+      // the file is not present in the repo
       return undefined;
     }
     throw err;

--- a/packages/widget.vite-plugin/src/build-plugin/getWidgetSetInputSpec.ts
+++ b/packages/widget.vite-plugin/src/build-plugin/getWidgetSetInputSpec.ts
@@ -14,21 +14,30 @@
  * limitations under the License.
  */
 
+import { readFile } from "fs/promises";
+
 import type {
   OntologySdkInputSpec,
+  WidgetSetAuthorizationsInputSpec,
   WidgetSetInputSpec,
 } from "@osdk/widget.api";
 
 import type { PackageJson } from "../common/PackageJson.js";
+import type { ResourcesJson } from "../common/ResourcesJson.js";
 import { visitNpmPackages } from "../common/visitNpmPackages.js";
 
 export async function getWidgetSetInputSpec(
   packageJsonPath: string,
+  resourcesJsonPath: string,
 ): Promise<WidgetSetInputSpec> {
-  const sdks = await discoverOntologySdkInputSpecs(packageJsonPath);
+  const [sdks, authorizations] = await Promise.all([
+    discoverOntologySdkInputSpecs(packageJsonPath),
+    getAuthorizations(resourcesJsonPath),
+  ]);
   return {
     discovered: {
       sdks,
+      authorizations,
     },
   };
 }
@@ -55,3 +64,42 @@ const fromKey = (key: string): OntologySdkInputSpec => {
     version,
   };
 };
+
+async function getAuthorizations(
+  resourcesJsonPath: string,
+): Promise<WidgetSetAuthorizationsInputSpec | undefined> {
+  const parsedResourcesJson: ResourcesJson | undefined =
+    await parseResourcesJson(resourcesJsonPath);
+  if (parsedResourcesJson == null) {
+    return undefined;
+  }
+  const { read, requiredRead } = parsedResourcesJson.authorizations ?? {};
+  return {
+    read,
+    requiredRead,
+  };
+}
+
+async function parseResourcesJson(
+  resourcesJsonPath: string,
+): Promise<ResourcesJson | undefined> {
+  let content: string;
+  try {
+    content = await readFile(resourcesJsonPath, "utf-8");
+  } catch (err) {
+    if ((err as { code?: string }).code === "ENOENT") {
+      // the file is not present in the repo; authorizations are optional.
+      return undefined;
+    }
+    throw err;
+  }
+
+  try {
+    return JSON.parse(content) as ResourcesJson;
+  } catch (err) {
+    throw new Error(
+      `Failed to parse resources.json content from file "${resourcesJsonPath}"`,
+      { cause: err },
+    );
+  }
+}

--- a/packages/widget.vite-plugin/src/common/ResourcesJson.ts
+++ b/packages/widget.vite-plugin/src/common/ResourcesJson.ts
@@ -23,7 +23,7 @@ type DeclaredWidgetSetAuthorizations = Pick<
 
 interface ResourcesJsonV1 {
   authorizations: DeclaredWidgetSetAuthorizations;
-  version: number;
+  version: 1;
 }
 
 export type ResourcesJson = ResourcesJsonV1;

--- a/packages/widget.vite-plugin/src/common/ResourcesJson.ts
+++ b/packages/widget.vite-plugin/src/common/ResourcesJson.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { WidgetSetAuthorizationsInputSpec } from "@osdk/widget.api";
+
+type DeclaredWidgetSetAuthorizations = Pick<
+  WidgetSetAuthorizationsInputSpec,
+  "read" | "requiredRead"
+>;
+
+interface ResourcesJsonV1 {
+  authorizations: DeclaredWidgetSetAuthorizations;
+  version: number;
+}
+
+export type ResourcesJson = ResourcesJsonV1;

--- a/packages/widget.vite-plugin/src/dev-plugin/__tests__/buildDevModeManifest.test.ts
+++ b/packages/widget.vite-plugin/src/dev-plugin/__tests__/buildDevModeManifest.test.ts
@@ -158,6 +158,7 @@ describe("buildDevModeManifest", () => {
     expect(result.devSettings.inputSpec).toEqual(MOCK_INPUT_SPEC);
     expect(vi.mocked(getWidgetSetInputSpec)).toHaveBeenCalledWith(
       "/project/package.json",
+      "/project/resources.json",
     );
   });
 

--- a/packages/widget.vite-plugin/src/dev-plugin/buildDevModeManifest.ts
+++ b/packages/widget.vite-plugin/src/dev-plugin/buildDevModeManifest.ts
@@ -79,6 +79,7 @@ export async function buildDevModeManifest(
 
   const inputSpec = await getWidgetSetInputSpec(
     path.resolve(server.config.root, "package.json"),
+    path.resolve(server.config.root, "resources.json"),
   );
 
   return {


### PR DESCRIPTION
As part of the custom widget integration with PASS, users can define widges set authorizations in a resouces.json file in the widget set repo, e.g.

```json
{
  "authorizations": {
    "read": [["OrgA", "OrgB"], ["PII"]],
    "requiredRead": []
  },
  "version": 1
}

```

In this PR we are updating the widget set manifest build to also contain the defined authorizations.