### PR TITLE
Export getClient and getPlatformClient from @osdk/agents/experimental

### DIFF
--- a/.changeset/agents-clients.md
+++ b/.changeset/agents-clients.md
@@ -1,0 +1,5 @@
+---
+"@osdk/agents": patch
+---
+
+Export `withClients`, `getClient`, and `getPlatformClient` from `@osdk/agents/experimental` so an agent can reach the Ontology and Platform SDK clients the platform injected into its invocation.

--- a/packages/agents/package.json
+++ b/packages/agents/package.json
@@ -44,6 +44,7 @@
     "clean": "rm -rf lib dist types build tsconfig.tsbuildinfo",
     "fix-lint": "oxlint -c ./oxlint.config.ts --fix . && oxfmt -c ../../oxfmt.config.ts .",
     "lint": "oxlint -c ./oxlint.config.ts . && oxfmt -c ../../oxfmt.config.ts --check .",
+    "test": "vitest run --pool=forks",
     "transpileBrowser": "monorepo.tool.transpile -f esm -m normal -t browser",
     "transpileCjs": "monorepo.tool.transpile -f cjs -m bundle -t node",
     "transpileEsm": "monorepo.tool.transpile -f esm -m normal -t node",
@@ -51,14 +52,17 @@
     "typecheck": "tsc --noEmit --emitDeclarationOnly false"
   },
   "peerDependencies": {
+    "@osdk/client": "workspace:^",
     "@osdk/functions": "workspace:^"
   },
   "devDependencies": {
     "@microsoft/api-documenter": "^7.26.32",
     "@microsoft/api-extractor": "^7.52.11",
+    "@osdk/client": "workspace:~",
     "@osdk/functions": "workspace:~",
     "@osdk/monorepo.api-extractor": "workspace:~",
     "@osdk/monorepo.tsconfig": "workspace:~",
+    "@types/node": "^18.19.0",
     "typescript": "~5.5.4"
   },
   "publishConfig": {

--- a/packages/agents/src/clients.test.ts
+++ b/packages/agents/src/clients.test.ts
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { Client, PlatformClient } from "@osdk/client";
+import { describe, expect, it } from "vitest";
+
+import { getClient, getPlatformClient, withClients } from "./clients.js";
+
+const platformClient = {} as PlatformClient;
+const client = {} as Client;
+
+describe("clients", () => {
+  it("returns the clients from the enclosing withClients", async () => {
+    await withClients({ client, platformClient }, async () => {
+      await Promise.resolve();
+      expect(getClient()).toBe(client);
+      expect(getPlatformClient()).toBe(platformClient);
+    });
+  });
+
+  it("passes the body's result through", async () => {
+    const result = await withClients({ client, platformClient }, async () => {
+      await Promise.resolve();
+      return "done";
+    });
+    expect(result).toBe("done");
+  });
+
+  it("does not leak between concurrent invocations", async () => {
+    const otherClient = {} as Client;
+    await Promise.all([
+      withClients({ client, platformClient }, async () => {
+        await Promise.resolve();
+        expect(getClient()).toBe(client);
+      }),
+      withClients({ client: otherClient, platformClient }, async () => {
+        await Promise.resolve();
+        expect(getClient()).toBe(otherClient);
+      }),
+    ]);
+  });
+
+  it("throws from getClient when no ontology has been imported", async () => {
+    await withClients({ platformClient }, async () => {
+      await Promise.resolve();
+      expect(() => getClient()).toThrow("No Ontology SDK client is available");
+      expect(getPlatformClient()).toBe(platformClient);
+    });
+  });
+
+  it("throws outside of an invocation", () => {
+    expect(() => getClient()).toThrow(
+      "Clients are only available while a session is running",
+    );
+    expect(() => getPlatformClient()).toThrow(
+      "Clients are only available while a session is running",
+    );
+  });
+});

--- a/packages/agents/src/clients.ts
+++ b/packages/agents/src/clients.ts
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { AsyncLocalStorage } from "node:async_hooks";
+
+import type { Client, PlatformClient } from "@osdk/client";
+
+/**
+ * The clients the platform injected into an invocation.
+ */
+export interface Clients {
+  /** Only available if an ontology has been imported. */
+  readonly client?: Client;
+  readonly platformClient: PlatformClient;
+}
+
+const storage = new AsyncLocalStorage<Clients>();
+
+/**
+ * Makes `clients` the clients that `getClient` and `getPlatformClient` return for the duration of
+ * `run`.
+ */
+export function withClients<T>(
+  clients: Clients,
+  run: () => Promise<T>,
+): Promise<T> {
+  return storage.run(clients, run);
+}
+
+/**
+ * The Platform SDK client for the current invocation.
+ */
+export function getPlatformClient(): PlatformClient {
+  return currentClients().platformClient;
+}
+
+/**
+ * The Ontology SDK client for the current invocation. Throws if no ontology has been imported into
+ * the repository.
+ */
+export function getClient(): Client {
+  const { client } = currentClients();
+  if (client === undefined) {
+    throw new Error(
+      "No Ontology SDK client is available. Import an Ontology into this repository to use " +
+        "getClient(), or use getPlatformClient() for the platform APIs.",
+    );
+  }
+  return client;
+}
+
+function currentClients(): Clients {
+  const clients = storage.getStore();
+  if (clients === undefined) {
+    throw new Error(
+      "Clients are only available while a session is running. getClient() and " +
+        "getPlatformClient() read what the platform injected into the current invocation, so " +
+        "they cannot be called at module load time, or from work that outlives the invocation " +
+        "that started it.",
+    );
+  }
+  return clients;
+}

--- a/packages/agents/src/public/experimental.ts
+++ b/packages/agents/src/public/experimental.ts
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+export { getClient, getPlatformClient, withClients } from "../clients.js";
+export type { Clients } from "../clients.js";
 export {
   ScopeAuthorization,
   ScopeResources,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1670,10 +1670,13 @@ importers:
     devDependencies:
       '@microsoft/api-documenter':
         specifier: ^7.26.32
-        version: 7.26.32(@types/node@26.1.1)
+        version: 7.26.32(@types/node@18.19.124)
       '@microsoft/api-extractor':
         specifier: ^7.52.11
-        version: 7.52.11(@types/node@26.1.1)
+        version: 7.52.11(@types/node@18.19.124)
+      '@osdk/client':
+        specifier: workspace:~
+        version: link:../client
       '@osdk/functions':
         specifier: workspace:~
         version: link:../functions
@@ -1683,6 +1686,9 @@ importers:
       '@osdk/monorepo.tsconfig':
         specifier: workspace:~
         version: link:../monorepo.tsconfig
+      '@types/node':
+        specifier: ^18.19.0
+        version: 18.19.124
       typescript:
         specifier: ~5.5.4
         version: 5.5.4


### PR DESCRIPTION
Util functions for making OSDK and platform clients available in agents.