### PR TITLE
Widen @osdk/integration-testing peer ranges to avoid a forced major bump

### DIFF
--- a/.changeset/fix-integration-testing-peer-ranges.md
+++ b/.changeset/fix-integration-testing-peer-ranges.md
@@ -1,0 +1,5 @@
+---
+"@osdk/integration-testing": patch
+---
+
+Widen `@osdk/integration-testing` peer dependency ranges so a minor bump of a peer no longer forces a major version bump

--- a/packages/integration-testing/package.json
+++ b/packages/integration-testing/package.json
@@ -55,9 +55,9 @@
     "undici": "^6.28.0"
   },
   "peerDependencies": {
-    "@osdk/api": "workspace:*",
-    "@osdk/client": "workspace:*",
-    "@osdk/seed-helpers": "workspace:*"
+    "@osdk/api": "workspace:^",
+    "@osdk/client": "workspace:^",
+    "@osdk/seed-helpers": ">=0.25.0 <1.0.0"
   },
   "devDependencies": {
     "@microsoft/api-documenter": "^7.26.32",
@@ -66,6 +66,7 @@
     "@osdk/client": "workspace:~",
     "@osdk/monorepo.api-extractor": "workspace:~",
     "@osdk/monorepo.tsconfig": "workspace:~",
+    "@osdk/seed-helpers": "workspace:~",
     "@types/node": "^26.1.1",
     "@types/semver": "^7.7.1",
     "typescript": "~5.5.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4343,9 +4343,6 @@ importers:
       '@osdk/generator-converters.preview':
         specifier: workspace:~
         version: link:../generator-converters.preview
-      '@osdk/seed-helpers':
-        specifier: workspace:*
-        version: link:../seed-helpers
       '@osdk/unit-testing':
         specifier: workspace:~
         version: link:../unit-testing
@@ -4383,6 +4380,9 @@ importers:
       '@osdk/monorepo.tsconfig':
         specifier: workspace:~
         version: link:../monorepo.tsconfig
+      '@osdk/seed-helpers':
+        specifier: workspace:~
+        version: link:../seed-helpers
       '@types/node':
         specifier: ^26.1.1
         version: 26.1.1


### PR DESCRIPTION
Ran into an issue with peer dep `@osdk/seed-helper`'s range, bumping beta versions (`0.x.x`) with `workspace:*` triggers a major release which is unintended.

---

This is similar to what `@osdk/functions` does, but is not an issue since the version bump on `workspace:^` is on `@osdk/client`, which is already on a stable version (`2.x`). npm treats "magic numbered versions"(any version below 1, so `0.x`) differently. A caret dep on 0.1 would range from 0.1 to 0.2 whereas a caret dep on 1.0 would range from 1.0 to 2.0.

> semver.toComparators("^1.1")
[ [ '>=1.1.0', '<2.0.0-0' ] ]
> semver.toComparators("^0.1")
[ [ '>=0.1.0', '<0.2.0-0' ] ]