### PR TITLE
Reflect $defaultLoadLevel and $applyModifiers in fetchPageByRid result types

### DIFF
--- a/etc/api.report.api.md
+++ b/etc/api.report.api.md
@@ -839,6 +839,8 @@ export type FetchLinksPageResult<
     	nextPageToken?: string
 };
 
+// Warning: (ae-forgotten-export) The symbol "PropertyModifierValue" needs to be exported by the entry point index.d.ts
+//
 // @public (undocumented)
 export interface FetchPageArgs<
 	Q extends ObjectOrInterfaceDefinition,
@@ -850,12 +852,12 @@ export interface FetchPageArgs<
 	RDP_KEYS extends string = never,
 	ORDER_BY_OPTIONS extends ObjectSetArgs.OrderByOptions<K> = {},
 	PROPERTY_SECURITIES extends boolean = false,
-	MODIFIERS extends ApplyModifiersArg<Q> = {}
+	MODIFIERS extends ApplyModifiersArg<Q> = {},
+	DEFAULT_LOAD_LEVEL extends PropertyModifierValue | undefined = PropertyModifierValue
 > extends AsyncIterArgs<Q, K, R, A, S, T, RDP_KEYS, ORDER_BY_OPTIONS, PROPERTY_SECURITIES, MODIFIERS> {
     	// (undocumented)
     $applyModifiers?: ApplyModifiersArg<Q> & MODIFIERS & { [P in Exclude<keyof MODIFIERS, PropertyKeys<Q>>] : never };
-    	// Warning: (ae-forgotten-export) The symbol "PropertyModifierValue" needs to be exported by the entry point index.d.ts
-    $defaultLoadLevel?: PropertyModifierValue;
+    	$defaultLoadLevel?: DEFAULT_LOAD_LEVEL;
     	// (undocumented)
     $nextPageToken?: string;
     	// (undocumented)
@@ -865,6 +867,7 @@ export interface FetchPageArgs<
 }
 
 // Warning: (ae-forgotten-export) The symbol "ExtractOptions" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "SelectedKeysWithDefaultLoadLevel" needs to be exported by the entry point index.d.ts
 // Warning: (ae-forgotten-export) The symbol "ModifiersToSelectStrings_2" needs to be exported by the entry point index.d.ts
 //
 // @public
@@ -876,8 +879,9 @@ export type FetchPageResult<
 	T extends boolean = false,
 	ORDER_BY_OPTIONS extends ObjectSetArgs.OrderByOptions<L> = {},
 	PROPERTY_SECURITIES extends boolean = false,
-	MODIFIERS extends ApplyModifiersArg<Q> = {}
-> = PageResult<MaybeScore<Osdk.Instance<Q, ExtractOptions<R, S, T, PROPERTY_SECURITIES>, Exclude<PropertyKeys<Q> extends L ? never : L, keyof MODIFIERS> | ModifiersToSelectStrings_2<MODIFIERS>, {}>, ORDER_BY_OPTIONS>>;
+	MODIFIERS extends ApplyModifiersArg<Q> = {},
+	DEFAULT_LOAD_LEVEL extends PropertyModifierValue | undefined = undefined
+> = PageResult<MaybeScore<Osdk.Instance<Q, ExtractOptions<R, S, T, PROPERTY_SECURITIES>, SelectedKeysWithDefaultLoadLevel<Q, L, MODIFIERS, DEFAULT_LOAD_LEVEL> | ModifiersToSelectStrings_2<MODIFIERS>, {}>, ORDER_BY_OPTIONS>>;
 
 // @public (undocumented)
 export type FlipAxis = "HORIZONTAL" | "VERTICAL" | "UNKNOWN";

--- a/packages/api/src/experimental/fetchPageByRid.ts
+++ b/packages/api/src/experimental/fetchPageByRid.ts
@@ -23,6 +23,10 @@ import type {
   ObjectOrInterfaceDefinition,
   PropertyKeys,
 } from "../ontology/ObjectOrInterface.js";
+import type {
+  ApplyModifiersArg,
+  PropertyModifierValue,
+} from "../ontology/PropertyModifiers.js";
 import type { Experiment } from "./Experiment.js";
 
 type fetchPageByRidFn = <
@@ -32,11 +36,38 @@ type fetchPageByRidFn = <
   const S extends NullabilityAdherence,
   const T extends boolean,
   const PROPERTY_SECURITIES extends boolean = false,
+  const MODIFIERS extends ApplyModifiersArg<Q> = {},
+  const DEFAULT_LOAD_LEVEL extends PropertyModifierValue | undefined =
+    undefined,
 >(
   objectType: Q,
   rids: string[],
-  options?: FetchPageArgs<Q, L, R, any, S, T, never, {}, PROPERTY_SECURITIES>,
-) => Promise<FetchPageResult<Q, L, R, S, T, {}, PROPERTY_SECURITIES>>;
+  options?: FetchPageArgs<
+    Q,
+    L,
+    R,
+    any,
+    S,
+    T,
+    never,
+    {},
+    PROPERTY_SECURITIES,
+    MODIFIERS,
+    DEFAULT_LOAD_LEVEL
+  >,
+) => Promise<
+  FetchPageResult<
+    Q,
+    L,
+    R,
+    S,
+    T,
+    {},
+    PROPERTY_SECURITIES,
+    MODIFIERS,
+    DEFAULT_LOAD_LEVEL
+  >
+>;
 
 export type FetchPageByRidPayload = {
   fetchPageByRid: fetchPageByRidFn;

--- a/packages/api/src/object/FetchPageArgs.ts
+++ b/packages/api/src/object/FetchPageArgs.ts
@@ -114,6 +114,8 @@ export interface FetchPageArgs<
   ORDER_BY_OPTIONS extends ObjectSetArgs.OrderByOptions<K> = {},
   PROPERTY_SECURITIES extends boolean = false,
   MODIFIERS extends ApplyModifiersArg<Q> = {},
+  DEFAULT_LOAD_LEVEL extends PropertyModifierValue | undefined =
+    PropertyModifierValue,
 > extends AsyncIterArgs<
   Q,
   K,
@@ -133,11 +135,14 @@ export interface FetchPageArgs<
   /**
    * Best-effort load level applied to every property without listing them:
    * reducers and struct main values where defined, other properties unchanged.
-   * A per-property `$applyModifiers` entry wins. Does not narrow the result type.
+   * A per-property `$applyModifiers` entry wins.
+   *
+   * Only reflected in the result type where the signature threads the
+   * `DEFAULT_LOAD_LEVEL` parameter through (currently `fetchPageByRid`).
    *
    * @experimental
    */
-  $defaultLoadLevel?: PropertyModifierValue;
+  $defaultLoadLevel?: DEFAULT_LOAD_LEVEL;
   /**
    * Ensures paging consistency by freezing the view at the time of query to prevent duplicate or missing items. Setting $snapshot to false ensures that you will always get the latest results.
    * @default false

--- a/packages/api/src/object/FetchPageArgs.ts
+++ b/packages/api/src/object/FetchPageArgs.ts
@@ -137,9 +137,6 @@ export interface FetchPageArgs<
    * reducers and struct main values where defined, other properties unchanged.
    * A per-property `$applyModifiers` entry wins.
    *
-   * Only reflected in the result type where the signature threads the
-   * `DEFAULT_LOAD_LEVEL` parameter through (currently `fetchPageByRid`).
-   *
    * @experimental
    */
   $defaultLoadLevel?: DEFAULT_LOAD_LEVEL;

--- a/packages/api/src/object/FetchPageResult.ts
+++ b/packages/api/src/object/FetchPageResult.ts
@@ -19,6 +19,7 @@ import type {
   PropertyKeys,
 } from "../ontology/ObjectOrInterface.js";
 import type {
+  ApplyDefaultLoadLevelToKeys,
   ApplyModifiersArg,
   PropertyModifierValue,
 } from "../ontology/PropertyModifiers.js";
@@ -68,18 +69,41 @@ export type FetchPageResult<
   ORDER_BY_OPTIONS extends ObjectSetArgs.OrderByOptions<L> = {},
   PROPERTY_SECURITIES extends boolean = false,
   MODIFIERS extends ApplyModifiersArg<Q> = {},
+  DEFAULT_LOAD_LEVEL extends PropertyModifierValue | undefined = undefined,
 > = PageResult<
   MaybeScore<
     Osdk.Instance<
       Q,
       ExtractOptions<R, S, T, PROPERTY_SECURITIES>,
-      | Exclude<PropertyKeys<Q> extends L ? never : L, keyof MODIFIERS>
+      | SelectedKeysWithDefaultLoadLevel<Q, L, MODIFIERS, DEFAULT_LOAD_LEVEL>
       | ModifiersToSelectStrings<MODIFIERS>,
       {}
     >,
     ORDER_BY_OPTIONS
   >
 >;
+
+/**
+ * The selected keys of a fetch, as `prop:modifier` select strings where a
+ * default load level applies to them. Keys carrying a per-property
+ * `$applyModifiers` entry are dropped here; they come back through
+ * `ModifiersToSelectStrings`.
+ *
+ * Without a default load level this stays `never` when everything is selected,
+ * which is how `Osdk.Instance` spells "all properties".
+ */
+type SelectedKeysWithDefaultLoadLevel<
+  Q extends ObjectOrInterfaceDefinition,
+  L extends PropertyKeys<Q>,
+  MODIFIERS,
+  DEFAULT_LOAD_LEVEL extends PropertyModifierValue | undefined,
+> = [DEFAULT_LOAD_LEVEL] extends [PropertyModifierValue]
+  ? ApplyDefaultLoadLevelToKeys<
+      Q,
+      Exclude<PropertyKeys<Q> extends L ? PropertyKeys<Q> : L, keyof MODIFIERS>,
+      DEFAULT_LOAD_LEVEL
+    >
+  : Exclude<PropertyKeys<Q> extends L ? never : L, keyof MODIFIERS>;
 
 /**
  * Helper type for converting fetch options into an Osdk object

--- a/packages/api/src/ontology/PropertyModifiers.ts
+++ b/packages/api/src/ontology/PropertyModifiers.ts
@@ -131,6 +131,51 @@ export type ApplyModifiersArg<Q extends ObjectOrInterfaceDefinition> = {
     | "applyReducersAndExtractMainValue";
 };
 
+/**
+ * The modifier a default load level resolves to for a single property.
+ *
+ * A default load level is best-effort: it only applies to properties that
+ * actually support it, and `applyReducersAndExtractMainValue` degrades to the
+ * half of itself that a property supports. Properties that support neither
+ * resolve to `never`.
+ */
+export type ResolveDefaultLoadLevelForProp<
+  Q extends ObjectOrInterfaceDefinition,
+  K extends PropertyKeys<Q>,
+  D extends PropertyModifierValue,
+> = D extends "applyMainValue"
+  ? K extends PropsWithMainValue<Q>
+    ? "applyMainValue"
+    : never
+  : D extends "applyReducers"
+    ? K extends PropsWithReducers<Q>
+      ? "applyReducers"
+      : never
+    : K extends PropsWithBoth<Q>
+      ? "applyReducersAndExtractMainValue"
+      : K extends PropsWithMainValue<Q>
+        ? "applyMainValue"
+        : K extends PropsWithReducers<Q>
+          ? "applyReducers"
+          : never;
+
+/**
+ * Turns a union of property keys into the `prop:modifier` select strings that
+ * `Osdk.Instance` understands, given a default load level. Keys the load level
+ * does not apply to are passed through unchanged.
+ */
+export type ApplyDefaultLoadLevelToKeys<
+  Q extends ObjectOrInterfaceDefinition,
+  K extends PropertyKeys<Q>,
+  D extends PropertyModifierValue | undefined,
+> = [D] extends [PropertyModifierValue]
+  ? K extends unknown
+    ? [ResolveDefaultLoadLevelForProp<Q, K, D>] extends [never]
+      ? K
+      : `${K & string}:${ResolveDefaultLoadLevelForProp<Q, K, D>}`
+    : never
+  : K;
+
 export type ApplyModifiersToProps<
   Q extends ObjectOrInterfaceDefinition,
   MODIFIERS extends Record<string, PropertyModifierValue>,

--- a/packages/client/src/objectSet/ObjectSet.test.ts
+++ b/packages/client/src/objectSet/ObjectSet.test.ts
@@ -1392,6 +1392,33 @@ describe("ObjectSet", () => {
       });
     });
 
+    it("accepts $defaultLoadLevel on fetchPageByRid", async () => {
+      const employees = await client(
+        __EXPERIMENTAL__NOT_SUPPORTED_YET__fetchPageByRid,
+      ).fetchPageByRid(
+        Employee,
+        [stubData.employee1.__rid, stubData.employee2.__rid],
+        { $defaultLoadLevel: "applyReducers" },
+      );
+      expect(employees.data[0].$primaryKey).toBe(stubData.employee1.employeeId);
+      expectTypeOf(employees.data[0].employeeProfile).toMatchTypeOf<
+        string | undefined
+      >();
+      expectTypeOf(employees.data[0].performanceScores).toMatchTypeOf<
+        number | undefined
+      >();
+    });
+
+    it("accepts $defaultLoadLevel on fetchPageByRidNoType", async () => {
+      const employees = await client(
+        __EXPERIMENTAL__NOT_SUPPORTED_YET__fetchPageByRid,
+      ).fetchPageByRidNoType(
+        [stubData.employee1.__rid, stubData.employee2.__rid],
+        { $defaultLoadLevel: "applyReducers" },
+      );
+      expect(employees.data[0].$primaryKey).toBe(stubData.employee1.employeeId);
+    });
+
     it("sends defaultLoadLevel for fetchStaticRidPage", async () => {
       const { client, fetchFn } = createMockCaptureClient();
       await fetchStaticRidPage(client, [stubData.employee1.__rid], {

--- a/packages/e2e.sandbox.catchall/src/runReducerAndMainValueTest.ts
+++ b/packages/e2e.sandbox.catchall/src/runReducerAndMainValueTest.ts
@@ -1,16 +1,20 @@
 import { assert } from "console";
 
+import { __EXPERIMENTAL__NOT_SUPPORTED_YET__fetchPageByRid } from "@osdk/api/unstable";
 import { ReducerTest } from "@osdk/e2e.generated.catchall";
 
 import { client } from "./client.js";
 
 export async function runReducerAndMainValueTest(): Promise<void> {
-  const reducerTestObject = await client(ReducerTest).fetchPage({
-    $applyModifiers: {
-      stringArray: "applyReducers",
-      structWithMultipleMain: "applyMainValue",
-    },
-  });
+  const reducerTestObject = await client(ReducerTest)
+    .where({ $primaryKey: "dfb62395-1187-48f7-aac8-da170e00973b" })
+    .fetchPage({
+      $applyModifiers: {
+        stringArray: "applyReducers",
+        structWithMultipleMain: "applyMainValue",
+      },
+      $includeRid: true,
+    });
 
   const reducedValue: string | undefined =
     reducerTestObject.data[0].stringArray;
@@ -23,6 +27,17 @@ export async function runReducerAndMainValueTest(): Promise<void> {
   assert(typeof reducedValue === "string");
   assert(typeof mainValueStruct);
   console.log("Object with reduced values", reducerTestObject.data);
+
+  const allDefault = (
+    await client(
+      __EXPERIMENTAL__NOT_SUPPORTED_YET__fetchPageByRid,
+    ).fetchPageByRid(ReducerTest, [reducerTestObject.data[0].$rid], {
+      $defaultLoadLevel: "applyReducersAndExtractMainValue",
+      $applyModifiers: { structArray: "applyReducers" },
+    })
+  ).data[0];
+  assert(typeof allDefault.stringArray === "string");
+  console.log(JSON.stringify(allDefault, undefined, 2));
 }
 
 void runReducerAndMainValueTest();


### PR DESCRIPTION
Stacked on #3790 (`braedens/default-load-level`).

## Problem

`fetchPageByRid` hardcoded the `FetchPageResult` modifiers slot to `{}` and had no load-level slot at all:

```ts
options?: FetchPageArgs<Q, L, R, any, S, T, never, {}, PROPERTY_SECURITIES>,
) => Promise<FetchPageResult<Q, L, R, S, T, {}, PROPERTY_SECURITIES>>;
```

So neither `$applyModifiers` nor the new `$defaultLoadLevel` showed up in the returned object types — you'd pass a load level, the wire request would carry it, and the result would still be typed as the unmodified struct/array.

## Change

- `FetchPageResult` takes a new `DEFAULT_LOAD_LEVEL` parameter (default `undefined`) and resolves the selected keys through it. Reducers and struct main values are applied where a property supports them and `applyReducersAndExtractMainValue` degrades to whichever half a property supports; properties supporting neither are untouched. A per-property `$applyModifiers` entry wins over the default level.
- `FetchPageArgs` gains a trailing `DEFAULT_LOAD_LEVEL` slot so the literal can be inferred. Its default stays `PropertyModifierValue`, so every existing unparameterized use still accepts any level.
- `fetchPageByRid` infers both `MODIFIERS` and `DEFAULT_LOAD_LEVEL` from its options and forwards them. This also makes `$applyModifiers` reach the result type here for the first time.
- New `ResolveDefaultLoadLevelForProp` / `ApplyDefaultLoadLevelToKeys` helpers in `PropertyModifiers.ts`.

The object-set `fetchPage` / `fetchPageWithErrors` signatures are deliberately left alone, so regular `fetchPage` result types are unchanged and the arg stays hidden there for now.

`fetchPageByRidNoType` is also untouched — `Q` is the base union there, so the helpers have nothing to resolve against.

## Tests

`packages/client/src/objectSet/ObjectSet.test.ts` asserts the pass-through on `fetchPageByRid` and `fetchPageByRidNoType` against the real generated `Employee` (`employeeProfile` has `mainValue: ['bio']`, `performanceScores` has reducers), alongside the existing wire-body coverage.

## Notes

No changeset here — the feature's changeset lives on the base branch and covers the same release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)