### PR TITLE
Support dynamic query mocks in unit-testing

### DIFF
--- a/.changeset/lucky-mangos-listen.md
+++ b/.changeset/lucky-mangos-listen.md
@@ -1,0 +1,6 @@
+---
+"@osdk/unit-testing": minor
+"@osdk/integration-testing": minor
+---
+
+Support dynamic query mocks: `whenQuery(query, (params) => result)` registers an implementation that computes the result from the caller's params, and may be async. `IntegrationClient.whenQuery` inherits the new overload.

--- a/etc/unit-testing.report.api.md
+++ b/etc/unit-testing.report.api.md
@@ -65,9 +65,9 @@ export interface MockClient extends Client {
     	>(objectSet: ObjectSet<Q>, callback: ObjectSetStubCallback<Q, T>): StubBuilderFor<T>;
     	// Warning: (ae-forgotten-export) The symbol "QueryParamsFromDef" needs to be exported by the entry point index.d.ts
     // Warning: (ae-forgotten-export) The symbol "QueryReturnTypeFromDef" needs to be exported by the entry point index.d.ts
-    //
-    // (undocumented)
     whenQuery<Q extends QueryDefinition>(query: Q, params?: QueryParamsFromDef<Q>): QueryStubBuilder<QueryReturnTypeFromDef<Q>>;
+    	// Warning: (ae-forgotten-export) The symbol "QueryImplFromDef" needs to be exported by the entry point index.d.ts
+    whenQuery<Q extends QueryDefinition>(query: Q, impl: QueryImplFromDef<Q>): void;
 }
 
 // @public

--- a/packages/unit-testing/src/api/MockClient.ts
+++ b/packages/unit-testing/src/api/MockClient.ts
@@ -25,15 +25,19 @@ import type { Client } from "@osdk/client";
 import type { QueryStubBuilder, StubBuilderFor } from "./StubBuilders.js";
 import type { StubClient } from "./StubClient.js";
 
-type QueryReturnTypeFromDef<Q extends QueryDefinition> =
+export type QueryReturnTypeFromDef<Q extends QueryDefinition> =
   ReturnType<CompileTimeMetadata<Q>["signature"]> extends Promise<infer R>
     ? R
     : never;
 
-type QueryParamsFromDef<Q extends QueryDefinition> =
+export type QueryParamsFromDef<Q extends QueryDefinition> =
   Parameters<CompileTimeMetadata<Q>["signature"]> extends [infer P]
     ? P
     : undefined;
+
+export type QueryImplFromDef<Q extends QueryDefinition> = (
+  args: QueryParamsFromDef<Q>,
+) => QueryReturnTypeFromDef<Q> | Promise<QueryReturnTypeFromDef<Q>>;
 
 export type StubPatternCallback<T> = (client: StubClient) => T;
 
@@ -47,9 +51,22 @@ export interface MockClient extends Client {
     objectSet: ObjectSet<Q>,
     callback: ObjectSetStubCallback<Q, T>,
   ): StubBuilderFor<T>;
+  /**
+   * Registers a stub matched against `params`, to be completed with
+   * `.thenReturn()` / `.thenThrow()`.
+   */
   whenQuery<Q extends QueryDefinition>(
     query: Q,
     params?: QueryParamsFromDef<Q>,
   ): QueryStubBuilder<QueryReturnTypeFromDef<Q>>;
+  /**
+   * Registers a dynamic implementation, invoked with the caller's params to
+   * compute the result. May be async. Returns nothing: there is no result to
+   * stub.
+   */
+  whenQuery<Q extends QueryDefinition>(
+    query: Q,
+    impl: QueryImplFromDef<Q>,
+  ): void;
   clearStubs(): void;
 }

--- a/packages/unit-testing/src/mock/__tests__/createMockClient.test.ts
+++ b/packages/unit-testing/src/mock/__tests__/createMockClient.test.ts
@@ -20,7 +20,7 @@ import {
   Office,
   queryTypeReturnsArray,
 } from "@osdk/client.test.ontology";
-import { describe, expect, expectTypeOf, it } from "vitest";
+import { describe, expect, expectTypeOf, it, vi } from "vitest";
 
 import { createMockClient } from "../createMockClient.js";
 import { createMockObjectSet } from "../createMockObjectSet.js";
@@ -533,6 +533,138 @@ describe("createMockClient", () => {
       await expect(
         mockClient(addOne).executeFunction({ n: 5 }),
       ).rejects.toThrow("No stub for query 'addOne'");
+    });
+
+    it("computes the result from params with a dynamic implementation", async () => {
+      const mockClient = createMockClient();
+
+      mockClient.whenQuery(addOne, (args) => args.n + 1);
+
+      expect(await mockClient(addOne).executeFunction({ n: 5 })).toBe(6);
+      expect(await mockClient(addOne).executeFunction({ n: 41 })).toBe(42);
+    });
+
+    it("passes the caller's params to the implementation", async () => {
+      const mockClient = createMockClient();
+      const impl = vi.fn((args: { people: readonly string[] }) => [
+        ...args.people,
+      ]);
+
+      mockClient.whenQuery(queryTypeReturnsArray, impl);
+
+      await mockClient(queryTypeReturnsArray).executeFunction({
+        people: ["Alice"],
+      });
+
+      expect(impl).toHaveBeenCalledTimes(1);
+      expect(impl).toHaveBeenCalledWith({ people: ["Alice"] });
+    });
+
+    it("rejects when the implementation throws", async () => {
+      const mockClient = createMockClient();
+
+      mockClient.whenQuery(addOne, () => {
+        throw new Error("boom");
+      });
+
+      await expect(
+        mockClient(addOne).executeFunction({ n: 5 }),
+      ).rejects.toThrow("boom");
+    });
+
+    it("clears dynamic implementations with clearStubs", async () => {
+      const mockClient = createMockClient();
+
+      mockClient.whenQuery(addOne, (args) => args.n + 1);
+      mockClient.clearStubs();
+
+      await expect(
+        mockClient(addOne).executeFunction({ n: 5 }),
+      ).rejects.toThrow("No stub for query 'addOne'");
+    });
+
+    it("uses the last registered stub, mixing params and implementations", async () => {
+      const mockClient = createMockClient();
+
+      mockClient.whenQuery(addOne, { n: 5 }).thenReturn(999);
+      mockClient.whenQuery(addOne, (args) => args.n + 1);
+
+      // The impl was registered last, so it wins even for the stubbed params.
+      expect(await mockClient(addOne).executeFunction({ n: 5 })).toBe(6);
+
+      mockClient.whenQuery(addOne, { n: 5 }).thenReturn(999);
+
+      expect(await mockClient(addOne).executeFunction({ n: 5 })).toBe(999);
+      // Params the later stub doesn't match still fall through to the impl.
+      expect(await mockClient(addOne).executeFunction({ n: 7 })).toBe(8);
+    });
+
+    it("keeps implementations scoped to their own query", async () => {
+      const mockClient = createMockClient();
+
+      mockClient.whenQuery(addOne, (args) => args.n + 1);
+
+      await expect(
+        mockClient(queryTypeReturnsArray).executeFunction({ people: [] }),
+      ).rejects.toThrow("No stub for query 'queryTypeReturnsArray'");
+    });
+
+    it("types the implementation's params from the query definition", () => {
+      const mockClient = createMockClient();
+
+      mockClient.whenQuery(addOne, (args) => {
+        expectTypeOf(args).toEqualTypeOf<addOne.Parameters>();
+        return args.n + 1;
+      });
+
+      mockClient.whenQuery(queryTypeReturnsArray, (args) => {
+        expectTypeOf(args).toEqualTypeOf<queryTypeReturnsArray.Parameters>();
+        return [...args.people];
+      });
+    });
+
+    it("awaits an async implementation", async () => {
+      const mockClient = createMockClient();
+
+      mockClient.whenQuery(addOne, async (args) => {
+        await Promise.resolve();
+        return args.n + 1;
+      });
+
+      expect(await mockClient(addOne).executeFunction({ n: 5 })).toBe(6);
+    });
+
+    it("rejects when an async implementation rejects", async () => {
+      const mockClient = createMockClient();
+
+      mockClient.whenQuery(addOne, async () => {
+        await Promise.resolve();
+        throw new Error("async boom");
+      });
+
+      await expect(
+        mockClient(addOne).executeFunction({ n: 5 }),
+      ).rejects.toThrow("async boom");
+    });
+
+    it("matches any params with an asymmetric matcher", async () => {
+      const mockClient = createMockClient();
+
+      mockClient.whenQuery(addOne, expect.anything()).thenReturn(6);
+
+      expect(await mockClient(addOne).executeFunction({ n: 5 })).toBe(6);
+      expect(await mockClient(addOne).executeFunction({ n: 41 })).toBe(6);
+    });
+
+    it("throws for any params with an asymmetric matcher", async () => {
+      const mockClient = createMockClient();
+      const err = new Error("nope");
+
+      mockClient.whenQuery(addOne, expect.anything()).thenThrow(err);
+
+      await expect(mockClient(addOne).executeFunction({ n: 5 })).rejects.toBe(
+        err,
+      );
     });
 
     it("thenThrow: executeFunction rejects with the configured error", async () => {

--- a/packages/unit-testing/src/mock/createMockClient.ts
+++ b/packages/unit-testing/src/mock/createMockClient.ts
@@ -25,6 +25,7 @@ import invariant from "tiny-invariant";
 import type {
   MockClient,
   ObjectSetStubCallback,
+  QueryReturnTypeFromDef,
   StubPatternCallback,
 } from "../api/MockClient.js";
 import type { QueryStubBuilder, StubBuilderFor } from "../api/StubBuilders.js";
@@ -167,8 +168,8 @@ export function createMockClient(): MockClient {
     } as unknown as StubBuilderFor<T>;
   };
 
-  mockClient.whenQuery = ((
-    query: QueryDefinition,
+  mockClient.whenQuery = (<Q extends QueryDefinition>(
+    query: Q,
     params?: unknown,
   ): QueryStubBuilder<unknown> | void => {
     if (typeof params === "function") {
@@ -180,7 +181,7 @@ export function createMockClient(): MockClient {
       return;
     }
     return {
-      thenReturn: (result: unknown) => {
+      thenReturn: (result: QueryReturnTypeFromDef<Q>) => {
         queryStubs.push({
           queryApiName: query.apiName,
           type: "params",

--- a/packages/unit-testing/src/mock/createMockClient.ts
+++ b/packages/unit-testing/src/mock/createMockClient.ts
@@ -15,7 +15,6 @@
  */
 
 import type {
-  CompileTimeMetadata,
   ObjectOrInterfaceDefinition,
   ObjectSet,
   QueryDefinition,
@@ -41,22 +40,20 @@ import {
 
 type ClientStub = Stub & { objectType: string };
 
-type QueryStub = {
-  queryApiName: string;
-  params: unknown;
-  value?: unknown;
-  error?: Error;
-};
-
-type QueryReturnTypeFromDef<Q extends QueryDefinition> =
-  ReturnType<CompileTimeMetadata<Q>["signature"]> extends Promise<infer R>
-    ? R
-    : never;
-
-type QueryParamsFromDef<Q extends QueryDefinition> =
-  Parameters<CompileTimeMetadata<Q>["signature"]> extends [infer P]
-    ? P
-    : undefined;
+type QueryStub = { queryApiName: string } & (
+  | {
+      /** Matched by deep-equality against the caller's params. */
+      type: "params";
+      params: unknown;
+      value?: unknown;
+      error?: Error;
+    }
+  | {
+      /** Matches any params for the query; computes the result from them. */
+      type: "impl";
+      impl: (params: unknown) => unknown;
+    }
+);
 
 // Well-known string key used by Foundry Platform APIs to pull the
 // SharedClientContext (baseUrl, tokenProvider, fetch) off a client. Matches
@@ -74,10 +71,14 @@ export function createMockClient(): MockClient {
       `No stub for request\n`,
     );
 
+  // Last matching stub wins, so a later registration overrides an earlier one.
   const resolveQuery = (queryApiName: string, params: unknown): unknown => {
     for (let i = queryStubs.length - 1; i >= 0; i--) {
       const stub = queryStubs[i];
       if (stub.queryApiName !== queryApiName) continue;
+      if (stub.type === "impl") {
+        return stub.impl(params);
+      }
       if (deepEqual(stub.params, params)) {
         if (stub.error !== undefined) {
           throw stub.error;
@@ -85,7 +86,6 @@ export function createMockClient(): MockClient {
         return stub.value;
       }
     }
-
     const msg = `No stub for query '${queryApiName}'`;
     throw new Error(msg);
   };
@@ -167,14 +167,23 @@ export function createMockClient(): MockClient {
     } as unknown as StubBuilderFor<T>;
   };
 
-  mockClient.whenQuery = <Q extends QueryDefinition>(
-    query: Q,
-    params?: QueryParamsFromDef<Q>,
-  ): QueryStubBuilder<QueryReturnTypeFromDef<Q>> => {
+  mockClient.whenQuery = ((
+    query: QueryDefinition,
+    params?: unknown,
+  ): QueryStubBuilder<unknown> | void => {
+    if (typeof params === "function") {
+      queryStubs.push({
+        queryApiName: query.apiName,
+        type: "impl",
+        impl: params as (params: unknown) => unknown,
+      });
+      return;
+    }
     return {
-      thenReturn: (result: QueryReturnTypeFromDef<Q>) => {
+      thenReturn: (result: unknown) => {
         queryStubs.push({
           queryApiName: query.apiName,
+          type: "params",
           params,
           value: result,
         });
@@ -182,12 +191,13 @@ export function createMockClient(): MockClient {
       thenThrow: (error: Error) => {
         queryStubs.push({
           queryApiName: query.apiName,
+          type: "params",
           params,
           error,
         });
       },
     };
-  };
+  }) as MockClient["whenQuery"];
 
   mockClient.clearStubs = () => {
     stubs.length = 0;


### PR DESCRIPTION
Adds a dynamic-implementation overload to `MockClient.whenQuery`:

```ts
client.whenQuery(myQuery, (params) => ({ result: params.a + params.b }));
```

The implementation receives the caller's params and computes the result; it may be async. The existing `whenQuery(query, params).thenReturn(...)` / `.thenThrow(...)` form is unchanged, and query stubs still resolve last-registered-first. `IntegrationClient.whenQuery` inherits the overload.
