### PR TITLE
Integration testing: drop interfaces when ontology metadata does not include it

### DIFF
--- a/.changeset/tangy-sloths-exist.md
+++ b/.changeset/tangy-sloths-exist.md
@@ -1,0 +1,5 @@
+---
+"@osdk/integration-testing": patch
+---
+
+Drop unimported interfaces in integration testing server startup

--- a/packages/integration-testing/src/createIntegrationServer.ts
+++ b/packages/integration-testing/src/createIntegrationServer.ts
@@ -20,6 +20,7 @@ import path from "node:path";
 import type { OntologyFullMetadata } from "@osdk/foundry.ontologies";
 import type { PreviewOntologyFullMetadata } from "@osdk/generator-converters.preview";
 import { PreviewOntologyIrConverter } from "@osdk/generator-converters.preview";
+import consola from "consola";
 import invariant from "tiny-invariant";
 import { Agent, fetch as undiciFetch } from "undici";
 
@@ -43,8 +44,45 @@ const transformMetadata = (
       EMPTY_ONTOLOGY_BLOCK_DATA,
       metadata,
     );
+  const interfaceTypeApiNames = new Set<string>(
+    Object.keys(transformed.interfaceTypes),
+  );
+  const objectTypes: OntologyFullMetadata["objectTypes"] = Object.fromEntries(
+    Object.entries(transformed.objectTypes).map(([key, value]) => {
+      const implementsInterfaces = value.implementsInterfaces.filter((n) =>
+        interfaceTypeApiNames.has(n),
+      );
+      const implementsInterfaces2 = Object.fromEntries(
+        Object.entries(value.implementsInterfaces2).filter(([n]) =>
+          interfaceTypeApiNames.has(n),
+        ),
+      );
+      const excluded = [
+        ...value.implementsInterfaces.filter(
+          (n) => !interfaceTypeApiNames.has(n),
+        ),
+        ...Object.keys(value.implementsInterfaces2).filter(
+          ([n]) => !interfaceTypeApiNames.has(n),
+        ),
+      ];
+      if (excluded.length > 0) {
+        consola.warn(
+          `The following interface types were removed from the ontology metadata since they were not imported: ${excluded.join(", ")}`,
+        );
+      }
+      return [
+        key,
+        {
+          ...value,
+          implementsInterfaces,
+          implementsInterfaces2,
+        },
+      ];
+    }),
+  );
   return {
     ...transformed,
+    objectTypes,
     ontology: metadata.ontology,
   };
 };

--- a/packages/integration-testing/src/test/IntegrationServer.test.ts
+++ b/packages/integration-testing/src/test/IntegrationServer.test.ts
@@ -18,10 +18,65 @@ import { mkdtemp, readdir, readFile, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
+import type { OntologyFullMetadata } from "@osdk/foundry.ontologies";
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import { createIntegrationServer } from "../createIntegrationServer.js";
 import { EMPTY_ONTOLOGY_METADATA } from "./emptyOntologyMetadata.js";
+
+/**
+ * Metadata for a single object type that claims two interfaces, only one of
+ * which — `com.example.Present` — is actually defined here.
+ */
+const metadataWithMissingInterface = (): OntologyFullMetadata => ({
+  ...EMPTY_ONTOLOGY_METADATA,
+  interfaceTypes: {
+    "com.example.Present": {
+      rid: "ri.ontology.main.interface.present",
+      apiName: "com.example.Present",
+      displayName: "Present",
+      properties: {},
+      allProperties: {},
+      propertiesV2: {},
+      allPropertiesV2: {},
+      extendsInterfaces: [],
+      allExtendsInterfaces: [],
+      implementedByObjectTypes: ["Todo"],
+      links: {},
+      allLinks: {},
+    },
+  },
+  objectTypes: {
+    Todo: {
+      objectType: {
+        apiName: "Todo",
+        displayName: "Todo",
+        pluralDisplayName: "Todos",
+        status: "ACTIVE",
+        icon: { type: "blueprint", name: "document", color: "blue" },
+        primaryKey: "id",
+        titleProperty: "id",
+        properties: {
+          id: {
+            dataType: { type: "string" },
+            rid: "ri.a.b.property.id",
+            typeClasses: [],
+          },
+        },
+        rid: "ri.ontology.main.object-type.todo",
+        aliases: [],
+        datasources: [],
+      },
+      linkTypes: [],
+      implementsInterfaces: ["com.example.Present", "com.example.Missing"],
+      implementsInterfaces2: {
+        "com.example.Present": { properties: {}, propertiesV2: {}, links: {} },
+        "com.example.Missing": { properties: {}, propertiesV2: {}, links: {} },
+      },
+      sharedPropertyTypeMapping: {},
+    },
+  },
+});
 
 /**
  * Creating a server only lays out its directory — nothing is spawned until
@@ -77,6 +132,27 @@ describe("createIntegrationServer", () => {
         readFile(join(projectPath, run, "ontology-metadata.json")),
       ).resolves.toBeDefined();
     }
+  });
+
+  it("drops interfaces an object claims that the metadata never defines", async () => {
+    // A caller can hand us metadata whose object types reference an interface
+    // that was never imported alongside them; the ontology server rejects the
+    // dangling reference, so it has to be stripped before we write the file.
+    await createIntegrationServer({
+      metadata: metadataWithMissingInterface(),
+      projectPath,
+    });
+
+    const [run] = await runDirs();
+    const written = JSON.parse(
+      await readFile(join(projectPath, run, "ontology-metadata.json"), "utf-8"),
+    ) as OntologyFullMetadata;
+
+    const todo = written.objectTypes.Todo;
+    expect(todo.implementsInterfaces).toEqual(["com.example.Present"]);
+    expect(Object.keys(todo.implementsInterfaces2)).toEqual([
+      "com.example.Present",
+    ]);
   });
 
   it("removes only its own run directory when stopped", async () => {


### PR DESCRIPTION
Foundry CLI fails to launch if an object has an `implementsInterfaces` or `implementsInterfaces2` entry for an interface that does not exist in the ontology metadata. This PR sanitizes the ontology metadata before we launch the server to prevent the hard failure.

On omission, the integration testing library will print a warning with the list of interfaces dropped.

Added a test to verify this behavior.