### PR TITLE
[FilterList] sandboxes: adopt defaultFilterState and exercise every filter type

### DIFF
--- a/packages/e2e.sandbox.officeassignment/src/tables/AssignmentsTable/AssignmentsFilterDefs.tsx
+++ b/packages/e2e.sandbox.officeassignment/src/tables/AssignmentsTable/AssignmentsFilterDefs.tsx
@@ -28,7 +28,7 @@ export const ASSIGNMENT_FILTER_DEFS: Array<IdentifiedFilterDef<Assignment>> = [
     key: "title",
     label: "Title",
     filterComponent: "CONTAINS_TEXT",
-    filterState: { type: "CONTAINS_TEXT" },
+    defaultFilterState: { type: "CONTAINS_TEXT" },
   },
   {
     type: "PROPERTY",
@@ -36,7 +36,7 @@ export const ASSIGNMENT_FILTER_DEFS: Array<IdentifiedFilterDef<Assignment>> = [
     key: "function",
     label: "Function",
     filterComponent: "LISTOGRAM",
-    filterState: { type: "EXACT_MATCH", values: [] },
+    defaultFilterState: { type: "EXACT_MATCH", values: [] },
   },
   {
     type: "PROPERTY",
@@ -44,7 +44,7 @@ export const ASSIGNMENT_FILTER_DEFS: Array<IdentifiedFilterDef<Assignment>> = [
     key: "assignmentType",
     label: "Type",
     filterComponent: "MULTI_SELECT",
-    filterState: { type: "SELECT", selectedValues: [] },
+    defaultFilterState: { type: "SELECT", selectedValues: [] },
   },
   {
     type: "PROPERTY",
@@ -52,7 +52,7 @@ export const ASSIGNMENT_FILTER_DEFS: Array<IdentifiedFilterDef<Assignment>> = [
     key: "startDate",
     label: "Start date",
     filterComponent: "DATE_RANGE",
-    filterState: { type: "DATE_RANGE" },
+    defaultFilterState: { type: "DATE_RANGE" },
   },
   {
     type: "PROPERTY",
@@ -60,6 +60,6 @@ export const ASSIGNMENT_FILTER_DEFS: Array<IdentifiedFilterDef<Assignment>> = [
     key: "tenureDays",
     label: "Tenure (days)",
     filterComponent: "NUMBER_RANGE",
-    filterState: { type: "NUMBER_RANGE" },
+    defaultFilterState: { type: "NUMBER_RANGE" },
   },
 ];

--- a/packages/e2e.sandbox.officeassignment/src/tables/AssignmentsTable/AssignmentsFilters.tsx
+++ b/packages/e2e.sandbox.officeassignment/src/tables/AssignmentsTable/AssignmentsFilters.tsx
@@ -37,7 +37,7 @@ interface AssignmentsFiltersProps {
     newStates: Array<{ filterKey: string; isVisible: boolean }>,
   ) => void;
   onReset?: () => void;
-  initialFilterStates?: Map<string, FilterState>;
+  defaultFilterStates?: Map<string, FilterState>;
   className?: string;
   collapsed?: boolean;
   onCollapsedChange?: (collapsed: boolean) => void;
@@ -55,7 +55,7 @@ export const AssignmentsFilters = React.memo<AssignmentsFiltersProps>(
     onFilterStateChanged,
     onFilterVisibilityChange,
     onReset,
-    initialFilterStates,
+    defaultFilterStates,
     className,
     collapsed,
     onCollapsedChange,
@@ -70,7 +70,7 @@ export const AssignmentsFilters = React.memo<AssignmentsFiltersProps>(
         onFilterStateChanged={onFilterStateChanged}
         onFilterVisibilityChange={onFilterVisibilityChange}
         onReset={onReset}
-        initialFilterStates={initialFilterStates}
+        defaultFilterStates={defaultFilterStates}
         title="Filters"
         collapsed={collapsed}
         onCollapsedChange={onCollapsedChange}

--- a/packages/e2e.sandbox.officeassignment/src/tables/StatusUpdatesTable/StatusUpdatesFilterDefs.tsx
+++ b/packages/e2e.sandbox.officeassignment/src/tables/StatusUpdatesTable/StatusUpdatesFilterDefs.tsx
@@ -27,7 +27,7 @@ export const STATUS_UPDATE_FILTER_DEFS: Array<
     key: "type",
     label: "Type",
     filterComponent: "LISTOGRAM",
-    filterState: { type: "EXACT_MATCH", values: [] },
+    defaultFilterState: { type: "EXACT_MATCH", values: [] },
   },
   {
     type: "PROPERTY",
@@ -35,7 +35,7 @@ export const STATUS_UPDATE_FILTER_DEFS: Array<
     key: "value",
     label: "Value",
     filterComponent: "LISTOGRAM",
-    filterState: { type: "EXACT_MATCH", values: [] },
+    defaultFilterState: { type: "EXACT_MATCH", values: [] },
   },
   {
     type: "PROPERTY",
@@ -43,6 +43,6 @@ export const STATUS_UPDATE_FILTER_DEFS: Array<
     key: "isExcluded",
     label: "Excluded",
     filterComponent: "LISTOGRAM",
-    filterState: { type: "EXACT_MATCH", values: [] },
+    defaultFilterState: { type: "EXACT_MATCH", values: [] },
   },
 ];

--- a/packages/e2e.sandbox.officeassignment/src/tables/StatusUpdatesTable/StatusUpdatesFilters.tsx
+++ b/packages/e2e.sandbox.officeassignment/src/tables/StatusUpdatesTable/StatusUpdatesFilters.tsx
@@ -37,7 +37,7 @@ interface StatusUpdatesFiltersProps {
     newStates: Array<{ filterKey: string; isVisible: boolean }>,
   ) => void;
   onReset?: () => void;
-  initialFilterStates?: Map<string, FilterState>;
+  defaultFilterStates?: Map<string, FilterState>;
   className?: string;
   collapsed?: boolean;
   onCollapsedChange?: (collapsed: boolean) => void;
@@ -52,7 +52,7 @@ export const StatusUpdatesFilters = React.memo<StatusUpdatesFiltersProps>(
     onFilterStateChanged,
     onFilterVisibilityChange,
     onReset,
-    initialFilterStates,
+    defaultFilterStates,
     className,
     collapsed,
     onCollapsedChange,
@@ -67,7 +67,7 @@ export const StatusUpdatesFilters = React.memo<StatusUpdatesFiltersProps>(
         onFilterStateChanged={onFilterStateChanged}
         onFilterVisibilityChange={onFilterVisibilityChange}
         onReset={onReset}
-        initialFilterStates={initialFilterStates}
+        defaultFilterStates={defaultFilterStates}
         title="Filters"
         collapsed={collapsed}
         onCollapsedChange={onCollapsedChange}

--- a/packages/e2e.sandbox.officeassignment/src/tabs/AssignmentsTab/AssignmentsTab.tsx
+++ b/packages/e2e.sandbox.officeassignment/src/tabs/AssignmentsTab/AssignmentsTab.tsx
@@ -76,7 +76,7 @@ export function AssignmentsTab(): React.JSX.Element {
           onFilterStateChanged={handleFilterStateChanged}
           onFilterVisibilityChange={handleFilterVisibilityChange}
           onReset={handleReset}
-          initialFilterStates={filterStates}
+          defaultFilterStates={filterStates}
         />
       </aside>
       <div className={styles.main}>

--- a/packages/e2e.sandbox.officeassignment/src/tabs/StatusUpdatesTab/StatusUpdatesTab.tsx
+++ b/packages/e2e.sandbox.officeassignment/src/tabs/StatusUpdatesTab/StatusUpdatesTab.tsx
@@ -50,7 +50,7 @@ export function StatusUpdatesTab(): React.JSX.Element {
           onFilterStateChanged={handleFilterStateChanged}
           onFilterVisibilityChange={handleFilterVisibilityChange}
           onReset={handleReset}
-          initialFilterStates={filterStates}
+          defaultFilterStates={filterStates}
         />
       </aside>
       <div className={styles.main}>

--- a/packages/e2e.sandbox.peopleapp/src/app/action-form-filter-list-repro/page.tsx
+++ b/packages/e2e.sandbox.peopleapp/src/app/action-form-filter-list-repro/page.tsx
@@ -1,4 +1,4 @@
-import type { WhereClause } from "@osdk/api";
+import type { ObjectSet } from "@osdk/api";
 import type {
   ActionDefinition,
   ActionParam,
@@ -11,7 +11,6 @@ import type {
   FormFieldDefinition,
 } from "@osdk/react-components/experimental/action-form";
 import { ActionForm } from "@osdk/react-components/experimental/action-form";
-import type { FilterDefinitionUnion } from "@osdk/react-components/experimental/filter-list";
 import { FilterList } from "@osdk/react-components/experimental/filter-list";
 import type { ColumnDefinition } from "@osdk/react-components/experimental/object-table";
 import { ObjectTable } from "@osdk/react-components/experimental/object-table";
@@ -20,6 +19,7 @@ import React, { useCallback, useMemo, useState } from "react";
 import { Button } from "../../components/Button.js";
 import { $ } from "../../foundryClient.js";
 import { Employee, modifyEmployee } from "../../generatedNoCheck2/index.js";
+import { EMPLOYEE_FILTER_CATALOG } from "../filters/employeeFilterCatalog.js";
 
 import "./page.css";
 
@@ -52,49 +52,6 @@ interface ModifyEmployeeDepartmentSignatures {
 // parameter shape while the real sandbox action metadata catches up.
 const modifyEmployeeDepartment =
   modifyEmployee as unknown as ModifyEmployeeDepartmentAction;
-
-const EMPLOYEE_FILTERS: Array<FilterDefinitionUnion<Employee>> = [
-  {
-    type: "PROPERTY",
-    id: "department",
-    key: "department",
-    label: "Department",
-    filterComponent: "LISTOGRAM",
-    filterState: { type: "EXACT_MATCH", values: [] },
-  },
-  {
-    type: "PROPERTY",
-    id: "locationCity",
-    key: "locationCity",
-    label: "Location city",
-    filterComponent: "LISTOGRAM",
-    filterState: { type: "EXACT_MATCH", values: [] },
-  },
-  {
-    type: "PROPERTY",
-    id: "workerType",
-    key: "workerType",
-    label: "Worker type",
-    filterComponent: "LISTOGRAM",
-    filterState: { type: "EXACT_MATCH", values: [] },
-  },
-  {
-    type: "PROPERTY",
-    id: "team",
-    key: "team",
-    label: "Team contains",
-    filterComponent: "CONTAINS_TEXT",
-    filterState: { type: "CONTAINS_TEXT", value: "" },
-  },
-  {
-    type: "PROPERTY",
-    id: "firstFullTimeStartDate",
-    key: "firstFullTimeStartDate",
-    label: "Full-time start date",
-    filterComponent: "DATE_RANGE",
-    filterState: { type: "DATE_RANGE" },
-  },
-];
 
 const EMPLOYEE_COLUMNS: Array<ColumnDefinition<Employee>> = [
   {
@@ -166,10 +123,11 @@ interface StatusMessage {
 
 export const EmployeeActionFormFilterListReproPage = React.memo(
   function EmployeeActionFormFilterListReproPageFn() {
-    const [filterClause, setFilterClause] = useState<WhereClause<Employee>>({});
     const [isDialogOpen, setIsDialogOpen] = useState(false);
     const [statusMessage, setStatusMessage] = useState<StatusMessage>();
     const employeeObjectSet = useMemo(() => $(Employee), []);
+    const [effectiveObjectSet, setEffectiveObjectSet] =
+      useState<ObjectSet<Employee>>();
 
     const openDialog = useCallback(function openDialog() {
       setIsDialogOpen(true);
@@ -228,18 +186,23 @@ export const EmployeeActionFormFilterListReproPage = React.memo(
           <FilterList
             objectType={Employee}
             objectSet={employeeObjectSet}
-            filterDefinitions={EMPLOYEE_FILTERS}
-            onFilterClauseChanged={setFilterClause}
+            filterDefinitions={EMPLOYEE_FILTER_CATALOG}
+            onEffectiveObjectSet={setEffectiveObjectSet}
             title="Employee filters"
             showActiveFilterCount={true}
             showResetButton={true}
             enableSorting={true}
           />
 
+          {/*
+            Fetch through the effective object set rather than `filter`, so the
+            linked filters above actually narrow the table — they never appear
+            in a where clause. It already folds in the direct filters too.
+          */}
           <ObjectTable
             objectType={Employee}
+            objectSet={effectiveObjectSet ?? employeeObjectSet}
             columnDefinitions={EMPLOYEE_COLUMNS}
-            filter={filterClause}
             defaultOrderBy={DEFAULT_ORDER_BY}
             pageSize={50}
           />

--- a/packages/e2e.sandbox.peopleapp/src/app/employees/EmployeesWithFilterList.tsx
+++ b/packages/e2e.sandbox.peopleapp/src/app/employees/EmployeesWithFilterList.tsx
@@ -14,19 +14,18 @@
  * limitations under the License.
  */
 
-import type { WhereClause } from "@osdk/api";
-import { useOsdkObjects } from "@osdk/react";
+import type { ObjectSet, WhereClause } from "@osdk/api";
+import { useObjectSet } from "@osdk/react";
 
 import "@osdk/react-components/styles.css";
-import {
-  type FilterDefinitionUnion,
-  FilterList,
-} from "@osdk/react-components/experimental/filter-list";
-import { useState } from "react";
+import { FilterList } from "@osdk/react-components/experimental/filter-list";
+import { useMemo, useState } from "react";
 
 import { List } from "../../components/List.js";
 import { ListItem } from "../../components/ListItem.js";
+import { $ } from "../../foundryClient.js";
 import { Employee } from "../../generatedNoCheck2/index.js";
+import { EMPLOYEE_FILTER_CATALOG } from "../filters/employeeFilterCatalog.js";
 
 interface EmployeeListItemProps {
   item: Employee.OsdkInstance;
@@ -62,36 +61,18 @@ interface EmployeesWithFilterListProps {
   onSelect: (employee: Employee.OsdkInstance) => void;
 }
 
-const INITIAL_FILTER_DEFINITIONS: Array<FilterDefinitionUnion<Employee>> = [
-  {
-    type: "PROPERTY",
-    id: "department",
-    key: "department",
-    label: "Department",
-    filterComponent: "LISTOGRAM",
-    filterState: { type: "EXACT_MATCH", values: [] },
-  },
-  {
-    type: "LINKED_PROPERTY",
-    id: "lead-department",
-    linkName: "lead",
-    reverseLinkName: "peeps",
-    linkedPropertyKey: "department",
-    linkedFilterComponent: "LISTOGRAM",
-    linkedFilterState: { type: "EXACT_MATCH", values: [] },
-    filterState: {
-      type: "linkedProperty",
-      linkedFilterState: { type: "EXACT_MATCH", values: [] },
-    },
-    label: "Lead's Department",
-  },
-];
-
 export function EmployeesWithFilterList(props: EmployeesWithFilterListProps) {
   const [whereClause, setWhereClause] = useState<WhereClause<Employee>>({});
+  // LINKED_PROPERTY filters pivot off an object set, so they render empty
+  // without one — `objectType` alone is not enough for them.
+  const employeeObjectSet = useMemo(() => $(Employee), []);
+  const [effectiveObjectSet, setEffectiveObjectSet] =
+    useState<ObjectSet<Employee>>();
 
-  const employees = useOsdkObjects(Employee, {
-    where: whereClause,
+  // The effective object set already folds in `whereClause`, and unlike it also
+  // carries the LINKED_PROPERTY narrowing, which never appears in a where
+  // clause. Falling back to the unfiltered set avoids an empty first paint.
+  const employees = useObjectSet(effectiveObjectSet ?? employeeObjectSet, {
     orderBy: { fullName: "asc" },
     pageSize: 50,
   });
@@ -102,8 +83,10 @@ export function EmployeesWithFilterList(props: EmployeesWithFilterListProps) {
         <div>
           <FilterList
             objectType={Employee}
-            filterDefinitions={INITIAL_FILTER_DEFINITIONS}
+            objectSet={employeeObjectSet}
+            filterDefinitions={EMPLOYEE_FILTER_CATALOG}
             onFilterClauseChanged={setWhereClause}
+            onEffectiveObjectSet={setEffectiveObjectSet}
             enableSorting={true}
             title="Filters"
             showActiveFilterCount={true}
@@ -128,6 +111,10 @@ export function EmployeesWithFilterList(props: EmployeesWithFilterListProps) {
             <pre style={{ fontSize: 10, marginTop: 8 }}>
               Where: {JSON.stringify(whereClause, null, 2)}
             </pre>
+            <div style={{ fontSize: 10, color: "#666" }}>
+              Linked filters never appear above — they narrow the list through
+              the object set instead.
+            </div>
           </div>
 
           <List<Employee>

--- a/packages/e2e.sandbox.peopleapp/src/app/filters/CustomSalaryBandInput.tsx
+++ b/packages/e2e.sandbox.peopleapp/src/app/filters/CustomSalaryBandInput.tsx
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import React from "react";
+
+/** Bands the custom filter offers, and the salary floor each one maps to. */
+export const SALARY_BANDS = {
+  any: undefined,
+  "over-100k": 100_000,
+  "over-200k": 200_000,
+} as const;
+
+export type SalaryBand = keyof typeof SALARY_BANDS;
+
+export function isSalaryBand(value: unknown): value is SalaryBand {
+  return typeof value === "string" && value in SALARY_BANDS;
+}
+
+interface CustomSalaryBandInputProps {
+  band: SalaryBand;
+  onBandChanged: (band: SalaryBand) => void;
+}
+
+/**
+ * Stands in for whatever bespoke control a consumer would supply through a
+ * CUSTOM filter's `renderInput` — the point is that FilterList renders it and
+ * routes its state, not that the control itself is interesting.
+ */
+export function CustomSalaryBandInput({
+  band,
+  onBandChanged,
+}: CustomSalaryBandInputProps) {
+  return (
+    <select
+      aria-label="Salary band"
+      value={band}
+      onChange={(event) => {
+        const next = event.target.value;
+        if (isSalaryBand(next)) {
+          onBandChanged(next);
+        }
+      }}
+      style={{ width: "100%" }}
+    >
+      <option value="any">Any salary</option>
+      <option value="over-100k">Over 100k</option>
+      <option value="over-200k">Over 200k</option>
+    </select>
+  );
+}

--- a/packages/e2e.sandbox.peopleapp/src/app/filters/employeeFilterCatalog.tsx
+++ b/packages/e2e.sandbox.peopleapp/src/app/filters/employeeFilterCatalog.tsx
@@ -1,0 +1,212 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { FilterDefinitionUnion } from "@osdk/react-components/experimental/filter-list";
+import React from "react";
+
+import type { Employee } from "../../generatedNoCheck2/index.js";
+import {
+  CustomSalaryBandInput,
+  isSalaryBand,
+  SALARY_BANDS,
+} from "./CustomSalaryBandInput.js";
+
+/**
+ * One filter per FilterList definition kind, and one per filter component,
+ * so both demo tabs exercise the whole surface from a single source.
+ *
+ * Every entry carries an explicit `id`: several of them filter the same
+ * property with different components, and the derived key would collide.
+ *
+ * The one component missing is TOGGLE, which needs a `boolean` property.
+ * Employee has none, and neither does anything it links to (`lead` and `peeps`
+ * are Employee, `primaryOffice` is Office), so it is not reachable from this
+ * ontology. HAS_LINK below renders the same switch control.
+ */
+export const EMPLOYEE_FILTER_CATALOG: Array<FilterDefinitionUnion<Employee>> = [
+  // PROPERTY — string components
+  {
+    type: "PROPERTY",
+    id: "department-listogram",
+    key: "department",
+    label: "Department (LISTOGRAM)",
+    filterComponent: "LISTOGRAM",
+    defaultFilterState: { type: "EXACT_MATCH", values: [] },
+  },
+  {
+    type: "PROPERTY",
+    id: "locationCountry-textTags",
+    key: "locationCountry",
+    label: "Country (TEXT_TAGS)",
+    filterComponent: "TEXT_TAGS",
+    defaultFilterState: { type: "EXACT_MATCH", values: [] },
+  },
+  {
+    type: "PROPERTY",
+    id: "team-containsText",
+    key: "team",
+    label: "Team (CONTAINS_TEXT)",
+    filterComponent: "CONTAINS_TEXT",
+    defaultFilterState: { type: "CONTAINS_TEXT", value: "" },
+  },
+  {
+    type: "PROPERTY",
+    id: "locationRegion-singleSelect",
+    key: "locationRegion",
+    label: "Region (SINGLE_SELECT)",
+    filterComponent: "SINGLE_SELECT",
+    defaultFilterState: { type: "SELECT", selectedValues: [] },
+  },
+  {
+    type: "PROPERTY",
+    id: "jobTitle-multiSelect",
+    key: "jobTitle",
+    label: "Job title (MULTI_SELECT)",
+    filterComponent: "MULTI_SELECT",
+    // MULTI_SELECT has its own inline search, so the header monocle is noise.
+    searchField: false,
+    defaultFilterState: { type: "SELECT", selectedValues: [] },
+  },
+
+  // PROPERTY — numeric components
+  {
+    type: "PROPERTY",
+    id: "salary-numberRange",
+    key: "salary",
+    label: "Salary (NUMBER_RANGE)",
+    filterComponent: "NUMBER_RANGE",
+    defaultFilterState: { type: "NUMBER_RANGE" },
+    clickToFilter: true,
+  },
+
+  // PROPERTY — datetime components
+  {
+    type: "PROPERTY",
+    id: "firstFullTimeStartDate-dateRange",
+    key: "firstFullTimeStartDate",
+    label: "Full-time start (DATE_RANGE)",
+    filterComponent: "DATE_RANGE",
+    defaultFilterState: { type: "DATE_RANGE" },
+    clickToFilter: true,
+  },
+  {
+    type: "PROPERTY",
+    id: "firstInternStartDate-singleDate",
+    key: "firstInternStartDate",
+    label: "Intern start (SINGLE_DATE)",
+    filterComponent: "SINGLE_DATE",
+    defaultFilterState: { type: "SELECT", selectedValues: [] },
+  },
+  {
+    type: "PROPERTY",
+    id: "firstInternStartDate-multiDate",
+    key: "firstInternStartDate",
+    label: "Intern start (MULTI_DATE)",
+    filterComponent: "MULTI_DATE",
+    defaultFilterState: { type: "SELECT", selectedValues: [] },
+  },
+  {
+    type: "PROPERTY",
+    id: "firstFullTimeStartDate-timeline",
+    key: "firstFullTimeStartDate",
+    label: "Full-time start (TIMELINE)",
+    filterComponent: "TIMELINE",
+    defaultFilterState: { type: "TIMELINE" },
+  },
+
+  // STATIC_VALUES — values supplied inline instead of aggregated
+  {
+    type: "STATIC_VALUES",
+    id: "workerType-static",
+    key: "workerType",
+    label: "Worker type (STATIC_VALUES)",
+    filterComponent: "LISTOGRAM",
+    values: ["Employee", "Contingent Worker", "Intern"],
+    listogramConfig: { displayMode: "minimal" },
+    defaultFilterState: { type: "EXACT_MATCH", values: [] },
+  },
+
+  // KEYWORD_SEARCH — one box across several string properties
+  {
+    type: "KEYWORD_SEARCH",
+    id: "keyword-search",
+    properties: ["fullName", "team", "jobTitle"],
+    label: "Keyword search",
+    defaultFilterState: {
+      type: "keywordSearch",
+      searchTerm: "",
+      operator: "AND",
+    },
+  },
+
+  // HAS_LINK — left unseeded, since seeding would narrow before anyone
+  // touched the filter
+  {
+    type: "HAS_LINK",
+    id: "has-lead",
+    linkName: "lead",
+    label: "Has a lead (HAS_LINK)",
+  },
+
+  // LINKED_PROPERTY — narrows through `onEffectiveObjectSet`, never the where
+  // clause, and only when `reverseLinkName` is set
+  {
+    type: "LINKED_PROPERTY",
+    id: "lead-department",
+    linkName: "lead",
+    reverseLinkName: "peeps",
+    linkedPropertyKey: "department",
+    label: "Lead's department (LINKED_PROPERTY)",
+    filterComponent: "LISTOGRAM",
+    defaultFilterState: { type: "EXACT_MATCH", values: [] },
+  },
+  {
+    type: "LINKED_PROPERTY",
+    id: "primaryOffice-name",
+    linkName: "primaryOffice",
+    reverseLinkName: "occupants",
+    linkedPropertyKey: "name",
+    label: "Office (LINKED_PROPERTY)",
+    filterComponent: "MULTI_SELECT",
+    defaultFilterState: { type: "SELECT", selectedValues: [] },
+  },
+
+  // CUSTOM — consumer-owned control and where clause
+  {
+    type: "CUSTOM",
+    id: "salary-band-custom",
+    key: "salary-band-custom",
+    label: "Salary band (CUSTOM)",
+    filterComponent: "CUSTOM",
+    defaultFilterState: { type: "custom", customState: { band: "any" } },
+    renderInput: ({ filterState, onFilterStateChanged }) => {
+      const raw = filterState.customState.band;
+      return (
+        <CustomSalaryBandInput
+          band={isSalaryBand(raw) ? raw : "any"}
+          onBandChanged={(band) =>
+            onFilterStateChanged({ type: "custom", customState: { band } })
+          }
+        />
+      );
+    },
+    toWhereClause: (state) => {
+      const raw = state.customState.band;
+      const floor = isSalaryBand(raw) ? SALARY_BANDS[raw] : undefined;
+      return floor == null ? undefined : { salary: { $gte: floor } };
+    },
+  },
+];

--- a/packages/e2e.sandbox.peopleapp/src/components/List.tsx
+++ b/packages/e2e.sandbox.peopleapp/src/components/List.tsx
@@ -22,7 +22,9 @@ interface ListProps<T extends ObjectTypeDefinition> {
 
   header: ReactNode;
 
-  items: UseOsdkListResult<T>;
+  // Narrowed to the fields actually read, so callers can pass either a
+  // `useOsdkObjects` or a `useObjectSet` result.
+  items: Pick<UseOsdkListResult<T>, "data" | "isLoading" | "error">;
 }
 
 export function List<T extends ObjectTypeDefinition>({


### PR DESCRIPTION
Stacked on #3827 — review and merge that first; this PR's diff will shrink to sandbox-only once it lands.

Splits the e2e sandbox changes out of #3827 to keep that PR to the library surface.

## What this does

- Moves both sandboxes off the deprecated `filterState` / `linkedFilterComponent` spellings introduced in #3827.
- **Fixes two real bugs in the peopleapp demo**, both pre-existing:
  - `EmployeesWithFilterList` passed `objectType` but no `objectSet`. LINKED_PROPERTY needs an object set to pivot, so `FilterInput` bailed out early and the filter rendered an empty body — no listogram.
  - Both tabs filtered off the where clause. LINKED_PROPERTY filters never appear in a where clause (they narrow via `onEffectiveObjectSet`), so selecting one changed nothing. Both now fetch through the effective object set.
- Both tabs render from one shared catalog covering **every definition kind and 10 of 11 filter components**. TOGGLE is not reachable: it requires a `boolean` property, and `Employee` has none, nor does anything it links to (`lead`/`peeps` are Employee, `primaryOffice` is Office). Documented in the catalog header.

## Notes

- No changeset — both sandbox packages are `private: true`.
- **Not visually verified**: the sandbox needs a Foundry stack on localhost:8080. Typecheck and lint pass, and the data path is wired, but I have not watched a listogram populate. The `primaryOffice`/`occupants` reverse-link pairing is the assumption I would check first.