### PR TITLE
[ScenariosV2] Add conflict detection methods (beta)

### DIFF
--- a/.changeset/scenario-conflicting-objects.md
+++ b/.changeset/scenario-conflicting-objects.md
@@ -1,0 +1,5 @@
+---
+"@osdk/client": minor
+---
+
+Add `getConflictingObjects` (paginated) and `conflictingObjectsAsyncIter` (auto-paginating) methods to `ScenarioClient`. Lets consumers discover which objects have edits that conflict with changes on a scenario's base before merge. Beta — surface may change.

--- a/packages/client/src/scenarios/ScenarioClient.test.ts
+++ b/packages/client/src/scenarios/ScenarioClient.test.ts
@@ -16,6 +16,7 @@
 
 import { Employee } from "@osdk/client.test.ontology";
 import type {
+  ListScenarioConflictingObjectsResponse,
   ListScenarioEditedEntityTypesResponse,
   ListScenarioEditedLinksResponse,
   ListScenarioEditedLinkTypesResponse,
@@ -105,6 +106,110 @@ describe("ScenarioClient methods", () => {
         { $apiName: "Employee", $primaryKey: 50030 },
         { $apiName: "Employee", $primaryKey: 50031 },
       ]);
+    });
+  });
+
+  describe("getConflictingObjects (page form)", () => {
+    it("calls the conflicting objects endpoint and converts object locators", async () => {
+      const scenario = withScenario(client, "ri.actions..scenario.abc");
+      const mock: ListScenarioConflictingObjectsResponse = {
+        data: [
+          { objectTypeApiName: "Employee", primaryKeyValue: 50030 },
+          { objectTypeApiName: "Employee", primaryKeyValue: 50031 },
+        ],
+        nextPageToken: "tok-2",
+      };
+      mockFetchResponse(fetchFunction, mock);
+
+      const result = await scenario.getConflictingObjects(Employee, {
+        pageSize: 1_000,
+        pageToken: "tok-1",
+      });
+
+      expect(fetchFunction).toHaveBeenCalledTimes(1);
+      const url = new URL(
+        fetchFunction.mock.calls[0][0] as string,
+        "https://mock.com",
+      );
+      expect(url.pathname).toMatch(
+        /\/scenarios\/ri\.actions\.\.scenario\.abc\/objects\/Employee\/conflicting$/u,
+      );
+      expect(url.searchParams.get("pageSize")).toBe("1000");
+      expect(url.searchParams.get("pageToken")).toBe("tok-1");
+      expect(url.searchParams.get("preview")).toBe("true");
+      expect(result).toEqual({
+        data: [
+          { $apiName: "Employee", $primaryKey: 50030 },
+          { $apiName: "Employee", $primaryKey: 50031 },
+        ],
+        nextPageToken: "tok-2",
+      });
+    });
+  });
+
+  describe("conflictingObjectsAsyncIter", () => {
+    it("paginates lazily through empty pages without deduplicating", async () => {
+      const scenario = withScenario(client, "ri.actions..scenario.abc");
+      const page1: ListScenarioConflictingObjectsResponse = {
+        data: [{ objectTypeApiName: "Employee", primaryKeyValue: 1 }],
+        nextPageToken: "tok-empty",
+      };
+      const emptyPage: ListScenarioConflictingObjectsResponse = {
+        data: [],
+        nextPageToken: "tok-3",
+      };
+      const page3: ListScenarioConflictingObjectsResponse = {
+        data: [
+          { objectTypeApiName: "Employee", primaryKeyValue: 1 },
+          { objectTypeApiName: "Employee", primaryKeyValue: 2 },
+        ],
+      };
+      mockFetchResponse(fetchFunction, page1);
+      mockFetchResponse(fetchFunction, emptyPage);
+      mockFetchResponse(fetchFunction, page3);
+
+      const iterator = scenario.conflictingObjectsAsyncIter(Employee, {
+        pageSize: 1_000,
+      });
+      expect(fetchFunction).not.toHaveBeenCalled();
+
+      await expect(iterator.next()).resolves.toEqual({
+        done: false,
+        value: { $apiName: "Employee", $primaryKey: 1 },
+      });
+      expect(fetchFunction).toHaveBeenCalledTimes(1);
+
+      await expect(iterator.next()).resolves.toEqual({
+        done: false,
+        value: { $apiName: "Employee", $primaryKey: 1 },
+      });
+      expect(fetchFunction).toHaveBeenCalledTimes(3);
+
+      await expect(iterator.next()).resolves.toEqual({
+        done: false,
+        value: { $apiName: "Employee", $primaryKey: 2 },
+      });
+      await expect(iterator.next()).resolves.toEqual({
+        done: true,
+        value: undefined,
+      });
+      expect(fetchFunction).toHaveBeenCalledTimes(3);
+
+      const firstUrl = new URL(
+        fetchFunction.mock.calls[0][0] as string,
+        "https://mock.com",
+      );
+      const secondUrl = new URL(
+        fetchFunction.mock.calls[1][0] as string,
+        "https://mock.com",
+      );
+      const thirdUrl = new URL(
+        fetchFunction.mock.calls[2][0] as string,
+        "https://mock.com",
+      );
+      expect(firstUrl.searchParams.get("pageSize")).toBe("1000");
+      expect(secondUrl.searchParams.get("pageToken")).toBe("tok-empty");
+      expect(thirdUrl.searchParams.get("pageToken")).toBe("tok-3");
     });
   });
 

--- a/packages/client/src/scenarios/ScenarioClient.ts
+++ b/packages/client/src/scenarios/ScenarioClient.ts
@@ -198,6 +198,13 @@ export interface EXPERIMENTAL_ScenarioClient extends Client {
   /**
    * Stream object identifiers for the objects whose scenario edits conflict with edits to the scenario's base for the
    * given object type. Pages are fetched lazily.
+   *
+   * @example
+   * ```ts
+   * for await (const obj of scenario.conflictingObjectsAsyncIter(Doctor, { pageSize: 500 })) {
+   *   // obj.$primaryKey identifies an object with a conflicting scenario edit
+   * }
+   * ```
    */
   conflictingObjectsAsyncIter<Q extends ObjectTypeDefinition>(
     objectType: Q,

--- a/packages/client/src/scenarios/ScenarioClient.ts
+++ b/packages/client/src/scenarios/ScenarioClient.ts
@@ -184,7 +184,7 @@ export interface EXPERIMENTAL_ScenarioClient extends Client {
   /**
    * Get a page of object identifiers whose scenario edits conflict with edits to the scenario's base for the given
    * object type. Conflict detection may report false positives when object versions change without user-visible data
-   * changes. Results are a point-in-time check, include only objects the caller may view and the backend can resolve,
+   * changes. Results are a point-in-time check, and include only objects the caller may view and the backend can resolve,
    * and may become stale before merge. Use the base client and scenario client to load both object states for review.
    *
    * `pageSize` bounds the number of objects examined, not the number of conflicts returned, so a page may contain fewer
@@ -196,9 +196,8 @@ export interface EXPERIMENTAL_ScenarioClient extends Client {
   ): Promise<ConflictingObjectsPage<Q>>;
 
   /**
-   * Lazily stream identifiers for objects whose scenario edits conflict with edits to the scenario's base. The iterator
-   * follows `nextPageToken` even when a page is short or empty. Results are forwarded in backend order without
-   * client-side deduplication.
+   * Stream object identifiers for the objects whose scenario edits conflict with edits to the scenario's base for the
+   * given object type. Pages are fetched lazily.
    */
   conflictingObjectsAsyncIter<Q extends ObjectTypeDefinition>(
     objectType: Q,

--- a/packages/client/src/scenarios/ScenarioClient.ts
+++ b/packages/client/src/scenarios/ScenarioClient.ts
@@ -71,6 +71,15 @@ export interface EditedLinksPage<
 }
 
 /**
+ * A page of object identifiers whose edits within a scenario conflict with edits to the scenario's base. Returned by
+ * {@link EXPERIMENTAL_ScenarioClient.getConflictingObjects}. Results contain only `$primaryKey` + `$apiName`.
+ */
+export interface ConflictingObjectsPage<Q extends ObjectTypeDefinition> {
+  data: ObjectIdentifiers<Q>[];
+  nextPageToken?: string;
+}
+
+/**
  * A {@link Client} attached to an ontology scenario. All read and write operations performed via this client are
  * scoped to that scenario. `EXPERIMENTAL_ScenarioClient` is a superset of {@link Client}.
  *
@@ -171,6 +180,30 @@ export interface EXPERIMENTAL_ScenarioClient extends Client {
   ): AsyncIterableIterator<
     MinimalDirectedObjectLinkInstance<Q, LINK_TYPE_API_NAME>
   >;
+
+  /**
+   * Get a page of object identifiers whose scenario edits conflict with edits to the scenario's base for the given
+   * object type. Conflict detection may report false positives when object versions change without user-visible data
+   * changes. Results are a point-in-time check, include only objects the caller may view and the backend can resolve,
+   * and may become stale before merge. Use the base client and scenario client to load both object states for review.
+   *
+   * `pageSize` bounds the number of objects examined, not the number of conflicts returned, so a page may contain fewer
+   * results than requested while still returning `nextPageToken`.
+   */
+  getConflictingObjects<Q extends ObjectTypeDefinition>(
+    objectType: Q,
+    options?: { pageSize?: number; pageToken?: string },
+  ): Promise<ConflictingObjectsPage<Q>>;
+
+  /**
+   * Lazily stream identifiers for objects whose scenario edits conflict with edits to the scenario's base. The iterator
+   * follows `nextPageToken` even when a page is short or empty. Results are forwarded in backend order without
+   * client-side deduplication.
+   */
+  conflictingObjectsAsyncIter<Q extends ObjectTypeDefinition>(
+    objectType: Q,
+    options?: { pageSize?: number },
+  ): AsyncIterableIterator<ObjectIdentifiers<Q>>;
 }
 
 export function isScenarioClient(
@@ -384,6 +417,49 @@ export function buildScenarioClient(
     } while (pageToken != null);
   }
 
+  async function getConflictingObjects<Q extends ObjectTypeDefinition>(
+    objectType: Q,
+    options?: { pageSize?: number; pageToken?: string },
+  ): Promise<ConflictingObjectsPage<Q>> {
+    const ontologyRid = await innerCtx.ontologyRid;
+    const response = await OntologyScenarios.listScenarioConflictingObjects(
+      innerCtx,
+      ontologyRid,
+      scenarioRid,
+      objectType.apiName,
+      {
+        pageSize: options?.pageSize,
+        pageToken: options?.pageToken,
+        preview: true,
+      },
+    );
+    const data: ObjectIdentifiers<Q>[] = response.data.map((entry) => ({
+      $apiName: entry.objectTypeApiName as Q["apiName"],
+      $primaryKey: entry.primaryKeyValue as PrimaryKeyType<Q>,
+    }));
+    return {
+      data,
+      nextPageToken: response.nextPageToken,
+    };
+  }
+
+  async function* conflictingObjectsAsyncIter<Q extends ObjectTypeDefinition>(
+    objectType: Q,
+    options?: { pageSize?: number },
+  ): AsyncIterableIterator<ObjectIdentifiers<Q>> {
+    let pageToken: string | undefined;
+    do {
+      const page = await getConflictingObjects(objectType, {
+        pageSize: options?.pageSize,
+        pageToken,
+      });
+      for (const object of page.data) {
+        yield object;
+      }
+      pageToken = page.nextPageToken;
+    } while (pageToken != null);
+  }
+
   return Object.defineProperties(inner, {
     getScenarioReference: {
       value: () => scenarioRid,
@@ -393,6 +469,12 @@ export function buildScenarioClient(
     },
     getEditedEntities: {
       value: getEditedEntities,
+    },
+    getConflictingObjects: {
+      value: getConflictingObjects,
+    },
+    conflictingObjectsAsyncIter: {
+      value: conflictingObjectsAsyncIter,
     },
     editedEntitiesAsyncIter: {
       value: editedEntitiesAsyncIter,

--- a/packages/client/src/scenarios/ScenarioClient.ts
+++ b/packages/client/src/scenarios/ScenarioClient.ts
@@ -470,12 +470,6 @@ export function buildScenarioClient(
     getEditedEntities: {
       value: getEditedEntities,
     },
-    getConflictingObjects: {
-      value: getConflictingObjects,
-    },
-    conflictingObjectsAsyncIter: {
-      value: conflictingObjectsAsyncIter,
-    },
     editedEntitiesAsyncIter: {
       value: editedEntitiesAsyncIter,
     },
@@ -487,6 +481,12 @@ export function buildScenarioClient(
     },
     editedLinksAsyncIter: {
       value: editedLinksAsyncIter,
+    },
+    getConflictingObjects: {
+      value: getConflictingObjects,
+    },
+    conflictingObjectsAsyncIter: {
+      value: conflictingObjectsAsyncIter,
     },
   }) as EXPERIMENTAL_ScenarioClient;
 }


### PR DESCRIPTION
## Description
Following the style of https://github.com/palantir/osdk-ts/pull/3332 and https://github.com/palantir/osdk-ts/pull/3333, we add methods to iterate/paginate over conflicting objects for a given object type.

## Testing
Automated