### PR TITLE
Add experimental $defaultLoadLevel fetch arg, reflected in fetchPageByRid result types

### DIFF
--- a/.changeset/default-load-level.md
+++ b/.changeset/default-load-level.md
@@ -3,4 +3,4 @@
 "@osdk/client": patch
 ---
 
-Add experimental `$defaultLoadLevel` fetch arg that applies reducers and struct main values to every property without listing property IDs. Wired through the object and static-rid load paths.
+Add experimental `$EXPERIMENTAL_defaultLoadLevel` fetch arg that applies reducers and struct main values to every property without listing property IDs. Wired through the object and static-rid load paths.

--- a/.changeset/default-load-level.md
+++ b/.changeset/default-load-level.md
@@ -1,0 +1,6 @@
+---
+"@osdk/api": patch
+"@osdk/client": patch
+---
+
+Add experimental `$defaultLoadLevel` fetch arg that applies reducers and struct main values to every property without listing property IDs. Wired through the object and static-rid load paths.

--- a/etc/api.report.api.md
+++ b/etc/api.report.api.md
@@ -839,6 +839,8 @@ export type FetchLinksPageResult<
     	nextPageToken?: string
 };
 
+// Warning: (ae-forgotten-export) The symbol "PropertyModifierValue" needs to be exported by the entry point index.d.ts
+//
 // @public (undocumented)
 export interface FetchPageArgs<
 	Q extends ObjectOrInterfaceDefinition,
@@ -850,12 +852,12 @@ export interface FetchPageArgs<
 	RDP_KEYS extends string = never,
 	ORDER_BY_OPTIONS extends ObjectSetArgs.OrderByOptions<K> = {},
 	PROPERTY_SECURITIES extends boolean = false,
-	MODIFIERS extends ApplyModifiersArg<Q> = {}
+	MODIFIERS extends ApplyModifiersArg<Q> = {},
+	DEFAULT_LOAD_LEVEL extends PropertyModifierValue | undefined = PropertyModifierValue
 > extends AsyncIterArgs<Q, K, R, A, S, T, RDP_KEYS, ORDER_BY_OPTIONS, PROPERTY_SECURITIES, MODIFIERS> {
     	// (undocumented)
     $applyModifiers?: ApplyModifiersArg<Q> & MODIFIERS & { [P in Exclude<keyof MODIFIERS, PropertyKeys<Q>>] : never };
-    	// Warning: (ae-forgotten-export) The symbol "PropertyModifierValue" needs to be exported by the entry point index.d.ts
-    $defaultLoadLevel?: PropertyModifierValue;
+    	$defaultLoadLevel?: DEFAULT_LOAD_LEVEL;
     	// (undocumented)
     $nextPageToken?: string;
     	// (undocumented)
@@ -865,6 +867,7 @@ export interface FetchPageArgs<
 }
 
 // Warning: (ae-forgotten-export) The symbol "ExtractOptions" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "SelectedKeysWithDefaultLoadLevel" needs to be exported by the entry point index.d.ts
 // Warning: (ae-forgotten-export) The symbol "ModifiersToSelectStrings_2" needs to be exported by the entry point index.d.ts
 //
 // @public
@@ -876,8 +879,9 @@ export type FetchPageResult<
 	T extends boolean = false,
 	ORDER_BY_OPTIONS extends ObjectSetArgs.OrderByOptions<L> = {},
 	PROPERTY_SECURITIES extends boolean = false,
-	MODIFIERS extends ApplyModifiersArg<Q> = {}
-> = PageResult<MaybeScore<Osdk.Instance<Q, ExtractOptions<R, S, T, PROPERTY_SECURITIES>, Exclude<PropertyKeys<Q> extends L ? never : L, keyof MODIFIERS> | ModifiersToSelectStrings_2<MODIFIERS>, {}>, ORDER_BY_OPTIONS>>;
+	MODIFIERS extends ApplyModifiersArg<Q> = {},
+	DEFAULT_LOAD_LEVEL extends PropertyModifierValue | undefined = undefined
+> = PageResult<MaybeScore<Osdk.Instance<Q, ExtractOptions<R, S, T, PROPERTY_SECURITIES>, SelectedKeysWithDefaultLoadLevel<Q, L, MODIFIERS, DEFAULT_LOAD_LEVEL> | ModifiersToSelectStrings_2<MODIFIERS>, {}>, ORDER_BY_OPTIONS>>;
 
 // @public (undocumented)
 export type FlipAxis = "HORIZONTAL" | "VERTICAL" | "UNKNOWN";

--- a/etc/api.report.api.md
+++ b/etc/api.report.api.md
@@ -854,6 +854,8 @@ export interface FetchPageArgs<
 > extends AsyncIterArgs<Q, K, R, A, S, T, RDP_KEYS, ORDER_BY_OPTIONS, PROPERTY_SECURITIES, MODIFIERS> {
     	// (undocumented)
     $applyModifiers?: ApplyModifiersArg<Q> & MODIFIERS & { [P in Exclude<keyof MODIFIERS, PropertyKeys<Q>>] : never };
+    	// Warning: (ae-forgotten-export) The symbol "PropertyModifierValue" needs to be exported by the entry point index.d.ts
+    $defaultLoadLevel?: PropertyModifierValue;
     	// (undocumented)
     $nextPageToken?: string;
     	// (undocumented)

--- a/etc/api.report.api.md
+++ b/etc/api.report.api.md
@@ -857,7 +857,7 @@ export interface FetchPageArgs<
 > extends AsyncIterArgs<Q, K, R, A, S, T, RDP_KEYS, ORDER_BY_OPTIONS, PROPERTY_SECURITIES, MODIFIERS> {
     	// (undocumented)
     $applyModifiers?: ApplyModifiersArg<Q> & MODIFIERS & { [P in Exclude<keyof MODIFIERS, PropertyKeys<Q>>] : never };
-    	$defaultLoadLevel?: DEFAULT_LOAD_LEVEL;
+    	$EXPERIMENTAL_defaultLoadLevel?: DEFAULT_LOAD_LEVEL;
     	// (undocumented)
     $nextPageToken?: string;
     	// (undocumented)

--- a/packages/api/src/experimental/fetchPageByRid.ts
+++ b/packages/api/src/experimental/fetchPageByRid.ts
@@ -23,6 +23,10 @@ import type {
   ObjectOrInterfaceDefinition,
   PropertyKeys,
 } from "../ontology/ObjectOrInterface.js";
+import type {
+  ApplyModifiersArg,
+  PropertyModifierValue,
+} from "../ontology/PropertyModifiers.js";
 import type { Experiment } from "./Experiment.js";
 
 type fetchPageByRidFn = <
@@ -32,11 +36,38 @@ type fetchPageByRidFn = <
   const S extends NullabilityAdherence,
   const T extends boolean,
   const PROPERTY_SECURITIES extends boolean = false,
+  const MODIFIERS extends ApplyModifiersArg<Q> = {},
+  const DEFAULT_LOAD_LEVEL extends PropertyModifierValue | undefined =
+    undefined,
 >(
   objectType: Q,
   rids: string[],
-  options?: FetchPageArgs<Q, L, R, any, S, T, never, {}, PROPERTY_SECURITIES>,
-) => Promise<FetchPageResult<Q, L, R, S, T, {}, PROPERTY_SECURITIES>>;
+  options?: FetchPageArgs<
+    Q,
+    L,
+    R,
+    any,
+    S,
+    T,
+    never,
+    {},
+    PROPERTY_SECURITIES,
+    MODIFIERS,
+    DEFAULT_LOAD_LEVEL
+  >,
+) => Promise<
+  FetchPageResult<
+    Q,
+    L,
+    R,
+    S,
+    T,
+    {},
+    PROPERTY_SECURITIES,
+    MODIFIERS,
+    DEFAULT_LOAD_LEVEL
+  >
+>;
 
 export type FetchPageByRidPayload = {
   fetchPageByRid: fetchPageByRidFn;

--- a/packages/api/src/object/FetchPageArgs.ts
+++ b/packages/api/src/object/FetchPageArgs.ts
@@ -139,7 +139,7 @@ export interface FetchPageArgs<
    *
    * @experimental
    */
-  $defaultLoadLevel?: DEFAULT_LOAD_LEVEL;
+  $EXPERIMENTAL_defaultLoadLevel?: DEFAULT_LOAD_LEVEL;
   /**
    * Ensures paging consistency by freezing the view at the time of query to prevent duplicate or missing items. Setting $snapshot to false ensures that you will always get the latest results.
    * @default false

--- a/packages/api/src/object/FetchPageArgs.ts
+++ b/packages/api/src/object/FetchPageArgs.ts
@@ -19,7 +19,10 @@ import type {
   PropertyKeys,
 } from "../ontology/ObjectOrInterface.js";
 import type { CompileTimeMetadata } from "../ontology/ObjectTypeDefinition.js";
-import type { ApplyModifiersArg } from "../ontology/PropertyModifiers.js";
+import type {
+  ApplyModifiersArg,
+  PropertyModifierValue,
+} from "../ontology/PropertyModifiers.js";
 
 export type NullabilityAdherence = false | "throw" | "drop";
 export namespace NullabilityAdherence {
@@ -127,6 +130,14 @@ export interface FetchPageArgs<
   $pageSize?: number;
   $applyModifiers?: ApplyModifiersArg<Q> &
     MODIFIERS & { [P in Exclude<keyof MODIFIERS, PropertyKeys<Q>>]: never };
+  /**
+   * Best-effort load level applied to every property without listing them:
+   * reducers and struct main values where defined, other properties unchanged.
+   * A per-property `$applyModifiers` entry wins. Does not narrow the result type.
+   *
+   * @experimental
+   */
+  $defaultLoadLevel?: PropertyModifierValue;
   /**
    * Ensures paging consistency by freezing the view at the time of query to prevent duplicate or missing items. Setting $snapshot to false ensures that you will always get the latest results.
    * @default false

--- a/packages/api/src/object/FetchPageArgs.ts
+++ b/packages/api/src/object/FetchPageArgs.ts
@@ -114,6 +114,8 @@ export interface FetchPageArgs<
   ORDER_BY_OPTIONS extends ObjectSetArgs.OrderByOptions<K> = {},
   PROPERTY_SECURITIES extends boolean = false,
   MODIFIERS extends ApplyModifiersArg<Q> = {},
+  DEFAULT_LOAD_LEVEL extends PropertyModifierValue | undefined =
+    PropertyModifierValue,
 > extends AsyncIterArgs<
   Q,
   K,
@@ -133,11 +135,14 @@ export interface FetchPageArgs<
   /**
    * Best-effort load level applied to every property without listing them:
    * reducers and struct main values where defined, other properties unchanged.
-   * A per-property `$applyModifiers` entry wins. Does not narrow the result type.
+   * A per-property `$applyModifiers` entry wins.
+   *
+   * Only reflected in the result type where the signature threads the
+   * `DEFAULT_LOAD_LEVEL` parameter through (currently `fetchPageByRid`).
    *
    * @experimental
    */
-  $defaultLoadLevel?: PropertyModifierValue;
+  $defaultLoadLevel?: DEFAULT_LOAD_LEVEL;
   /**
    * Ensures paging consistency by freezing the view at the time of query to prevent duplicate or missing items. Setting $snapshot to false ensures that you will always get the latest results.
    * @default false

--- a/packages/api/src/object/FetchPageArgs.ts
+++ b/packages/api/src/object/FetchPageArgs.ts
@@ -137,9 +137,6 @@ export interface FetchPageArgs<
    * reducers and struct main values where defined, other properties unchanged.
    * A per-property `$applyModifiers` entry wins.
    *
-   * Only reflected in the result type where the signature threads the
-   * `DEFAULT_LOAD_LEVEL` parameter through (currently `fetchPageByRid`).
-   *
    * @experimental
    */
   $defaultLoadLevel?: DEFAULT_LOAD_LEVEL;

--- a/packages/api/src/object/FetchPageResult.ts
+++ b/packages/api/src/object/FetchPageResult.ts
@@ -19,6 +19,7 @@ import type {
   PropertyKeys,
 } from "../ontology/ObjectOrInterface.js";
 import type {
+  ApplyDefaultLoadLevelToKeys,
   ApplyModifiersArg,
   PropertyModifierValue,
 } from "../ontology/PropertyModifiers.js";
@@ -68,18 +69,41 @@ export type FetchPageResult<
   ORDER_BY_OPTIONS extends ObjectSetArgs.OrderByOptions<L> = {},
   PROPERTY_SECURITIES extends boolean = false,
   MODIFIERS extends ApplyModifiersArg<Q> = {},
+  DEFAULT_LOAD_LEVEL extends PropertyModifierValue | undefined = undefined,
 > = PageResult<
   MaybeScore<
     Osdk.Instance<
       Q,
       ExtractOptions<R, S, T, PROPERTY_SECURITIES>,
-      | Exclude<PropertyKeys<Q> extends L ? never : L, keyof MODIFIERS>
+      | SelectedKeysWithDefaultLoadLevel<Q, L, MODIFIERS, DEFAULT_LOAD_LEVEL>
       | ModifiersToSelectStrings<MODIFIERS>,
       {}
     >,
     ORDER_BY_OPTIONS
   >
 >;
+
+/**
+ * The selected keys of a fetch, as `prop:modifier` select strings where a
+ * default load level applies to them. Keys carrying a per-property
+ * `$applyModifiers` entry are dropped here; they come back through
+ * `ModifiersToSelectStrings`.
+ *
+ * Without a default load level this stays `never` when everything is selected,
+ * which is how `Osdk.Instance` spells "all properties".
+ */
+type SelectedKeysWithDefaultLoadLevel<
+  Q extends ObjectOrInterfaceDefinition,
+  L extends PropertyKeys<Q>,
+  MODIFIERS,
+  DEFAULT_LOAD_LEVEL extends PropertyModifierValue | undefined,
+> = [DEFAULT_LOAD_LEVEL] extends [PropertyModifierValue]
+  ? ApplyDefaultLoadLevelToKeys<
+      Q,
+      Exclude<PropertyKeys<Q> extends L ? PropertyKeys<Q> : L, keyof MODIFIERS>,
+      DEFAULT_LOAD_LEVEL
+    >
+  : Exclude<PropertyKeys<Q> extends L ? never : L, keyof MODIFIERS>;
 
 /**
  * Helper type for converting fetch options into an Osdk object

--- a/packages/api/src/ontology/PropertyModifiers.ts
+++ b/packages/api/src/ontology/PropertyModifiers.ts
@@ -131,6 +131,51 @@ export type ApplyModifiersArg<Q extends ObjectOrInterfaceDefinition> = {
     | "applyReducersAndExtractMainValue";
 };
 
+/**
+ * The modifier a default load level resolves to for a single property.
+ *
+ * A default load level is best-effort: it only applies to properties that
+ * actually support it, and `applyReducersAndExtractMainValue` degrades to the
+ * half of itself that a property supports. Properties that support neither
+ * resolve to `never`.
+ */
+export type ResolveDefaultLoadLevelForProp<
+  Q extends ObjectOrInterfaceDefinition,
+  K extends PropertyKeys<Q>,
+  D extends PropertyModifierValue,
+> = D extends "applyMainValue"
+  ? K extends PropsWithMainValue<Q>
+    ? "applyMainValue"
+    : never
+  : D extends "applyReducers"
+    ? K extends PropsWithReducers<Q>
+      ? "applyReducers"
+      : never
+    : K extends PropsWithBoth<Q>
+      ? "applyReducersAndExtractMainValue"
+      : K extends PropsWithMainValue<Q>
+        ? "applyMainValue"
+        : K extends PropsWithReducers<Q>
+          ? "applyReducers"
+          : never;
+
+/**
+ * Turns a union of property keys into the `prop:modifier` select strings that
+ * `Osdk.Instance` understands, given a default load level. Keys the load level
+ * does not apply to are passed through unchanged.
+ */
+export type ApplyDefaultLoadLevelToKeys<
+  Q extends ObjectOrInterfaceDefinition,
+  K extends PropertyKeys<Q>,
+  D extends PropertyModifierValue | undefined,
+> = [D] extends [PropertyModifierValue]
+  ? K extends unknown
+    ? [ResolveDefaultLoadLevelForProp<Q, K, D>] extends [never]
+      ? K
+      : `${K & string}:${ResolveDefaultLoadLevelForProp<Q, K, D>}`
+    : never
+  : K;
+
 export type ApplyModifiersToProps<
   Q extends ObjectOrInterfaceDefinition,
   MODIFIERS extends Record<string, PropertyModifierValue>,

--- a/packages/client/src/object/fetchPage.ts
+++ b/packages/client/src/object/fetchPage.ts
@@ -249,9 +249,9 @@ export async function fetchStaticRidPage<
     {
       objectSet: {
         type: "static",
-        objects: [...rids],
+        objects: rids as string[],
       },
-      select: args?.$select ? [...args.$select] : [],
+      select: (args?.$select as string[] | undefined) ?? [],
       selectV2: [],
       excludeRid: !args?.$includeRid,
       snapshot: args.$snapshot ?? false,

--- a/packages/client/src/object/fetchPage.ts
+++ b/packages/client/src/object/fetchPage.ts
@@ -37,6 +37,7 @@ import type {
   LoadObjectSetV2MultipleObjectTypesRequest,
   ObjectSet,
   OntologyObjectV2,
+  PropertyLoadLevel,
   SearchJsonQueryV2,
   SearchOrderByV2,
 } from "@osdk/foundry.ontologies";
@@ -51,29 +52,37 @@ import { extractRdpDefinition } from "../util/extractRdpDefinition.js";
 import { resolveBaseObjectSetType } from "../util/objectSetUtils.js";
 
 /**
- * Converts a PropertyModifierValue to the corresponding wire format loadLevel type.
+ * Builds the wire `defaultLoadLevel` for a request from the experimental
+ * `$defaultLoadLevel` arg, or `undefined` when it is not set. Applied to every
+ * property server-side (best-effort) without listing property IDs.
  */
-function modifierToLoadLevelType(
+function buildDefaultLoadLevel(
+  defaultLoadLevel: PropertyModifierValue | undefined,
+): PropertyLoadLevel | undefined {
+  return defaultLoadLevel != null
+    ? modifierToLoadLevel(defaultLoadLevel)
+    : undefined;
+}
+
+/**
+ * Converts a PropertyModifierValue to the corresponding wire format loadLevel.
+ */
+function modifierToLoadLevel(
   modifier: PropertyModifierValue,
-): LoadLevelType {
+): PropertyLoadLevel {
   switch (modifier) {
     case "applyMainValue":
-      return "extractMainValue";
+      return { type: "extractMainValue" };
     case "applyReducers":
-      return "applyReducers";
+      return { type: "applyReducers" };
     case "applyReducersAndExtractMainValue":
-      return "applyReducersAndExtractMainValue";
+      return { type: "applyReducersAndExtractMainValue" };
     default: {
       const _exhaustiveCheck: never = modifier;
       throw new Error(`Unknown modifier: ${_exhaustiveCheck}`);
     }
   }
 }
-
-type LoadLevelType =
-  | "extractMainValue"
-  | "applyReducers"
-  | "applyReducersAndExtractMainValue";
 
 interface SelectV2SimpleProperty {
   type: "property";
@@ -83,7 +92,7 @@ interface SelectV2SimpleProperty {
 interface SelectV2PropertyWithLoadLevel {
   type: "propertyWithLoadLevel";
   propertyIdentifier: SelectV2SimpleProperty;
-  loadLevel: { type: LoadLevelType };
+  loadLevel: PropertyLoadLevel;
 }
 
 type SelectV2Entry = SelectV2SimpleProperty | SelectV2PropertyWithLoadLevel;
@@ -111,7 +120,7 @@ export function buildSelectV2(
         entries.push({
           type: "propertyWithLoadLevel",
           propertyIdentifier: { type: "property", apiName: prop },
-          loadLevel: { type: modifierToLoadLevelType(modifiersMap[prop]) },
+          loadLevel: modifierToLoadLevel(modifiersMap[prop]),
         });
       } else {
         entries.push({ type: "property", apiName: prop });
@@ -123,7 +132,7 @@ export function buildSelectV2(
         entries.push({
           type: "propertyWithLoadLevel",
           propertyIdentifier: { type: "property", apiName: prop },
-          loadLevel: { type: modifierToLoadLevelType(modifiersMap[prop]) },
+          loadLevel: modifierToLoadLevel(modifiersMap[prop]),
         });
       } else {
         entries.push({ type: "property", apiName: prop });
@@ -240,13 +249,15 @@ export async function fetchStaticRidPage<
     {
       objectSet: {
         type: "static",
-        objects: rids as string[],
+        objects: [...rids],
       },
-      select: (args?.$select as string[] | undefined) ?? [],
+      select: args?.$select ? [...args.$select] : [],
+      selectV2: [],
       excludeRid: !args?.$includeRid,
       snapshot: args.$snapshot ?? false,
       loadPropertySecurities: shouldLoadPropertySecurities,
-    } as LoadObjectSetV2MultipleObjectTypesRequest,
+      defaultLoadLevel: buildDefaultLoadLevel(args.$defaultLoadLevel),
+    } satisfies LoadObjectSetV2MultipleObjectTypesRequest,
     client,
     { type: "object", apiName: "" },
   );
@@ -735,6 +746,7 @@ export async function fetchObjectPage<
       loadPropertySecurities: shouldLoadPropertySecurities,
       excludeRid: !args?.$includeRid,
       snapshot: args.$snapshot ?? false,
+      defaultLoadLevel: buildDefaultLoadLevel(args.$defaultLoadLevel),
     },
     client,
     objectType,

--- a/packages/client/src/object/fetchPage.ts
+++ b/packages/client/src/object/fetchPage.ts
@@ -53,7 +53,7 @@ import { resolveBaseObjectSetType } from "../util/objectSetUtils.js";
 
 /**
  * Builds the wire `defaultLoadLevel` for a request from the experimental
- * `$defaultLoadLevel` arg, or `undefined` when it is not set. Applied to every
+ * `$EXPERIMENTAL_defaultLoadLevel` arg, or `undefined` when it is not set. Applied to every
  * property server-side (best-effort) without listing property IDs.
  */
 function buildDefaultLoadLevel(
@@ -256,7 +256,9 @@ export async function fetchStaticRidPage<
       excludeRid: !args?.$includeRid,
       snapshot: args.$snapshot ?? false,
       loadPropertySecurities: shouldLoadPropertySecurities,
-      defaultLoadLevel: buildDefaultLoadLevel(args.$defaultLoadLevel),
+      defaultLoadLevel: buildDefaultLoadLevel(
+        args.$EXPERIMENTAL_defaultLoadLevel,
+      ),
     } satisfies LoadObjectSetV2MultipleObjectTypesRequest,
     client,
     { type: "object", apiName: "" },
@@ -746,7 +748,9 @@ export async function fetchObjectPage<
       loadPropertySecurities: shouldLoadPropertySecurities,
       excludeRid: !args?.$includeRid,
       snapshot: args.$snapshot ?? false,
-      defaultLoadLevel: buildDefaultLoadLevel(args.$defaultLoadLevel),
+      defaultLoadLevel: buildDefaultLoadLevel(
+        args.$EXPERIMENTAL_defaultLoadLevel,
+      ),
     },
     client,
     objectType,

--- a/packages/client/src/objectSet/ObjectSet.test.ts
+++ b/packages/client/src/objectSet/ObjectSet.test.ts
@@ -52,7 +52,7 @@ import { beforeAll, describe, expect, expectTypeOf, it } from "vitest";
 
 import type { Client } from "../Client.js";
 import { createClient } from "../createClient.js";
-import { fetchPage } from "../object/fetchPage.js";
+import { fetchPage, fetchStaticRidPage } from "../object/fetchPage.js";
 import {
   createMockCaptureClient,
   getLastObjectSetRequest,
@@ -1351,6 +1351,56 @@ describe("ObjectSet", () => {
       expect(
         getLastObjectSetRequest(fetchFn) as { snapshot: boolean },
       ).not.toHaveProperty("$snapshot");
+    });
+  });
+
+  describe("$defaultLoadLevel", () => {
+    it("exposes $defaultLoadLevel to client (type)", () => {
+      expectTypeOf<FetchPageArgs<Employee>>().toHaveProperty(
+        "$defaultLoadLevel",
+      );
+    });
+
+    it("omits defaultLoadLevel from the wire request body by default", async () => {
+      const { client, fetchFn } = createMockCaptureClient();
+      await fetchPage(client, Employee, {});
+      expect(getLastObjectSetRequest(fetchFn)).not.toHaveProperty(
+        "defaultLoadLevel",
+      );
+    });
+
+    it("sends defaultLoadLevel for fetchObjectPage with an empty selection", async () => {
+      const { client, fetchFn } = createMockCaptureClient();
+      await fetchPage(client, Employee, {
+        $defaultLoadLevel: "applyReducersAndExtractMainValue",
+      });
+      // No $select => empty selection so the server applies the level to all properties.
+      expect(getLastObjectSetRequest(fetchFn)).toMatchObject({
+        select: [],
+        selectV2: [],
+        defaultLoadLevel: { type: "applyReducersAndExtractMainValue" },
+      });
+    });
+
+    it("maps applyMainValue to the extractMainValue wire discriminant", async () => {
+      const { client, fetchFn } = createMockCaptureClient();
+      await fetchPage(client, Employee, {
+        $defaultLoadLevel: "applyMainValue",
+      });
+      expect(getLastObjectSetRequest(fetchFn)).toMatchObject({
+        defaultLoadLevel: { type: "extractMainValue" },
+      });
+    });
+
+    it("sends defaultLoadLevel for fetchStaticRidPage", async () => {
+      const { client, fetchFn } = createMockCaptureClient();
+      await fetchStaticRidPage(client, [stubData.employee1.__rid], {
+        $defaultLoadLevel: "applyReducers",
+      });
+      expect(getLastObjectSetRequest(fetchFn)).toMatchObject({
+        objectSet: { type: "static" },
+        defaultLoadLevel: { type: "applyReducers" },
+      });
     });
   });
 

--- a/packages/client/src/objectSet/ObjectSet.test.ts
+++ b/packages/client/src/objectSet/ObjectSet.test.ts
@@ -1354,10 +1354,10 @@ describe("ObjectSet", () => {
     });
   });
 
-  describe("$defaultLoadLevel", () => {
-    it("exposes $defaultLoadLevel to client (type)", () => {
+  describe("$EXPERIMENTAL_defaultLoadLevel", () => {
+    it("exposes $EXPERIMENTAL_defaultLoadLevel to client (type)", () => {
       expectTypeOf<FetchPageArgs<Employee>>().toHaveProperty(
-        "$defaultLoadLevel",
+        "$EXPERIMENTAL_defaultLoadLevel",
       );
     });
 
@@ -1372,7 +1372,7 @@ describe("ObjectSet", () => {
     it("sends defaultLoadLevel for fetchObjectPage with an empty selection", async () => {
       const { client, fetchFn } = createMockCaptureClient();
       await fetchPage(client, Employee, {
-        $defaultLoadLevel: "applyReducersAndExtractMainValue",
+        $EXPERIMENTAL_defaultLoadLevel: "applyReducersAndExtractMainValue",
       });
       // No $select => empty selection so the server applies the level to all properties.
       expect(getLastObjectSetRequest(fetchFn)).toMatchObject({
@@ -1385,20 +1385,20 @@ describe("ObjectSet", () => {
     it("maps applyMainValue to the extractMainValue wire discriminant", async () => {
       const { client, fetchFn } = createMockCaptureClient();
       await fetchPage(client, Employee, {
-        $defaultLoadLevel: "applyMainValue",
+        $EXPERIMENTAL_defaultLoadLevel: "applyMainValue",
       });
       expect(getLastObjectSetRequest(fetchFn)).toMatchObject({
         defaultLoadLevel: { type: "extractMainValue" },
       });
     });
 
-    it("accepts $defaultLoadLevel on fetchPageByRid", async () => {
+    it("accepts $EXPERIMENTAL_defaultLoadLevel on fetchPageByRid", async () => {
       const employees = await client(
         __EXPERIMENTAL__NOT_SUPPORTED_YET__fetchPageByRid,
       ).fetchPageByRid(
         Employee,
         [stubData.employee1.__rid, stubData.employee2.__rid],
-        { $defaultLoadLevel: "applyReducers" },
+        { $EXPERIMENTAL_defaultLoadLevel: "applyReducers" },
       );
       expect(employees.data[0].$primaryKey).toBe(stubData.employee1.employeeId);
       expectTypeOf(employees.data[0].employeeProfile).toMatchTypeOf<
@@ -1409,12 +1409,12 @@ describe("ObjectSet", () => {
       >();
     });
 
-    it("accepts $defaultLoadLevel on fetchPageByRidNoType", async () => {
+    it("accepts $EXPERIMENTAL_defaultLoadLevel on fetchPageByRidNoType", async () => {
       const employees = await client(
         __EXPERIMENTAL__NOT_SUPPORTED_YET__fetchPageByRid,
       ).fetchPageByRidNoType(
         [stubData.employee1.__rid, stubData.employee2.__rid],
-        { $defaultLoadLevel: "applyReducers" },
+        { $EXPERIMENTAL_defaultLoadLevel: "applyReducers" },
       );
       expect(employees.data[0].$primaryKey).toBe(stubData.employee1.employeeId);
     });
@@ -1422,7 +1422,7 @@ describe("ObjectSet", () => {
     it("sends defaultLoadLevel for fetchStaticRidPage", async () => {
       const { client, fetchFn } = createMockCaptureClient();
       await fetchStaticRidPage(client, [stubData.employee1.__rid], {
-        $defaultLoadLevel: "applyReducers",
+        $EXPERIMENTAL_defaultLoadLevel: "applyReducers",
       });
       expect(getLastObjectSetRequest(fetchFn)).toMatchObject({
         objectSet: { type: "static" },

--- a/packages/client/src/objectSet/ObjectSet.test.ts
+++ b/packages/client/src/objectSet/ObjectSet.test.ts
@@ -1392,6 +1392,33 @@ describe("ObjectSet", () => {
       });
     });
 
+    it("accepts $defaultLoadLevel on fetchPageByRid", async () => {
+      const employees = await client(
+        __EXPERIMENTAL__NOT_SUPPORTED_YET__fetchPageByRid,
+      ).fetchPageByRid(
+        Employee,
+        [stubData.employee1.__rid, stubData.employee2.__rid],
+        { $defaultLoadLevel: "applyReducers" },
+      );
+      expect(employees.data[0].$primaryKey).toBe(stubData.employee1.employeeId);
+      expectTypeOf(employees.data[0].employeeProfile).toMatchTypeOf<
+        string | undefined
+      >();
+      expectTypeOf(employees.data[0].performanceScores).toMatchTypeOf<
+        number | undefined
+      >();
+    });
+
+    it("accepts $defaultLoadLevel on fetchPageByRidNoType", async () => {
+      const employees = await client(
+        __EXPERIMENTAL__NOT_SUPPORTED_YET__fetchPageByRid,
+      ).fetchPageByRidNoType(
+        [stubData.employee1.__rid, stubData.employee2.__rid],
+        { $defaultLoadLevel: "applyReducers" },
+      );
+      expect(employees.data[0].$primaryKey).toBe(stubData.employee1.employeeId);
+    });
+
     it("sends defaultLoadLevel for fetchStaticRidPage", async () => {
       const { client, fetchFn } = createMockCaptureClient();
       await fetchStaticRidPage(client, [stubData.employee1.__rid], {

--- a/packages/e2e.sandbox.catchall/src/runReducerAndMainValueTest.ts
+++ b/packages/e2e.sandbox.catchall/src/runReducerAndMainValueTest.ts
@@ -32,7 +32,7 @@ export async function runReducerAndMainValueTest(): Promise<void> {
     await client(
       __EXPERIMENTAL__NOT_SUPPORTED_YET__fetchPageByRid,
     ).fetchPageByRid(ReducerTest, [reducerTestObject.data[0].$rid], {
-      $defaultLoadLevel: "applyReducersAndExtractMainValue",
+      $EXPERIMENTAL_defaultLoadLevel: "applyReducersAndExtractMainValue",
       $applyModifiers: { structArray: "applyReducers" },
     })
   ).data[0];

--- a/packages/e2e.sandbox.catchall/src/runReducerAndMainValueTest.ts
+++ b/packages/e2e.sandbox.catchall/src/runReducerAndMainValueTest.ts
@@ -1,16 +1,20 @@
 import { assert } from "console";
 
+import { __EXPERIMENTAL__NOT_SUPPORTED_YET__fetchPageByRid } from "@osdk/api/unstable";
 import { ReducerTest } from "@osdk/e2e.generated.catchall";
 
 import { client } from "./client.js";
 
 export async function runReducerAndMainValueTest(): Promise<void> {
-  const reducerTestObject = await client(ReducerTest).fetchPage({
-    $applyModifiers: {
-      stringArray: "applyReducers",
-      structWithMultipleMain: "applyMainValue",
-    },
-  });
+  const reducerTestObject = await client(ReducerTest)
+    .where({ $primaryKey: "dfb62395-1187-48f7-aac8-da170e00973b" })
+    .fetchPage({
+      $applyModifiers: {
+        stringArray: "applyReducers",
+        structWithMultipleMain: "applyMainValue",
+      },
+      $includeRid: true,
+    });
 
   const reducedValue: string | undefined =
     reducerTestObject.data[0].stringArray;
@@ -23,6 +27,17 @@ export async function runReducerAndMainValueTest(): Promise<void> {
   assert(typeof reducedValue === "string");
   assert(typeof mainValueStruct);
   console.log("Object with reduced values", reducerTestObject.data);
+
+  const allDefault = (
+    await client(
+      __EXPERIMENTAL__NOT_SUPPORTED_YET__fetchPageByRid,
+    ).fetchPageByRid(ReducerTest, [reducerTestObject.data[0].$rid], {
+      $defaultLoadLevel: "applyReducersAndExtractMainValue",
+      $applyModifiers: { structArray: "applyReducers" },
+    })
+  ).data[0];
+  assert(typeof allDefault.stringArray === "string");
+  console.log(JSON.stringify(allDefault, undefined, 2));
 }
 
 void runReducerAndMainValueTest();


### PR DESCRIPTION
Standalone version of #3790 + #3838, rebased onto `main` so it can merge on its own. Same content as those two PRs combined; if #3790 merges first, this can be dropped (or vice versa).

## What

`$defaultLoadLevel` applies reducers and struct main values to every property without having to list property IDs, as an alternative to naming each one in `$applyModifiers`.

**From #3790 (@braedens):**
- `$defaultLoadLevel` on `FetchPageArgs`, carried on the wire through the object and static-rid load paths as `defaultLoadLevel`. `applyMainValue` maps to the `extractMainValue` wire discriminant.

**From #3838:**
- `fetchPageByRid` previously hardcoded the `FetchPageResult` modifiers slot to `{}` and had no load-level slot, so neither `$applyModifiers` nor `$defaultLoadLevel` showed up in the returned object types — you'd pass a load level, the request would carry it, and the result would still be typed as the unmodified struct/array.
- `FetchPageResult` now takes a `DEFAULT_LOAD_LEVEL` parameter and resolves the selected keys through it: reducers and struct main values where a property supports them, with `applyReducersAndExtractMainValue` degrading to whichever half a property supports, and properties supporting neither left untouched. A per-property `$applyModifiers` entry wins over the default level.
- `FetchPageArgs` gains a trailing `DEFAULT_LOAD_LEVEL` slot so the literal can be inferred; its default stays `PropertyModifierValue` so existing unparameterized uses still accept any level.
- New `ResolveDefaultLoadLevelForProp` / `ApplyDefaultLoadLevelToKeys` helpers in `PropertyModifiers.ts`.

The object-set `fetchPage` / `fetchPageWithErrors` signatures are deliberately untouched, so regular `fetchPage` result types are unchanged. `fetchPageByRidNoType` is untouched too — `Q` is the base union there, so the helpers have nothing to resolve against.

## Tests

`packages/client/src/objectSet/ObjectSet.test.ts` covers the wire body (omitted by default, all three levels, the `extractMainValue` mapping, the static-rid path) and the result-type pass-through on `fetchPageByRid` / `fetchPageByRidNoType` against the real generated `Employee` (`employeeProfile` has `mainValue: ['bio']`, `performanceScores` has reducers). `runReducerAndMainValueTest.ts` exercises it against a real stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)