### PR TITLE
Recursively convert block data for security policy

### DIFF
--- a/.changeset/thick-cups-think.md
+++ b/.changeset/thick-cups-think.md
@@ -1,0 +1,5 @@
+---
+"@osdk/maker-experimental": patch
+---
+
+Convert recursive security conditions

--- a/packages/maker-experimental/src/conversion/toMarketplace/convertActionValidation.ts
+++ b/packages/maker-experimental/src/conversion/toMarketplace/convertActionValidation.ts
@@ -307,7 +307,7 @@ function convertStructFieldValidations(
             display: {
               renderHint:
                 configuration.renderHint ??
-                (allowedValues.type === "oneOf"
+                (allowedValues.type === "oneOf" || fieldType.type === "boolean"
                   ? { type: "dropdown", dropdown: {} }
                   : renderHintFromActionParameterType(
                       actionParameterType,

--- a/packages/maker-experimental/src/conversion/toMarketplace/convertDatasourceDefinition.ts
+++ b/packages/maker-experimental/src/conversion/toMarketplace/convertDatasourceDefinition.ts
@@ -21,6 +21,7 @@ import type {
   PropertySecurityGroups,
   PropertyTypeMappingInfo,
   RetentionPolicy,
+  SecurityGroupComparisonValue,
   SecurityGroupGranularCondition,
   SecurityGroupGranularSecurityDefinition,
 } from "@osdk/client.unstable";
@@ -390,9 +391,15 @@ function convertSecurityCondition(
             ),
           },
         };
-      } else {
-        return condition;
       }
+      return {
+        type: "and",
+        and: {
+          conditions: condition.and.conditions.map((c) =>
+            convertSecurityCondition(c, ridGenerator, objectTypeApiName),
+          ),
+        },
+      };
     case "or":
       if ("conditions" in condition) {
         return {
@@ -403,20 +410,63 @@ function convertSecurityCondition(
             ),
           },
         };
-      } else {
-        return condition;
       }
+      return {
+        type: "or",
+        or: {
+          conditions: condition.or.conditions.map((c) =>
+            convertSecurityCondition(c, ridGenerator, objectTypeApiName),
+          ),
+        },
+      };
+    case "not":
+      return {
+        type: "not",
+        not: {
+          condition: convertSecurityCondition(
+            condition.not.condition,
+            ridGenerator,
+            objectTypeApiName,
+          ),
+        },
+      };
+    case "markings":
+      return {
+        type: "markings",
+        markings: {
+          property: convertSecurityProperty(
+            condition.markings.property,
+            ridGenerator,
+            objectTypeApiName,
+          ),
+        },
+      };
+    case "comparison":
+      return {
+        type: "comparison",
+        comparison: {
+          ...condition.comparison,
+          left: convertSecurityComparisonValue(
+            condition.comparison.left,
+            ridGenerator,
+            objectTypeApiName,
+          ),
+          right: convertSecurityComparisonValue(
+            condition.comparison.right,
+            ridGenerator,
+            objectTypeApiName,
+          ),
+        },
+      };
     case "markingProperty":
       return {
         type: "markings",
         markings: {
-          property:
-            ridGenerator && objectTypeApiName
-              ? ridGenerator.generatePropertyRid(
-                  condition.property,
-                  objectTypeApiName,
-                )
-              : condition.property,
+          property: convertSecurityProperty(
+            condition.property,
+            ridGenerator,
+            objectTypeApiName,
+          ),
         },
       };
     case "groupProperty":
@@ -433,13 +483,11 @@ function convertSecurityCondition(
           },
           right: {
             type: "property",
-            property:
-              ridGenerator && objectTypeApiName
-                ? ridGenerator.generatePropertyRid(
-                    condition.property,
-                    objectTypeApiName,
-                  )
-                : condition.property,
+            property: convertSecurityProperty(
+              condition.property,
+              ridGenerator,
+              objectTypeApiName,
+            ),
           },
         },
       };
@@ -468,6 +516,34 @@ function convertSecurityCondition(
     default:
       return condition;
   }
+}
+
+function convertSecurityComparisonValue(
+  value: SecurityGroupComparisonValue,
+  ridGenerator?: OntologyRidGenerator,
+  objectTypeApiName?: string,
+): SecurityGroupComparisonValue {
+  if (value.type !== "property") {
+    return value;
+  }
+  return {
+    type: "property",
+    property: convertSecurityProperty(
+      value.property,
+      ridGenerator,
+      objectTypeApiName,
+    ),
+  };
+}
+
+function convertSecurityProperty(
+  property: string,
+  ridGenerator?: OntologyRidGenerator,
+  objectTypeApiName?: string,
+): string {
+  return ridGenerator && objectTypeApiName
+    ? ridGenerator.generatePropertyRid(property, objectTypeApiName)
+    : property;
 }
 
 /**

--- a/packages/maker-experimental/src/conversion/toMarketplace/shapeExtractors/IrShapeExtractor.ts
+++ b/packages/maker-experimental/src/conversion/toMarketplace/shapeExtractors/IrShapeExtractor.ts
@@ -827,6 +827,13 @@ function getPropertiesForDatasource(datasourceDef: {
   return new Set(propertyMapping ? Object.keys(propertyMapping) : []);
 }
 
+function getMarkingType(type: Type): "CBAC" | "MANDATORY" | undefined {
+  if (type.type === "array") {
+    return getMarkingType(type.array.subtype);
+  }
+  return type.type === "marking" ? type.marking.markingType : undefined;
+}
+
 /**
  * Extract marking shapes from the ontology block data.
  * Port of Java's MarkingShapeExtractor.getMarkingShapes().
@@ -854,11 +861,8 @@ function getMarkingShapes(
     for (const [propertyRid, propertyType] of Object.entries(
       objectType.objectType.propertyTypes,
     )) {
-      if (propertyType.type.type === "marking") {
-        const markingData = (
-          propertyType.type as { marking?: { markingType?: string } }
-        ).marking;
-        const markingType = markingData?.markingType;
+      const markingType = getMarkingType(propertyType.type);
+      if (markingType) {
         const propertyApiName =
           propertyType.apiName ?? propertyType.displayMetadata?.displayName;
         if (propertyApiName) {


### PR DESCRIPTION
1. Convert all nested conditions in security policies
2. Extract marking shape from arrays
3. Fix a default render hint for struct props