### PR TITLE
Revert @osdk/e2e.sandbox.catchall from vitest v4 to v3.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -333,12 +333,9 @@ jobs:
       # worker RPC timeout ("Timeout calling onTaskUpdate") on the slowest matrix
       # leg. Running it isolated keeps the runner uncontended for it.
       # The other --filter exclusions are Vite 7+/Storybook packages that need Node 20+.
-      # @osdk/e2e.sandbox.catchall is excluded because its only test file
-      # (src/integration-tests/e2e.test.ts) drives the local-ontology integration
-      # harness, and the current vitest version is not fully supported on Node 18.
       - name: Test (excluding Vite 7/Storybook packages on Node 18, and react-components)
         if: matrix.node == 18
-        run: pnpm exec turbo run test --filter="!@osdk/react-components" --filter="!@osdk/create-app.template.*" --filter="!@osdk/create-widget.template.*" --filter="!@osdk/widget.vite-plugin" --filter="!@osdk/examples.*" --filter="!@psdk/examples.*" --filter="!@osdk/e2e.sandbox.todowidget" --filter="!@osdk/ontology-explorer-app" --filter="!@osdk/react-components-storybook" --filter="!@osdk/e2e.sandbox.catchall"
+        run: pnpm exec turbo run test --filter="!@osdk/react-components" --filter="!@osdk/create-app.template.*" --filter="!@osdk/create-widget.template.*" --filter="!@osdk/widget.vite-plugin" --filter="!@osdk/examples.*" --filter="!@psdk/examples.*" --filter="!@osdk/e2e.sandbox.todowidget" --filter="!@osdk/ontology-explorer-app" --filter="!@osdk/react-components-storybook"
 
       - name: Test (excluding react-components)
         if: matrix.node != 18

--- a/packages/e2e.sandbox.catchall/package.json
+++ b/packages/e2e.sandbox.catchall/package.json
@@ -58,7 +58,7 @@
     "@types/node": "^18.19.124",
     "ts-expect": "^1.3.0",
     "typescript": "~5.5.4",
-    "vitest": "^4.1.10"
+    "vitest": "^3.2.4"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/e2e.sandbox.catchall/src/integration-tests/e2e.test.ts
+++ b/packages/e2e.sandbox.catchall/src/integration-tests/e2e.test.ts
@@ -10,9 +10,9 @@ import {
   Todo,
 } from "@osdk/e2e.generated.catchall";
 import { checkFoundryCliVersion } from "@osdk/integration-testing";
-import { expect } from "vitest";
+import { beforeEach, describe, expect } from "vitest";
 
-import { createSeed, test } from "./test.fixture.js";
+import { createSeed, type IntegrationFixtures, test } from "./test.fixture.js";
 
 const foundryProbeResult = await checkFoundryCliVersion();
 
@@ -57,10 +57,10 @@ const baseSeed = createSeed((seed) => {
   return { alice, bob, charlie, todoItem1, todoItem2, game1, book1 };
 });
 
-test.describe.runIf(foundryProbeResult.type === "installed")(
+describe.runIf(foundryProbeResult.type === "installed")(
   "Local ontology integration tests",
   () => {
-    test.beforeEach(async ({ seed }) => {
+    beforeEach<IntegrationFixtures>(async ({ seed }) => {
       await seed.set(baseSeed.output);
     });
     test("List all people", async ({ client }) => {

--- a/packages/e2e.sandbox.catchall/src/integration-tests/test.fixture.ts
+++ b/packages/e2e.sandbox.catchall/src/integration-tests/test.fixture.ts
@@ -11,7 +11,7 @@ import {
   type SeedFunction,
   createSeedWithMetadata,
 } from "@osdk/seed-helpers";
-import { test as baseTest, type TestAPI } from "vitest";
+import { test as baseTest } from "vitest";
 
 const filteredObjectTypes = new Set(["Person", "Todo", "Game", "Book"]);
 const filteredInterfaceTypes = new Set(["LibraryItem"]);
@@ -34,35 +34,44 @@ const modifiedMetadata: Ontologies.OntologyFullMetadata = {
   sharedPropertyTypes: {},
 };
 
+export interface IntegrationFixtures {
+  server: IntegrationServer;
+  client: IntegrationClient;
+  seed: SeedClient;
+}
+
 /**
  * This is a fixture that injects server, seed and client to the testing functions contexts.
  * We need to initialize the server and client before the tests can consume them, and this
  * fixture ensures that all of the dependencies are ready before we run the tests.
  */
-export const test = baseTest
-  // eslint-disable no-empty-pattern
-  .extend("server", { scope: "worker" }, async ({}, { onCleanup }) => {
-    const server = await createIntegrationServer({
-      metadata: modifiedMetadata,
-    });
-    onCleanup(async () => await server.stop());
-    await server.start();
-    return server;
-  })
-  .extend(
-    "seed",
+export const test = baseTest.extend<IntegrationFixtures>({
+  server: [
+    // eslint-disable-next-line no-empty-pattern
+    async ({}, use) => {
+      const server = await createIntegrationServer({
+        metadata: modifiedMetadata,
+      });
+      // `stop()` runs even if `start()` throws, so a partially started server
+      // never leaks its subprocess or its `.test-run-*` directory.
+      try {
+        await server.start();
+        await use(server);
+      } finally {
+        await server.stop();
+      }
+    },
     { scope: "worker" },
-    async ({ server }) => await server.getSeedClient(),
-  )
-  .extend(
-    "client",
+  ],
+  seed: [
+    async ({ server }, use) => await use(await server.getSeedClient()),
     { scope: "worker" },
-    async ({ server }) => await server.getClient(),
-  ) as TestAPI<{
-  server: IntegrationServer;
-  client: IntegrationClient;
-  seed: SeedClient;
-}>;
+  ],
+  client: [
+    async ({ server }, use) => await use(await server.getClient()),
+    { scope: "worker" },
+  ],
+});
 
 export const createSeed: <T>(fn: SeedFunction<T>) => {
   output: SeedOutput;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3423,8 +3423,8 @@ importers:
         specifier: ~5.5.4
         version: 5.5.4
       vitest:
-        specifier: ^4.1.10
-        version: 4.1.10(@opentelemetry/api@1.9.0)(@types/node@18.19.124)(@vitest/coverage-v8@3.2.4(@vitest/browser@3.2.4)(vitest@3.2.4))(happy-dom@20.8.9)(jsdom@20.0.3(canvas@2.11.2))(msw@2.11.1(@types/node@18.19.124)(typescript@5.5.4))(vite@8.0.8(@types/node@18.19.124)(esbuild@0.27.3)(jiti@2.5.1)(less@4.5.1)(sass-embedded@1.97.3)(sass@1.97.3)(stylus@0.62.0)(terser@5.44.0)(tsx@4.20.5)(yaml@2.9.0))
+        specifier: ^3.2.4
+        version: 3.2.6(@types/debug@4.1.12)(@types/node@18.19.124)(@vitest/browser@3.2.6)(happy-dom@20.8.9)(jiti@2.5.1)(jsdom@20.0.3(canvas@2.11.2))(less@4.5.1)(lightningcss@1.32.0)(msw@2.11.1(@types/node@18.19.124)(typescript@5.5.4))(sass-embedded@1.97.3)(sass@1.97.3)(stylus@0.62.0)(terser@5.44.0)(tsx@4.20.5)(yaml@2.9.0)
 
   packages/e2e.sandbox.oauth:
     dependencies:
@@ -12397,9 +12397,6 @@ packages:
   '@vitest/expect@3.2.6':
     resolution: {integrity: sha512-1+7q9BtaKzEmO+fmNT3kYvoNn5Y71XWAx2Q5HRim4tTVRQVRv4uJFAQ5FbK0OPUeNP/WmVCpxYxoJdvuHVjzBQ==}
 
-  '@vitest/expect@4.1.10':
-    resolution: {integrity: sha512-YsCn+qAk1GWjQOWFEsEcL2gNQ0zmVmQu3T03qP6UyjhtmdtwtbuI+DASn/7iQB3HGTXkdBwGddzxPlmiql5vlA==}
-
   '@vitest/expect@4.1.9':
     resolution: {integrity: sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==}
 
@@ -12419,17 +12416,6 @@ packages:
     peerDependencies:
       msw: ^2.4.9
       vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
-    peerDependenciesMeta:
-      msw:
-        optional: true
-      vite:
-        optional: true
-
-  '@vitest/mocker@4.1.10':
-    resolution: {integrity: sha512-v0xaezt+DKEmKfaxg133ldzADrwLGd7Ze1MfQQTYfvs8OqZIwbxyxaYURivwV7sWy5fqn3rH5uOrSp07bp44Ow==}
-    peerDependencies:
-      msw: ^2.4.9
-      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
     peerDependenciesMeta:
       msw:
         optional: true
@@ -12477,9 +12463,6 @@ packages:
   '@vitest/snapshot@3.2.6':
     resolution: {integrity: sha512-H+ZjNTWGpObenh0YnlBctAPnJSI20P81PL8BPzWpx54YXLLTm8hEsWawtcYLMrwvpK48hGxLLbCS+1KRXhsKhw==}
 
-  '@vitest/snapshot@4.1.10':
-    resolution: {integrity: sha512-xRkfOT1qpTAi/Ti4Y1LtfRc3kEuqxGw59eN2jN9pRWMtS/XDevekhcFSqvQqjUNGksfjMJu3Y+oJ+4Ypn2OaJw==}
-
   '@vitest/snapshot@4.1.9':
     resolution: {integrity: sha512-Jc7RKGNBo8Z28WYIm0Niej4xdSPByRf6mU58VpHQkd6Zh05rlnA+twjbK5HyeIGHxrzsc3mJgS43uM0CZKzaIA==}
 
@@ -12488,9 +12471,6 @@ packages:
 
   '@vitest/spy@3.2.6':
     resolution: {integrity: sha512-oq6BbH68WzcWmwtBrU9nqLeaXTR4XwJF7FSLkKEZo4i6eoXcrxjcwSuTvWBIRUTC6VC72nXYunzqgZA+IKdtxg==}
-
-  '@vitest/spy@4.1.10':
-    resolution: {integrity: sha512-PLf/Ugvoq5wO/b4rwYCR1h2PSIdXz7wnkQFMiUpLdtM7l6pqVFcQIBEHyT1+l+cj7mNwAfZHzqXqDyjvOuwbDw==}
 
   '@vitest/spy@4.1.9':
     resolution: {integrity: sha512-fHpsS6mIi+PiEW+vcRVOMkX1oSaPKne3VOclSFICPcGOmfKgXPU5iAah+wcNcj2xPrCCmfq99IDGf+EojhhvhA==}
@@ -21596,47 +21576,6 @@ packages:
       jsdom:
         optional: true
 
-  vitest@4.1.10:
-    resolution: {integrity: sha512-R9jUTe5S4Qb0HCd4TNqpC7oGcrMssMRGXLW80ubjWsW9VH5GF8y1Y0SFLY9AbqSk6nt0PnOx4H4WNJYZ13GUPw==}
-    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
-    hasBin: true
-    peerDependencies:
-      '@edge-runtime/vm': '*'
-      '@opentelemetry/api': ^1.9.0
-      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
-      '@vitest/browser-playwright': 4.1.10
-      '@vitest/browser-preview': 4.1.10
-      '@vitest/browser-webdriverio': 4.1.10
-      '@vitest/coverage-istanbul': 4.1.10
-      '@vitest/coverage-v8': 4.1.10
-      '@vitest/ui': 4.1.10
-      happy-dom: '*'
-      jsdom: '*'
-      vite: ^6.0.0 || ^7.0.0 || ^8.0.0
-    peerDependenciesMeta:
-      '@edge-runtime/vm':
-        optional: true
-      '@opentelemetry/api':
-        optional: true
-      '@types/node':
-        optional: true
-      '@vitest/browser-playwright':
-        optional: true
-      '@vitest/browser-preview':
-        optional: true
-      '@vitest/browser-webdriverio':
-        optional: true
-      '@vitest/coverage-istanbul':
-        optional: true
-      '@vitest/coverage-v8':
-        optional: true
-      '@vitest/ui':
-        optional: true
-      happy-dom:
-        optional: true
-      jsdom:
-        optional: true
-
   vitest@4.1.9:
     resolution: {integrity: sha512-nE3/LEyc0z87uHYLZebqCUOaJr2hdtuPp7BQ4BosVFnfltxgAvMG08NyrSGlPpOUWvR27c5flSmYFTNr78L9GQ==}
     engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
@@ -30432,6 +30371,26 @@ snapshots:
       - vite
     optional: true
 
+  '@vitest/browser@3.2.6(msw@2.11.1(@types/node@18.19.124)(typescript@5.5.4))(playwright@1.60.0)(vite@7.3.2(@types/node@18.19.124)(jiti@2.5.1)(less@4.5.1)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(stylus@0.62.0)(terser@5.44.0)(tsx@4.20.5)(yaml@2.9.0))(vitest@3.2.6)':
+    dependencies:
+      '@testing-library/dom': 10.4.0
+      '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.0)
+      '@vitest/mocker': 3.2.6(msw@2.11.1(@types/node@18.19.124)(typescript@5.5.4))(vite@7.3.2(@types/node@18.19.124)(jiti@2.5.1)(less@4.5.1)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(stylus@0.62.0)(terser@5.44.0)(tsx@4.20.5)(yaml@2.9.0))
+      '@vitest/utils': 3.2.6
+      magic-string: 0.30.19
+      sirv: 3.0.2
+      tinyrainbow: 2.0.0
+      vitest: 3.2.6(@types/debug@4.1.12)(@types/node@18.19.124)(@vitest/browser@3.2.6)(happy-dom@20.8.9)(jiti@2.5.1)(jsdom@20.0.3(canvas@2.11.2))(less@4.5.1)(lightningcss@1.32.0)(msw@2.11.1(@types/node@18.19.124)(typescript@5.5.4))(sass-embedded@1.97.3)(sass@1.97.3)(stylus@0.62.0)(terser@5.44.0)(tsx@4.20.5)(yaml@2.9.0)
+      ws: 8.21.0
+    optionalDependencies:
+      playwright: 1.60.0
+    transitivePeerDependencies:
+      - bufferutil
+      - msw
+      - utf-8-validate
+      - vite
+    optional: true
+
   '@vitest/browser@3.2.6(msw@2.11.1(@types/node@20.19.13)(typescript@5.5.4))(playwright@1.60.0)(vite@6.4.2(@types/node@20.19.13)(jiti@2.5.1)(less@4.5.1)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(stylus@0.62.0)(terser@5.44.0)(tsx@4.20.5)(yaml@2.9.0))(vitest@3.2.6)':
     dependencies:
       '@testing-library/dom': 10.4.0
@@ -30507,15 +30466,6 @@ snapshots:
       '@vitest/utils': 3.2.6
       chai: 5.2.0
       tinyrainbow: 2.0.0
-
-  '@vitest/expect@4.1.10':
-    dependencies:
-      '@standard-schema/spec': 1.1.0
-      '@types/chai': 5.2.2
-      '@vitest/spy': 4.1.10
-      '@vitest/utils': 4.1.10
-      chai: 6.2.2
-      tinyrainbow: 3.1.0
 
   '@vitest/expect@4.1.9':
     dependencies:
@@ -30631,6 +30581,25 @@ snapshots:
       vite: 8.0.8(@types/node@26.1.1)(esbuild@0.27.3)(jiti@2.5.1)(less@4.5.1)(sass-embedded@1.97.3)(sass@1.97.3)(stylus@0.62.0)(terser@5.44.0)(tsx@4.20.5)(yaml@2.9.0)
     optional: true
 
+  '@vitest/mocker@3.2.6(msw@2.11.1(@types/node@18.19.124)(typescript@5.5.4))(vite@6.4.2(@types/node@18.19.124)(jiti@2.5.1)(less@4.5.1)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(stylus@0.62.0)(terser@5.44.0)(tsx@4.20.5)(yaml@2.9.0))':
+    dependencies:
+      '@vitest/spy': 3.2.6
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      msw: 2.11.1(@types/node@18.19.124)(typescript@5.5.4)
+      vite: 6.4.2(@types/node@18.19.124)(jiti@2.5.1)(less@4.5.1)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(stylus@0.62.0)(terser@5.44.0)(tsx@4.20.5)(yaml@2.9.0)
+
+  '@vitest/mocker@3.2.6(msw@2.11.1(@types/node@18.19.124)(typescript@5.5.4))(vite@7.3.2(@types/node@18.19.124)(jiti@2.5.1)(less@4.5.1)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(stylus@0.62.0)(terser@5.44.0)(tsx@4.20.5)(yaml@2.9.0))':
+    dependencies:
+      '@vitest/spy': 3.2.6
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      msw: 2.11.1(@types/node@18.19.124)(typescript@5.5.4)
+      vite: 7.3.2(@types/node@18.19.124)(jiti@2.5.1)(less@4.5.1)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(stylus@0.62.0)(terser@5.44.0)(tsx@4.20.5)(yaml@2.9.0)
+    optional: true
+
   '@vitest/mocker@3.2.6(msw@2.11.1(@types/node@20.19.13)(typescript@5.5.4))(vite@6.4.2(@types/node@20.19.13)(jiti@2.5.1)(less@4.5.1)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(stylus@0.62.0)(terser@5.44.0)(tsx@4.20.5)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 3.2.6
@@ -30648,15 +30617,6 @@ snapshots:
     optionalDependencies:
       msw: 2.11.1(@types/node@26.1.1)(typescript@5.5.4)
       vite: 6.4.2(@types/node@26.1.1)(jiti@2.5.1)(less@4.5.1)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(stylus@0.62.0)(terser@5.44.0)(tsx@4.20.5)(yaml@2.9.0)
-
-  '@vitest/mocker@4.1.10(msw@2.11.1(@types/node@18.19.124)(typescript@5.5.4))(vite@8.0.8(@types/node@18.19.124)(esbuild@0.27.3)(jiti@2.5.1)(less@4.5.1)(sass-embedded@1.97.3)(sass@1.97.3)(stylus@0.62.0)(terser@5.44.0)(tsx@4.20.5)(yaml@2.9.0))':
-    dependencies:
-      '@vitest/spy': 4.1.10
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      msw: 2.11.1(@types/node@18.19.124)(typescript@5.5.4)
-      vite: 8.0.8(@types/node@18.19.124)(esbuild@0.27.3)(jiti@2.5.1)(less@4.5.1)(sass-embedded@1.97.3)(sass@1.97.3)(stylus@0.62.0)(terser@5.44.0)(tsx@4.20.5)(yaml@2.9.0)
 
   '@vitest/mocker@4.1.9(msw@2.11.1(@types/node@26.1.1)(typescript@5.5.4))(vite@8.0.8(@types/node@26.1.1)(esbuild@0.27.3)(jiti@2.5.1)(less@4.5.1)(sass-embedded@1.97.3)(sass@1.97.3)(stylus@0.62.0)(terser@5.44.0)(tsx@4.20.5)(yaml@2.9.0))':
     dependencies:
@@ -30678,6 +30638,7 @@ snapshots:
   '@vitest/pretty-format@4.1.10':
     dependencies:
       tinyrainbow: 3.1.0
+    optional: true
 
   '@vitest/pretty-format@4.1.9':
     dependencies:
@@ -30699,6 +30660,7 @@ snapshots:
     dependencies:
       '@vitest/utils': 4.1.10
       pathe: 2.0.3
+    optional: true
 
   '@vitest/runner@4.1.9':
     dependencies:
@@ -30717,13 +30679,6 @@ snapshots:
       magic-string: 0.30.21
       pathe: 2.0.3
 
-  '@vitest/snapshot@4.1.10':
-    dependencies:
-      '@vitest/pretty-format': 4.1.10
-      '@vitest/utils': 4.1.10
-      magic-string: 0.30.21
-      pathe: 2.0.3
-
   '@vitest/snapshot@4.1.9':
     dependencies:
       '@vitest/pretty-format': 4.1.9
@@ -30738,8 +30693,6 @@ snapshots:
   '@vitest/spy@3.2.6':
     dependencies:
       tinyspy: 4.0.3
-
-  '@vitest/spy@4.1.10': {}
 
   '@vitest/spy@4.1.9': {}
 
@@ -30760,6 +30713,7 @@ snapshots:
       '@vitest/pretty-format': 4.1.10
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
+    optional: true
 
   '@vitest/utils@4.1.9':
     dependencies:
@@ -42335,26 +42289,6 @@ snapshots:
       tsx: 4.20.5
       yaml: 2.9.0
 
-  vite@8.0.8(@types/node@18.19.124)(esbuild@0.27.3)(jiti@2.5.1)(less@4.5.1)(sass-embedded@1.97.3)(sass@1.97.3)(stylus@0.62.0)(terser@5.44.0)(tsx@4.20.5)(yaml@2.9.0):
-    dependencies:
-      lightningcss: 1.32.0
-      picomatch: 4.0.4
-      postcss: 8.5.9
-      rolldown: 1.0.0-rc.15
-      tinyglobby: 0.2.15
-    optionalDependencies:
-      '@types/node': 18.19.124
-      esbuild: 0.27.3
-      fsevents: 2.3.3
-      jiti: 2.5.1
-      less: 4.5.1
-      sass: 1.97.3
-      sass-embedded: 1.97.3
-      stylus: 0.62.0
-      terser: 5.44.0
-      tsx: 4.20.5
-      yaml: 2.9.0
-
   vite@8.0.8(@types/node@26.1.1)(esbuild@0.27.3)(jiti@2.5.1)(less@4.5.1)(sass-embedded@1.97.3)(sass@1.97.3)(stylus@0.62.0)(terser@5.44.0)(tsx@4.20.5)(yaml@2.9.0):
     dependencies:
       lightningcss: 1.32.0
@@ -42600,6 +42534,51 @@ snapshots:
       - tsx
       - yaml
 
+  vitest@3.2.6(@types/debug@4.1.12)(@types/node@18.19.124)(@vitest/browser@3.2.6)(happy-dom@20.8.9)(jiti@2.5.1)(jsdom@20.0.3(canvas@2.11.2))(less@4.5.1)(lightningcss@1.32.0)(msw@2.11.1(@types/node@18.19.124)(typescript@5.5.4))(sass-embedded@1.97.3)(sass@1.97.3)(stylus@0.62.0)(terser@5.44.0)(tsx@4.20.5)(yaml@2.9.0):
+    dependencies:
+      '@types/chai': 5.2.2
+      '@vitest/expect': 3.2.6
+      '@vitest/mocker': 3.2.6(msw@2.11.1(@types/node@18.19.124)(typescript@5.5.4))(vite@6.4.2(@types/node@18.19.124)(jiti@2.5.1)(less@4.5.1)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(stylus@0.62.0)(terser@5.44.0)(tsx@4.20.5)(yaml@2.9.0))
+      '@vitest/pretty-format': 3.2.6
+      '@vitest/runner': 3.2.6
+      '@vitest/snapshot': 3.2.6
+      '@vitest/spy': 3.2.6
+      '@vitest/utils': 3.2.6
+      chai: 5.2.0
+      debug: 4.4.3
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      pathe: 2.0.3
+      picomatch: 4.0.4
+      std-env: 3.9.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.15
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 6.4.2(@types/node@18.19.124)(jiti@2.5.1)(less@4.5.1)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(stylus@0.62.0)(terser@5.44.0)(tsx@4.20.5)(yaml@2.9.0)
+      vite-node: 3.2.4(@types/node@18.19.124)(jiti@2.5.1)(less@4.5.1)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(stylus@0.62.0)(terser@5.44.0)(tsx@4.20.5)(yaml@2.9.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/debug': 4.1.12
+      '@types/node': 18.19.124
+      '@vitest/browser': 3.2.6(msw@2.11.1(@types/node@18.19.124)(typescript@5.5.4))(playwright@1.60.0)(vite@7.3.2(@types/node@18.19.124)(jiti@2.5.1)(less@4.5.1)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(stylus@0.62.0)(terser@5.44.0)(tsx@4.20.5)(yaml@2.9.0))(vitest@3.2.6)
+      happy-dom: 20.8.9
+      jsdom: 20.0.3(canvas@2.11.2)
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
   vitest@3.2.6(@types/debug@4.1.12)(@types/node@20.19.13)(@vitest/browser@3.2.6)(happy-dom@20.8.9)(jiti@2.5.1)(jsdom@20.0.3(canvas@2.11.2))(less@4.5.1)(lightningcss@1.32.0)(msw@2.11.1(@types/node@20.19.13)(typescript@5.5.4))(sass-embedded@1.97.3)(sass@1.97.3)(stylus@0.62.0)(terser@5.44.0)(tsx@4.20.5)(yaml@2.9.0):
     dependencies:
       '@types/chai': 5.2.2
@@ -42734,37 +42713,6 @@ snapshots:
       - terser
       - tsx
       - yaml
-
-  vitest@4.1.10(@opentelemetry/api@1.9.0)(@types/node@18.19.124)(@vitest/coverage-v8@3.2.4(@vitest/browser@3.2.4)(vitest@3.2.4))(happy-dom@20.8.9)(jsdom@20.0.3(canvas@2.11.2))(msw@2.11.1(@types/node@18.19.124)(typescript@5.5.4))(vite@8.0.8(@types/node@18.19.124)(esbuild@0.27.3)(jiti@2.5.1)(less@4.5.1)(sass-embedded@1.97.3)(sass@1.97.3)(stylus@0.62.0)(terser@5.44.0)(tsx@4.20.5)(yaml@2.9.0)):
-    dependencies:
-      '@vitest/expect': 4.1.10
-      '@vitest/mocker': 4.1.10(msw@2.11.1(@types/node@18.19.124)(typescript@5.5.4))(vite@8.0.8(@types/node@18.19.124)(esbuild@0.27.3)(jiti@2.5.1)(less@4.5.1)(sass-embedded@1.97.3)(sass@1.97.3)(stylus@0.62.0)(terser@5.44.0)(tsx@4.20.5)(yaml@2.9.0))
-      '@vitest/pretty-format': 4.1.10
-      '@vitest/runner': 4.1.10
-      '@vitest/snapshot': 4.1.10
-      '@vitest/spy': 4.1.10
-      '@vitest/utils': 4.1.10
-      es-module-lexer: 2.0.0
-      expect-type: 1.3.0
-      magic-string: 0.30.21
-      obug: 2.1.3
-      pathe: 2.0.3
-      picomatch: 4.0.4
-      std-env: 4.1.0
-      tinybench: 2.9.0
-      tinyexec: 1.2.4
-      tinyglobby: 0.2.15
-      tinyrainbow: 3.1.0
-      vite: 8.0.8(@types/node@18.19.124)(esbuild@0.27.3)(jiti@2.5.1)(less@4.5.1)(sass-embedded@1.97.3)(sass@1.97.3)(stylus@0.62.0)(terser@5.44.0)(tsx@4.20.5)(yaml@2.9.0)
-      why-is-node-running: 2.3.0
-    optionalDependencies:
-      '@opentelemetry/api': 1.9.0
-      '@types/node': 18.19.124
-      '@vitest/coverage-v8': 3.2.4(@vitest/browser@3.2.4)(vitest@3.2.4)
-      happy-dom: 20.8.9
-      jsdom: 20.0.3(canvas@2.11.2)
-    transitivePeerDependencies:
-      - msw
 
   vitest@4.1.9(@opentelemetry/api@1.9.0)(@types/node@26.1.1)(@vitest/coverage-v8@3.2.4(@vitest/browser@3.2.4)(vitest@3.2.4))(happy-dom@20.8.9)(jsdom@20.0.3(canvas@2.11.2))(msw@2.11.1(@types/node@26.1.1)(typescript@5.5.4))(vite@8.0.8(@types/node@26.1.1)(esbuild@0.27.3)(jiti@2.5.1)(less@4.5.1)(sass-embedded@1.97.3)(sass@1.97.3)(stylus@0.62.0)(terser@5.44.0)(tsx@4.20.5)(yaml@2.9.0)):
     dependencies:


### PR DESCRIPTION
Puts `@osdk/e2e.sandbox.catchall` back on the vitest v3 line. #3787 added it as a new
`vitest: ^4.1.10` devDependency, making it the only package pulling a v4 install while
the other ~47 sit on `^3.2.4`.

### Why

- **One package held a second vitest tree** - a duplicate `@vitest/*` set plus `vite@8.0.8` in the lockfile to serve one sandbox package, 4 distinct vitest versions down to 3.
- **v4 drops Node 18** - engines `^20 || ^22 || >=24` against v3's `^18 || ^20 || >=22`, which is why #3787 had to exclude this package from the Node 18 CI leg.
- **Not a deliberate upgrade** - the pin rode along with #3787's integration-testing work, going to v4 deserves its own PR.

### Changed

- **Version pin** - `^4.1.10` to `^3.2.4`, matching root and the `@osdk/integration-testing` package #3787 added on `^3.2.4`.
- **`test.extend` shape** - v4's `(name, options, fn)` with `onCleanup` becomes v3's `({ name: [fn, options] })` with teardown after `await use(value)`, and `scope: "worker"` already works in 3.2.x.
- **Cleanup ordering** - a `try/finally` preserves #3787's `stop()`-even-if-`start()`-throws behaviour.
- **Hooks** - `test.describe` / `test.beforeEach` become top-level `describe` / `beforeEach`, and `beforeEach<IntegrationFixtures>` lets the fixture set drop its `as TestAPI<...>` cast.
- **Node 18 CI exclusion removed** - restores that `ci.yml` block to its pre-#3787 state.

### Not Changed

- **`examples/example-typescript-library-sdk-2.x`** - still `^4.1.7`, predates #3787, so 4.1.9 stays in the lockfile.
- **`@storybook/addon-vitest`** - still pairs `@vitest/runner@4.1.10` with `vitest@3.2.6`, unmet-optional-peer behaviour unrelated to this.
- **No changeset** - `@osdk/e2e.sandbox.*` is in the changesets ignore list.

### Follow Ups

- **Decide on v4 properly** - one PR moving every package, which needs the Node 18 matrix leg dropped first.
- **Catalog entry for vitest** - 48 independent pins is how single-package outliers like this go unnoticed.
