### PR TITLE
Allow empty collections for marking props

### DIFF
--- a/.changeset/cuddly-towns-feel.md
+++ b/.changeset/cuddly-towns-feel.md
@@ -1,0 +1,5 @@
+---
+"@osdk/maker-experimental": patch
+---
+
+Allow empty collections for marking props

--- a/packages/maker-experimental/src/conversion/toMarketplace/convertNullabilityToDataConstraint.ts
+++ b/packages/maker-experimental/src/conversion/toMarketplace/convertNullabilityToDataConstraint.ts
@@ -34,8 +34,8 @@ export function convertNullabilityToDataConstraint(prop: {
       };
     }
     invariant(
-      prop.nullability?.noNulls && prop.nullability?.noEmptyCollections,
-      "Marking property type has noNulls or noEmptyCollections set to false, marking properties must not be nullable",
+      prop.nullability?.noNulls,
+      "Marking property type has noNulls set to false, marking properties must not be nullable",
     );
     return {
       propertyTypeConstraints: [],


### PR DESCRIPTION
matches legacy maker behavior