### PR TITLE
[2/3] Use minimal react widget template structure for react widget template

### DIFF
--- a/.changeset/good-parrots-fix.md
+++ b/.changeset/good-parrots-fix.md
@@ -1,0 +1,8 @@
+---
+"@osdk/create-widget.template.react.v2": patch
+"@osdk/create-app.template-packager": patch
+"@osdk/example-generator": patch
+"@osdk/create-widget": patch
+---
+
+Use minimal react template structure for react template

--- a/examples/example-widget-react-sdk-2.x-no-osdk/package.json
+++ b/examples/example-widget-react-sdk-2.x-no-osdk/package.json
@@ -15,10 +15,10 @@
     "test": "vitest run --passWithNoTests"
   },
   "dependencies": {
+    "@blueprintjs/core": "^6.10.0",
     "@osdk/widget.client": "workspace:*",
     "@osdk/widget.client-react": "workspace:*",
-    "@radix-ui/react-icons": "^1.3.2",
-    "@radix-ui/themes": "^3.2.1",
+    "clsx": "^2.1.1",
     "react": "^18",
     "react-dom": "^18"
   },

--- a/examples/example-widget-react-sdk-2.x-no-osdk/src/Widget.module.css
+++ b/examples/example-widget-react-sdk-2.x-no-osdk/src/Widget.module.css
@@ -1,0 +1,28 @@
+.container {
+    background-color: var(--bp-palette-white);
+    padding: 20px;
+    gap: 20px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    height: 100%;
+}
+
+@media (prefers-color-scheme: dark) {
+    .container {
+        background-color: var(--bp-palette-dark-gray-3);
+    }
+}
+
+.container .header {
+    margin: 0;
+}
+
+.card {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 10px;
+    width: 150px;
+}

--- a/examples/example-widget-react-sdk-2.x-no-osdk/src/Widget.tsx
+++ b/examples/example-widget-react-sdk-2.x-no-osdk/src/Widget.tsx
@@ -1,125 +1,48 @@
+import { Button, Card, Classes, H4 } from "@blueprintjs/core";
 import {
-  Box,
-  Button,
-  Checkbox,
-  Container,
-  Flex,
-  Heading,
-  Skeleton,
-  Table,
-  TextField,
-  Theme,
-} from "@radix-ui/themes";
-import React, { useCallback, useState } from "react";
-import { useWidgetContext } from "./context.js";
+  type FoundryWidgetClientContext,
+  useFoundryWidgetContext,
+} from "@osdk/widget.client-react";
+import clsx from "clsx";
+import React, { useCallback, useEffect } from "react";
+import type MainConfig from "./main.config.js";
 import { useDarkTheme } from "./useDarkTheme.js";
+import css from "./Widget.module.css";
+
+const useWidgetContext: () => FoundryWidgetClientContext<typeof MainConfig> =
+  useFoundryWidgetContext.withTypes<typeof MainConfig>();
 
 export const Widget: React.FC = () => {
   const { parameters, emitEvent } = useWidgetContext();
-  const { headerText, todoItems } = parameters.values;
-  const [newTodoItem, setNewTodoItem] = useState("");
+  const greetingName = parameters.values.greetingName ?? "World";
+  const counterValue = parameters.values.counterValue ?? 0;
 
-  const handleAddTodoItem = useCallback(() => {
-    emitEvent("updateTodoItems", {
-      parameterUpdates: {
-        todoItems: [...(todoItems ?? []), newTodoItem],
-      },
-    });
-    setNewTodoItem("");
-  }, [emitEvent, newTodoItem, todoItems]);
-
-  const handleNewTodoItemChange = useCallback(
-    (event: React.ChangeEvent<HTMLInputElement>) => {
-      setNewTodoItem(event.target.value);
-    },
-    []
+  const setCounterValue = useCallback(
+    (value: number) =>
+      emitEvent("setCounterValue", {
+        parameterUpdates: { counterValue: value },
+      }),
+    [emitEvent],
   );
+
+  const handleResetCounter = useCallback(() => setCounterValue(0), [
+    setCounterValue,
+  ]);
+
+  useEffect(() => {
+    const interval = setInterval(() => setCounterValue(counterValue + 1), 1000);
+    return () => clearInterval(interval);
+  }, [setCounterValue, counterValue]);
 
   const isDarkTheme = useDarkTheme();
 
   return (
-    <Theme appearance={isDarkTheme ? "dark" : "light"}>
-      <Box p="2">
-        <Container size="1">
-          <Flex direction="column" gap="4">
-            <Flex p="5" direction="column" gap="2">
-              <Heading size="4">
-                {parameters.state === "loading" ||
-                parameters.state === "not-started" ? (
-                  <Skeleton>Hello, world!</Skeleton>
-                ) : (
-                  headerText ?? "example-widget-react-sdk-2.x-no-osdk"
-                )}
-              </Heading>
-
-              <Table.Root>
-                <Table.Header>
-                  <Table.Row>
-                    <Table.ColumnHeaderCell>Finished</Table.ColumnHeaderCell>
-                    <Table.ColumnHeaderCell>Item</Table.ColumnHeaderCell>
-                  </Table.Row>
-                </Table.Header>
-
-                <Table.Body>
-                  {(parameters.state === "loading" ||
-                    parameters.state === "not-started") && (
-                    <>
-                      <Table.Row>
-                        <Table.Cell>
-                          <Skeleton>
-                            <Checkbox />
-                          </Skeleton>
-                        </Table.Cell>
-                        <Table.Cell>
-                          <Skeleton>Loading cell</Skeleton>
-                        </Table.Cell>
-                      </Table.Row>
-                      <Table.Row>
-                        <Table.Cell>
-                          <Skeleton>
-                            <Checkbox />
-                          </Skeleton>
-                        </Table.Cell>
-                        <Table.Cell>
-                          <Skeleton>Loading cell</Skeleton>
-                        </Table.Cell>
-                      </Table.Row>
-                    </>
-                  )}
-                  {parameters.state === "loaded" &&
-                    todoItems?.map((item, index) => (
-                      <Table.Row key={index}>
-                        <Table.Cell>
-                          <Checkbox />
-                        </Table.Cell>
-                        <Table.Cell>{item}</Table.Cell>
-                      </Table.Row>
-                    ))}
-                  {parameters.state === "loaded" &&
-                    (todoItems ?? []).length === 0 && (
-                      <Table.Row>
-                        <Table.Cell colSpan={2}>No items yet</Table.Cell>
-                      </Table.Row>
-                    )}
-                  <Table.Row>
-                    <Table.Cell colSpan={2}>
-                      <Flex gap="2">
-                        <TextField.Root
-                          value={newTodoItem}
-                          onChange={handleNewTodoItemChange}
-                          size="2"
-                          placeholder="Add item…"
-                        />
-                        <Button onClick={handleAddTodoItem}>Add item</Button>
-                      </Flex>
-                    </Table.Cell>
-                  </Table.Row>
-                </Table.Body>
-              </Table.Root>
-            </Flex>
-          </Flex>
-        </Container>
-      </Box>
-    </Theme>
+    <div className={clsx(css.container, isDarkTheme && Classes.DARK)}>
+      <H4 className={css.header}>Hello, {greetingName}!</H4>
+      <Card className={css.card} compact={true}>
+        <div>Count: {counterValue}</div>
+        <Button onClick={handleResetCounter}>Reset</Button>
+      </Card>
+    </div>
   );
 };

--- a/examples/example-widget-react-sdk-2.x-no-osdk/src/context.ts
+++ b/examples/example-widget-react-sdk-2.x-no-osdk/src/context.ts
@@ -1,6 +1,0 @@
-import { useFoundryWidgetContext } from "@osdk/widget.client-react";
-import type MainConfig from "./main.config.js";
-
-export const useWidgetContext = useFoundryWidgetContext.withTypes<
-  typeof MainConfig
->();

--- a/examples/example-widget-react-sdk-2.x-no-osdk/src/main.config.ts
+++ b/examples/example-widget-react-sdk-2.x-no-osdk/src/main.config.ts
@@ -11,24 +11,19 @@ export default defineConfig({
   description: "An example custom widget implementation",
   type: "workshop",
   parameters: {
-    headerText: {
-      displayName: "Widget title",
+    greetingName: {
+      displayName: "Greeting name",
       type: "string",
     },
-    todoItems: {
-      displayName: "Todo items",
-      type: "array",
-      subType: "string",
+    counterValue: {
+      displayName: "Counter value",
+      type: "number",
     },
   },
   events: {
-    updateHeader: {
-      displayName: "Update header",
-      parameterUpdateIds: ["headerText"],
-    },
-    updateTodoItems: {
-      displayName: "Update todo items",
-      parameterUpdateIds: ["todoItems"],
+    setCounterValue: {
+      displayName: "Set counter value",
+      parameterUpdateIds: ["counterValue"],
     },
   },
 });

--- a/examples/example-widget-react-sdk-2.x-no-osdk/src/main.css
+++ b/examples/example-widget-react-sdk-2.x-no-osdk/src/main.css
@@ -1,10 +1,3 @@
 html, body {
     margin: 0;
 }
-
-.radix-themes:where([data-is-root-theme='true']) {
-    min-height: 0;
-    @supports(min-height: 100dvh) {
-        min-height: 0;
-    }
-}

--- a/examples/example-widget-react-sdk-2.x-no-osdk/src/main.tsx
+++ b/examples/example-widget-react-sdk-2.x-no-osdk/src/main.tsx
@@ -1,4 +1,4 @@
-import "@radix-ui/themes/styles.css";
+import "@blueprintjs/core/lib/css/blueprint.css";
 import "./main.css";
 
 import { FoundryWidget } from "@osdk/widget.client-react";

--- a/examples/example-widget-react-sdk-2.x/package.json
+++ b/examples/example-widget-react-sdk-2.x/package.json
@@ -15,13 +15,13 @@
     "test": "vitest run --passWithNoTests"
   },
   "dependencies": {
+    "@blueprintjs/core": "^6.10.0",
     "@osdk/client": "workspace:*",
     "@osdk/e2e.generated.catchall": "workspace:*",
     "@osdk/react": "workspace:*",
     "@osdk/widget.client": "workspace:*",
     "@osdk/widget.client-react": "workspace:*",
-    "@radix-ui/react-icons": "^1.3.2",
-    "@radix-ui/themes": "^3.2.1",
+    "clsx": "^2.1.1",
     "react": "^18",
     "react-dom": "^18"
   },

--- a/examples/example-widget-react-sdk-2.x/src/Widget.module.css
+++ b/examples/example-widget-react-sdk-2.x/src/Widget.module.css
@@ -1,0 +1,28 @@
+.container {
+    background-color: var(--bp-palette-white);
+    padding: 20px;
+    gap: 20px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    height: 100%;
+}
+
+@media (prefers-color-scheme: dark) {
+    .container {
+        background-color: var(--bp-palette-dark-gray-3);
+    }
+}
+
+.container .header {
+    margin: 0;
+}
+
+.card {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 10px;
+    width: 150px;
+}

--- a/examples/example-widget-react-sdk-2.x/src/Widget.tsx
+++ b/examples/example-widget-react-sdk-2.x/src/Widget.tsx
@@ -1,168 +1,57 @@
-import { $Actions, $Objects, $Queries } from "@osdk/e2e.generated.catchall";
+import { Button, Card, Classes, H4, Tag } from "@blueprintjs/core";
 import {
-  Box,
-  Button,
-  Checkbox,
-  Container,
-  Flex,
-  Heading,
-  Skeleton,
-  Table,
-  Text,
-  TextField,
-  Theme,
-} from "@radix-ui/themes";
-import React, { useCallback, useState } from "react";
-import { useWidgetContext } from "./context.js";
+  type FoundryWidgetClientContext,
+  useFoundryWidgetContext,
+} from "@osdk/widget.client-react";
+import clsx from "clsx";
+import React, { useCallback, useEffect } from "react";
+import type MainConfig from "./main.config.js";
 import { useDarkTheme } from "./useDarkTheme.js";
+import css from "./Widget.module.css";
 // import { useOsdkClient } from "@osdk/react";
-// View the API documentation for your widget set to learn how to use the Ontology SDK.
+
+const useWidgetContext: () => FoundryWidgetClientContext<typeof MainConfig> =
+  useFoundryWidgetContext.withTypes<typeof MainConfig>();
 
 export const Widget: React.FC = () => {
-  // See Ontology and Platform SDK docs in Developer Console on how to
-  // use the client object to access Ontology resources and platform APIs
+  // View the API documentation for your widget set to learn how to use the Ontology SDK.
+  // https://fake.palantirfoundry.com/workspace/custom-widgets/widget-set/ri.widgetregistry..widget-set.fake/sdk/docs
   // const client = useOsdkClient();
 
   const { parameters, emitEvent } = useWidgetContext();
-  const { headerText, todoItems } = parameters.values;
-  const [newTodoItem, setNewTodoItem] = useState("");
+  const greetingName = parameters.values.greetingName ?? "World";
+  const counterValue = parameters.values.counterValue ?? 0;
 
-  const handleAddTodoItem = useCallback(() => {
-    emitEvent("updateTodoItems", {
-      parameterUpdates: {
-        todoItems: [...(todoItems ?? []), newTodoItem],
-      },
-    });
-    setNewTodoItem("");
-  }, [emitEvent, newTodoItem, todoItems]);
-
-  const handleNewTodoItemChange = useCallback(
-    (event: React.ChangeEvent<HTMLInputElement>) => {
-      setNewTodoItem(event.target.value);
-    },
-    []
+  const setCounterValue = useCallback(
+    (value: number) =>
+      emitEvent("setCounterValue", {
+        parameterUpdates: { counterValue: value },
+      }),
+    [emitEvent],
   );
+
+  const handleResetCounter = useCallback(() => setCounterValue(0), [
+    setCounterValue,
+  ]);
+
+  useEffect(() => {
+    const interval = setInterval(() => setCounterValue(counterValue + 1), 1000);
+    return () => clearInterval(interval);
+  }, [setCounterValue, counterValue]);
 
   const isDarkTheme = useDarkTheme();
 
-  const objectApiNames = Object.keys($Objects);
-  const actionApiNames = Object.keys($Actions);
-  const queryApiNames = Object.keys($Queries);
-
   return (
-    <Theme appearance={isDarkTheme ? "dark" : "light"}>
-      <Box p="2">
-        <Container size="1">
-          <Flex direction="column" gap="4">
-            <Flex p="5" direction="column" gap="2">
-              <Heading size="4">
-                {parameters.state === "loading" ||
-                parameters.state === "not-started" ? (
-                  <Skeleton>Hello, world!</Skeleton>
-                ) : (
-                  headerText ?? "example-widget-react-sdk-2.x"
-                )}
-              </Heading>
-
-              <Table.Root>
-                <Table.Header>
-                  <Table.Row>
-                    <Table.ColumnHeaderCell>Finished</Table.ColumnHeaderCell>
-                    <Table.ColumnHeaderCell>Item</Table.ColumnHeaderCell>
-                  </Table.Row>
-                </Table.Header>
-
-                <Table.Body>
-                  {(parameters.state === "loading" ||
-                    parameters.state === "not-started") && (
-                    <>
-                      <Table.Row>
-                        <Table.Cell>
-                          <Skeleton>
-                            <Checkbox />
-                          </Skeleton>
-                        </Table.Cell>
-                        <Table.Cell>
-                          <Skeleton>Loading cell</Skeleton>
-                        </Table.Cell>
-                      </Table.Row>
-                      <Table.Row>
-                        <Table.Cell>
-                          <Skeleton>
-                            <Checkbox />
-                          </Skeleton>
-                        </Table.Cell>
-                        <Table.Cell>
-                          <Skeleton>Loading cell</Skeleton>
-                        </Table.Cell>
-                      </Table.Row>
-                    </>
-                  )}
-                  {parameters.state === "loaded" &&
-                    todoItems?.map((item, index) => (
-                      <Table.Row key={index}>
-                        <Table.Cell>
-                          <Checkbox />
-                        </Table.Cell>
-                        <Table.Cell>{item}</Table.Cell>
-                      </Table.Row>
-                    ))}
-                  {parameters.state === "loaded" &&
-                    (todoItems ?? []).length === 0 && (
-                      <Table.Row>
-                        <Table.Cell colSpan={2}>No items yet</Table.Cell>
-                      </Table.Row>
-                    )}
-                  <Table.Row>
-                    <Table.Cell colSpan={2}>
-                      <Flex gap="2">
-                        <TextField.Root
-                          value={newTodoItem}
-                          onChange={handleNewTodoItemChange}
-                          size="2"
-                          placeholder="Add item…"
-                        />
-                        <Button onClick={handleAddTodoItem}>Add item</Button>
-                      </Flex>
-                    </Table.Cell>
-                  </Table.Row>
-                </Table.Body>
-              </Table.Root>
-            </Flex>
-            <Box>
-              <Flex direction="column" gap="2">
-                <Text>
-                  Try any of the following methods from your Ontology SDK
-                </Text>
-                <Flex direction="column" gap="1">
-                  <Heading size="4">Objects ({objectApiNames.length})</Heading>
-                  <pre>
-                    {objectApiNames.map((objectApiName) => (
-                      <div key={objectApiName}>client({objectApiName})</div>
-                    ))}
-                  </pre>
-                </Flex>
-                <Flex direction="column" gap="1">
-                  <Heading size="4">Actions ({actionApiNames.length})</Heading>
-                  <pre>
-                    {actionApiNames.map((actionApiName) => (
-                      <div key={actionApiName}>client({actionApiName})</div>
-                    ))}
-                  </pre>
-                </Flex>
-                <Flex direction="column" gap="1">
-                  <Heading size="4">Queries ({queryApiNames.length})</Heading>
-                  <pre>
-                    {queryApiNames.map((queryApiName) => (
-                      <div key={queryApiName}>client({queryApiName})</div>
-                    ))}
-                  </pre>
-                </Flex>
-              </Flex>
-            </Box>
-          </Flex>
-        </Container>
-      </Box>
-    </Theme>
+    <div className={clsx(css.container, isDarkTheme && Classes.DARK)}>
+      <H4 className={css.header}>Hello, {greetingName}!</H4>
+      <Card className={css.card} compact={true}>
+        <div>Count: {counterValue}</div>
+        <Button onClick={handleResetCounter}>Reset</Button>
+      </Card>
+      <div>
+        <span>OSDK: </span>
+        <Tag minimal={true}>@osdk/e2e.generated.catchall</Tag>
+      </div>
+    </div>
   );
 };

--- a/examples/example-widget-react-sdk-2.x/src/context.ts
+++ b/examples/example-widget-react-sdk-2.x/src/context.ts
@@ -1,6 +1,0 @@
-import { useFoundryWidgetContext } from "@osdk/widget.client-react";
-import type MainConfig from "./main.config.js";
-
-export const useWidgetContext = useFoundryWidgetContext.withTypes<
-  typeof MainConfig
->();

--- a/examples/example-widget-react-sdk-2.x/src/main.config.ts
+++ b/examples/example-widget-react-sdk-2.x/src/main.config.ts
@@ -11,24 +11,19 @@ export default defineConfig({
   description: "An example custom widget implementation",
   type: "workshop",
   parameters: {
-    headerText: {
-      displayName: "Widget title",
+    greetingName: {
+      displayName: "Greeting name",
       type: "string",
     },
-    todoItems: {
-      displayName: "Todo items",
-      type: "array",
-      subType: "string",
+    counterValue: {
+      displayName: "Counter value",
+      type: "number",
     },
   },
   events: {
-    updateHeader: {
-      displayName: "Update header",
-      parameterUpdateIds: ["headerText"],
-    },
-    updateTodoItems: {
-      displayName: "Update todo items",
-      parameterUpdateIds: ["todoItems"],
+    setCounterValue: {
+      displayName: "Set counter value",
+      parameterUpdateIds: ["counterValue"],
     },
   },
 });

--- a/examples/example-widget-react-sdk-2.x/src/main.css
+++ b/examples/example-widget-react-sdk-2.x/src/main.css
@@ -1,10 +1,3 @@
 html, body {
     margin: 0;
 }
-
-.radix-themes:where([data-is-root-theme='true']) {
-    min-height: 0;
-    @supports(min-height: 100dvh) {
-        min-height: 0;
-    }
-}

--- a/examples/example-widget-react-sdk-2.x/src/main.tsx
+++ b/examples/example-widget-react-sdk-2.x/src/main.tsx
@@ -1,4 +1,4 @@
-import "@radix-ui/themes/styles.css";
+import "@blueprintjs/core/lib/css/blueprint.css";
 import "./main.css";
 
 import { OsdkProvider } from "@osdk/react";

--- a/packages/create-widget.template.react.v2/package.json
+++ b/packages/create-widget.template.react.v2/package.json
@@ -34,8 +34,8 @@
     "typecheck": "tsc --noEmit --emitDeclarationOnly false"
   },
   "dependencies": {
-    "@radix-ui/react-icons": "^1.3.2",
-    "@radix-ui/themes": "^3.2.1",
+    "@blueprintjs/core": "^6.10.0",
+    "clsx": "^2.1.1",
     "react": "^18",
     "react-dom": "^18"
   },

--- a/packages/create-widget.template.react.v2/templates/src/Widget.module.css
+++ b/packages/create-widget.template.react.v2/templates/src/Widget.module.css
@@ -1,0 +1,28 @@
+.container {
+    background-color: var(--bp-palette-white);
+    padding: 20px;
+    gap: 20px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    height: 100%;
+}
+
+@media (prefers-color-scheme: dark) {
+    .container {
+        background-color: var(--bp-palette-dark-gray-3);
+    }
+}
+
+.container .header {
+    margin: 0;
+}
+
+.card {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 10px;
+    width: 150px;
+}

--- a/packages/create-widget.template.react.v2/templates/src/Widget.tsx.hbs
+++ b/packages/create-widget.template.react.v2/templates/src/Widget.tsx.hbs
@@ -1,180 +1,67 @@
 {{#if osdkPackage}}
-import { $Actions, $Objects, $Queries } from "{{osdkPackage}}";
+import { Button, Card, Classes, H4, Tag } from "@blueprintjs/core";
+{{else}}
+import { Button, Card, Classes, H4 } from "@blueprintjs/core";
 {{/if}}
 import {
-  Box,
-  Button,
-  Checkbox,
-  Container,
-  Flex,
-  Heading,
-  Skeleton,
-  Table,
-{{#if osdkPackage}}
-  Text,
-{{/if}}
-  TextField,
-  Theme,
-} from "@radix-ui/themes";
-import React, { useCallback, useState } from "react";
-import { useWidgetContext } from "./context.js";
+  type FoundryWidgetClientContext,
+  useFoundryWidgetContext,
+} from "@osdk/widget.client-react";
+import clsx from "clsx";
+import React, { useCallback, useEffect } from "react";
+import type MainConfig from "./main.config.js";
 import { useDarkTheme } from "./useDarkTheme.js";
+import css from "./Widget.module.css";
 {{#if osdkPackage}}
 // import { useOsdkClient } from "@osdk/react";
-// View the API documentation for your widget set to learn how to use the Ontology SDK.
 {{/if}}
+
+const useWidgetContext: () => FoundryWidgetClientContext<typeof MainConfig> =
+  useFoundryWidgetContext.withTypes<typeof MainConfig>();
 
 export const Widget: React.FC = () => {
 {{#if osdkPackage}}
-  // See Ontology and Platform SDK docs in Developer Console on how to
-  // use the client object to access Ontology resources and platform APIs
+  // View the API documentation for your widget set to learn how to use the Ontology SDK.
+  // {{foundryUrl}}/workspace/custom-widgets/widget-set/{{widgetSet}}/sdk/docs
   // const client = useOsdkClient();
 
 {{/if}}
   const { parameters, emitEvent } = useWidgetContext();
-  const { headerText, todoItems } = parameters.values;
-  const [newTodoItem, setNewTodoItem] = useState("");
+  const greetingName = parameters.values.greetingName ?? "World";
+  const counterValue = parameters.values.counterValue ?? 0;
 
-  const handleAddTodoItem = useCallback(() => {
-    emitEvent("updateTodoItems", {
-      parameterUpdates: {
-        todoItems: [...(todoItems ?? []), newTodoItem],
-      },
-    });
-    setNewTodoItem("");
-  }, [emitEvent, newTodoItem, todoItems]);
-
-  const handleNewTodoItemChange = useCallback(
-    (event: React.ChangeEvent<HTMLInputElement>) => {
-      setNewTodoItem(event.target.value);
-    },
-    []
+  const setCounterValue = useCallback(
+    (value: number) =>
+      emitEvent("setCounterValue", {
+        parameterUpdates: { counterValue: value },
+      }),
+    [emitEvent],
   );
+
+  const handleResetCounter = useCallback(() => setCounterValue(0), [
+    setCounterValue,
+  ]);
+
+  useEffect(() => {
+    const interval = setInterval(() => setCounterValue(counterValue + 1), 1000);
+    return () => clearInterval(interval);
+  }, [setCounterValue, counterValue]);
 
   const isDarkTheme = useDarkTheme();
 
-{{#if osdkPackage}}
-  const objectApiNames = Object.keys($Objects);
-  const actionApiNames = Object.keys($Actions);
-  const queryApiNames = Object.keys($Queries);
-
-{{/if}}
   return (
-    <Theme appearance={isDarkTheme ? "dark" : "light"}>
-      <Box p="2">
-        <Container size="1">
-          <Flex direction="column" gap="4">
-            <Flex p="5" direction="column" gap="2">
-              <Heading size="4">
-                {parameters.state === "loading" ||
-                parameters.state === "not-started" ? (
-                  <Skeleton>Hello, world!</Skeleton>
-                ) : (
-                  headerText ?? "{{project}}"
-                )}
-              </Heading>
-
-              <Table.Root>
-                <Table.Header>
-                  <Table.Row>
-                    <Table.ColumnHeaderCell>Finished</Table.ColumnHeaderCell>
-                    <Table.ColumnHeaderCell>Item</Table.ColumnHeaderCell>
-                  </Table.Row>
-                </Table.Header>
-
-                <Table.Body>
-                  {(parameters.state === "loading" ||
-                    parameters.state === "not-started") && (
-                    <>
-                      <Table.Row>
-                        <Table.Cell>
-                          <Skeleton>
-                            <Checkbox />
-                          </Skeleton>
-                        </Table.Cell>
-                        <Table.Cell>
-                          <Skeleton>Loading cell</Skeleton>
-                        </Table.Cell>
-                      </Table.Row>
-                      <Table.Row>
-                        <Table.Cell>
-                          <Skeleton>
-                            <Checkbox />
-                          </Skeleton>
-                        </Table.Cell>
-                        <Table.Cell>
-                          <Skeleton>Loading cell</Skeleton>
-                        </Table.Cell>
-                      </Table.Row>
-                    </>
-                  )}
-                  {parameters.state === "loaded" &&
-                    todoItems?.map((item, index) => (
-                      <Table.Row key={index}>
-                        <Table.Cell>
-                          <Checkbox />
-                        </Table.Cell>
-                        <Table.Cell>{item}</Table.Cell>
-                      </Table.Row>
-                    ))}
-                  {parameters.state === "loaded" &&
-                    (todoItems ?? []).length === 0 && (
-                      <Table.Row>
-                        <Table.Cell colSpan={2}>No items yet</Table.Cell>
-                      </Table.Row>
-                    )}
-                  <Table.Row>
-                    <Table.Cell colSpan={2}>
-                      <Flex gap="2">
-                        <TextField.Root
-                          value={newTodoItem}
-                          onChange={handleNewTodoItemChange}
-                          size="2"
-                          placeholder="Add item…"
-                        />
-                        <Button onClick={handleAddTodoItem}>Add item</Button>
-                      </Flex>
-                    </Table.Cell>
-                  </Table.Row>
-                </Table.Body>
-              </Table.Root>
-            </Flex>
+    <div className={clsx(css.container, isDarkTheme && Classes.DARK)}>
+      <H4 className={css.header}>Hello, {greetingName}!</H4>
+      <Card className={css.card} compact={true}>
+        <div>Count: {counterValue}</div>
+        <Button onClick={handleResetCounter}>Reset</Button>
+      </Card>
 {{#if osdkPackage}}
-            <Box>
-              <Flex direction="column" gap="2">
-                <Text>
-                  Try any of the following methods from your Ontology SDK
-                </Text>
-                <Flex direction="column" gap="1">
-                  <Heading size="4">Objects ({objectApiNames.length})</Heading>
-                  <pre>
-                    {objectApiNames.map((objectApiName) => (
-                      <div key={objectApiName}>client({objectApiName})</div>
-                    ))}
-                  </pre>
-                </Flex>
-                <Flex direction="column" gap="1">
-                  <Heading size="4">Actions ({actionApiNames.length})</Heading>
-                  <pre>
-                    {actionApiNames.map((actionApiName) => (
-                      <div key={actionApiName}>client({actionApiName})</div>
-                    ))}
-                  </pre>
-                </Flex>
-                <Flex direction="column" gap="1">
-                  <Heading size="4">Queries ({queryApiNames.length})</Heading>
-                  <pre>
-                    {queryApiNames.map((queryApiName) => (
-                      <div key={queryApiName}>client({queryApiName})</div>
-                    ))}
-                  </pre>
-                </Flex>
-              </Flex>
-            </Box>
+      <div>
+        <span>OSDK: </span>
+        <Tag minimal={true}>{{osdkPackage}}</Tag>
+      </div>
 {{/if}}
-          </Flex>
-        </Container>
-      </Box>
-    </Theme>
+    </div>
   );
 };

--- a/packages/create-widget.template.react.v2/templates/src/context.ts
+++ b/packages/create-widget.template.react.v2/templates/src/context.ts
@@ -1,6 +1,0 @@
-import { useFoundryWidgetContext } from "@osdk/widget.client-react";
-import type MainConfig from "./main.config.js";
-
-export const useWidgetContext = useFoundryWidgetContext.withTypes<
-  typeof MainConfig
->();

--- a/packages/create-widget.template.react.v2/templates/src/main.config.ts
+++ b/packages/create-widget.template.react.v2/templates/src/main.config.ts
@@ -11,24 +11,19 @@ export default defineConfig({
   description: "An example custom widget implementation",
   type: "workshop",
   parameters: {
-    headerText: {
-      displayName: "Widget title",
+    greetingName: {
+      displayName: "Greeting name",
       type: "string",
     },
-    todoItems: {
-      displayName: "Todo items",
-      type: "array",
-      subType: "string",
+    counterValue: {
+      displayName: "Counter value",
+      type: "number",
     },
   },
   events: {
-    updateHeader: {
-      displayName: "Update header",
-      parameterUpdateIds: ["headerText"],
-    },
-    updateTodoItems: {
-      displayName: "Update todo items",
-      parameterUpdateIds: ["todoItems"],
+    setCounterValue: {
+      displayName: "Set counter value",
+      parameterUpdateIds: ["counterValue"],
     },
   },
 });

--- a/packages/create-widget.template.react.v2/templates/src/main.css
+++ b/packages/create-widget.template.react.v2/templates/src/main.css
@@ -1,10 +1,3 @@
 html, body {
     margin: 0;
 }
-
-.radix-themes:where([data-is-root-theme='true']) {
-    min-height: 0;
-    @supports(min-height: 100dvh) {
-        min-height: 0;
-    }
-}

--- a/packages/create-widget.template.react.v2/templates/src/main.tsx.hbs
+++ b/packages/create-widget.template.react.v2/templates/src/main.tsx.hbs
@@ -1,4 +1,4 @@
-import "@radix-ui/themes/styles.css";
+import "@blueprintjs/core/lib/css/blueprint.css";
 import "./main.css";
 
 {{#if osdkPackage}}

--- a/packages/create-widget/src/run.ts
+++ b/packages/create-widget/src/run.ts
@@ -94,6 +94,8 @@ export async function run({
 
   const templateContext: TemplateContext = {
     project,
+    foundryUrl,
+    widgetSet,
     osdkPackage,
   };
   const processFiles = function (dir: string) {

--- a/packages/create-widget/src/templates.ts
+++ b/packages/create-widget/src/templates.ts
@@ -43,5 +43,7 @@ export interface Template {
 
 export interface TemplateContext {
   project: string;
+  foundryUrl: string;
+  widgetSet: string;
   osdkPackage?: string;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1580,6 +1580,9 @@ importers:
 
   examples/example-widget-react-sdk-2.x:
     dependencies:
+      '@blueprintjs/core':
+        specifier: ^6.10.0
+        version: 6.11.3(@types/react@18.3.24)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@osdk/client':
         specifier: workspace:*
         version: link:../../packages/client
@@ -1595,12 +1598,9 @@ importers:
       '@osdk/widget.client-react':
         specifier: workspace:*
         version: link:../../packages/widget.client-react
-      '@radix-ui/react-icons':
-        specifier: ^1.3.2
-        version: 1.3.2(react@18.3.1)
-      '@radix-ui/themes':
-        specifier: ^3.2.1
-        version: 3.2.1(@types/react-dom@18.3.7(@types/react@18.3.24))(@types/react@18.3.24)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      clsx:
+        specifier: ^2.1.1
+        version: 2.1.1
       react:
         specifier: ^18
         version: 18.3.1
@@ -1668,18 +1668,18 @@ importers:
 
   examples/example-widget-react-sdk-2.x-no-osdk:
     dependencies:
+      '@blueprintjs/core':
+        specifier: ^6.10.0
+        version: 6.11.3(@types/react@18.3.24)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@osdk/widget.client':
         specifier: workspace:*
         version: link:../../packages/widget.client
       '@osdk/widget.client-react':
         specifier: workspace:*
         version: link:../../packages/widget.client-react
-      '@radix-ui/react-icons':
-        specifier: ^1.3.2
-        version: 1.3.2(react@18.3.1)
-      '@radix-ui/themes':
-        specifier: ^3.2.1
-        version: 3.2.1(@types/react-dom@18.3.7(@types/react@18.3.24))(@types/react@18.3.24)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      clsx:
+        specifier: ^2.1.1
+        version: 2.1.1
       react:
         specifier: ^18
         version: 18.3.1
@@ -3261,12 +3261,12 @@ importers:
 
   packages/create-widget.template.react.v2:
     dependencies:
-      '@radix-ui/react-icons':
-        specifier: ^1.3.2
-        version: 1.3.2(react@18.3.1)
-      '@radix-ui/themes':
-        specifier: ^3.2.1
-        version: 3.2.1(@types/react-dom@18.3.7(@types/react@18.3.24))(@types/react@18.3.24)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@blueprintjs/core':
+        specifier: ^6.10.0
+        version: 6.11.3(@types/react@18.3.24)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      clsx:
+        specifier: ^2.1.1
+        version: 2.1.1
       react:
         specifier: ^18
         version: 18.3.1


### PR DESCRIPTION
Requires https://github.com/palantir/osdk-ts/pull/3849

This PR moves the react widget template over to the minimal react widget template structure of an example counter widget for consistency. It mirrors create-app to optionally include the OSDK client and @osdk/react bootstrapping and renders an extra tag when an OSDK package is used.

Aside from the OSDK branching there are two minor changes made to the template:

- Apply CSS gap to container rather than header margin to provide OSDK section spacing when it is rendered
- Use blueprint design tokens which are now exposed in CSS variables since [6.7.0](https://github.com/palantir/blueprint/releases/tag/%40blueprintjs/core%406.7.0) which are also used in create-app

The next step will be to delete the minimal react widget template completely and provide a hidden compatibility alias for it to render this react template without osdk instead.

| Light | Dark |
|-|-|
<img width="530" height="334" alt="Screenshot 2026-08-13 at 16 25 09" src="https://github.com/user-attachments/assets/04106a83-ec46-4d08-9d5d-7b4136c2fe49" /> | <img width="529" height="296" alt="Screenshot 2026-08-13 at 16 50 17" src="https://github.com/user-attachments/assets/1d2ad36d-8856-40ae-b2a8-a5198bd3d136" />
