### PR TITLE
BaseEmailViewer: rename email to content

### DIFF
--- a/.changeset/email-viewer-content-prop.md
+++ b/.changeset/email-viewer-content-prop.md
@@ -1,0 +1,11 @@
+---
+"@osdk/react-components": minor
+---
+
+`BaseEmailViewer` takes its parsed email as `content`, matching the convention shared by the other viewers.
+
+Nothing is removed. `email` is still accepted, is `@deprecated`, and `content` wins when both are set.
+
+```
+BaseEmailViewer  email -> content
+```

--- a/packages/react-components-storybook/src/stories/EmailViewer/EmailViewer.stories.tsx
+++ b/packages/react-components-storybook/src/stories/EmailViewer/EmailViewer.stories.tsx
@@ -99,7 +99,7 @@ const meta: Meta<BaseEmailViewerProps> = {
   component: BaseEmailViewer,
   tags: ["beta"],
   args: {
-    email: SAMPLE_EMAIL,
+    content: SAMPLE_EMAIL,
   },
   render: (args: BaseEmailViewerProps) => (
     <div style={{ height: "500px" }}>
@@ -110,8 +110,8 @@ const meta: Meta<BaseEmailViewerProps> = {
     controls: { expanded: true },
   },
   argTypes: {
-    email: {
-      description: "Parsed email data",
+    content: {
+      description: "The parsed email to render",
       control: false,
     },
     className: {
@@ -150,7 +150,7 @@ export const HtmlEmail: Story = {
       source: {
         code: `import { BaseEmailViewer } from "@osdk/react-components/experimental/email-viewer";
 
-<BaseEmailViewer email={parsedEmail} />`,
+<BaseEmailViewer content={parsedEmail} />`,
       },
     },
   },
@@ -158,6 +158,6 @@ export const HtmlEmail: Story = {
 
 export const PlainTextEmail: Story = {
   args: {
-    email: SAMPLE_TEXT_EMAIL,
+    content: SAMPLE_TEXT_EMAIL,
   },
 };

--- a/packages/react-components/docs/EmailViewer.md
+++ b/packages/react-components/docs/EmailViewer.md
@@ -32,7 +32,7 @@ import { EmailViewer } from "@osdk/react-components/experimental/email-viewer";
 import { BaseEmailViewer } from "@osdk/react-components/experimental/email-viewer";
 
 <BaseEmailViewer
-  email={{
+  content={{
     subject: "Hello",
     from: { name: "Alice", address: "alice@example.com" },
     to: [{ name: "Bob", address: "bob@example.com" }],
@@ -50,7 +50,8 @@ import { BaseEmailViewer } from "@osdk/react-components/experimental/email-viewe
 
 | Prop        | Type          | Required | Description                           |
 | ----------- | ------------- | -------- | ------------------------------------- |
-| `email`     | `ParsedEmail` | Yes      | Parsed email data                     |
+| `content`   | `ParsedEmail` | No       | The parsed email to render            |
+| `email`     | `ParsedEmail` | No       | **Deprecated** — rename to `content`  |
 | `className` | `string`      | No       | CSS class applied to the root element |
 
 ### EmailViewerProps

--- a/packages/react-components/src/email-viewer/BaseEmailViewer.tsx
+++ b/packages/react-components/src/email-viewer/BaseEmailViewer.tsx
@@ -33,13 +33,17 @@ function formatAddressList(addresses: readonly EmailAddress[]): string {
 }
 
 export function BaseEmailViewer({
+  content,
   email,
   className,
 }: BaseEmailViewerProps): React.ReactElement {
   const rootClassName = classnames(styles.container, className);
 
+  // eslint-disable-next-line @typescript-eslint/no-deprecated -- pre-rename fallback
+  const resolved = content ?? email;
+
   const bodyContent = useMemo(() => {
-    if (email.html != null) {
+    if (resolved?.html != null) {
       return (
         <div className={styles.bodyContainer}>
           {/*
@@ -56,52 +60,52 @@ export function BaseEmailViewer({
           <iframe
             className={styles.bodyIframe}
             sandbox="allow-same-origin"
-            srcDoc={email.html}
+            srcDoc={resolved.html}
             title="Email body"
           />
         </div>
       );
     }
-    if (email.text != null) {
-      return <div className={styles.textBody}>{email.text}</div>;
+    if (resolved?.text != null) {
+      return <div className={styles.textBody}>{resolved.text}</div>;
     }
     return <div className={styles.emptyBody}>No content</div>;
-  }, [email.html, email.text]);
+  }, [resolved?.html, resolved?.text]);
 
   return (
     <div className={rootClassName}>
       <div className={styles.header}>
-        {email.subject != null && (
-          <div className={styles.subject}>{email.subject}</div>
+        {resolved?.subject != null && (
+          <div className={styles.subject}>{resolved.subject}</div>
         )}
-        {email.from != null && (
+        {resolved?.from != null && (
           <div className={styles.headerRow}>
             <span className={styles.headerLabel}>From:</span>
             <span className={styles.headerValue}>
-              {formatAddress(email.from)}
+              {formatAddress(resolved.from)}
             </span>
           </div>
         )}
-        {email.to.length > 0 && (
+        {resolved != null && resolved.to.length > 0 && (
           <div className={styles.headerRow}>
             <span className={styles.headerLabel}>To:</span>
             <span className={styles.headerValue}>
-              {formatAddressList(email.to)}
+              {formatAddressList(resolved.to)}
             </span>
           </div>
         )}
-        {email.cc.length > 0 && (
+        {resolved != null && resolved.cc.length > 0 && (
           <div className={styles.headerRow}>
             <span className={styles.headerLabel}>Cc:</span>
             <span className={styles.headerValue}>
-              {formatAddressList(email.cc)}
+              {formatAddressList(resolved.cc)}
             </span>
           </div>
         )}
-        {email.date != null && (
+        {resolved?.date != null && (
           <div className={styles.headerRow}>
             <span className={styles.headerLabel}>Date:</span>
-            <span className={styles.headerValue}>{email.date}</span>
+            <span className={styles.headerValue}>{resolved.date}</span>
           </div>
         )}
       </div>

--- a/packages/react-components/src/email-viewer/EmailViewer.tsx
+++ b/packages/react-components/src/email-viewer/EmailViewer.tsx
@@ -31,7 +31,7 @@ export function EmailViewer({
   ...emailViewerProps
 }: EmailViewerProps): React.ReactElement {
   const {
-    data: email,
+    data: content,
     loading,
     error,
   } = useMediaContents<ParsedEmail>(media, parseEmailFromResponse);
@@ -52,7 +52,9 @@ export function EmailViewer({
           Failed to load email: {error.message}
         </div>
       )}
-      {email != null && <BaseEmailViewer email={email} {...emailViewerProps} />}
+      {content != null && (
+        <BaseEmailViewer content={content} {...emailViewerProps} />
+      )}
     </div>
   );
 }

--- a/packages/react-components/src/email-viewer/EmailViewerApi.ts
+++ b/packages/react-components/src/email-viewer/EmailViewerApi.ts
@@ -32,14 +32,20 @@ export interface ParsedEmail {
 }
 
 export interface BaseEmailViewerProps {
-  /** Parsed email data */
-  email: ParsedEmail;
+  /** The parsed email to render. */
+  // TODO: make this required when `email` is removed.
+  content?: ParsedEmail;
+  /** @deprecated Rename to `content`. */
+  email?: ParsedEmail;
   /** Additional CSS class name for the root element
    * @default undefined */
   className?: string;
 }
 
-export interface EmailViewerProps extends Omit<BaseEmailViewerProps, "email"> {
+export interface EmailViewerProps extends Omit<
+  BaseEmailViewerProps,
+  "content" | "email"
+> {
   /** The Media object to fetch EML contents from */
   media: Media;
 }

--- a/packages/react-components/src/email-viewer/__tests__/BaseEmailViewer.test.tsx
+++ b/packages/react-components/src/email-viewer/__tests__/BaseEmailViewer.test.tsx
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { BaseEmailViewer } from "../BaseEmailViewer.js";
+import type { ParsedEmail } from "../EmailViewerApi.js";
+
+afterEach(() => {
+  cleanup();
+});
+
+function parsedEmail(overrides: Partial<ParsedEmail> = {}): ParsedEmail {
+  return {
+    subject: "Quarterly report",
+    from: { name: "Alice", address: "alice@example.com" },
+    to: [{ name: "Bob", address: "bob@example.com" }],
+    cc: [],
+    date: "2026-01-15T10:30:00Z",
+    html: undefined,
+    text: "Numbers attached.",
+    ...overrides,
+  };
+}
+
+describe("BaseEmailViewer", () => {
+  it("should render headers and the text body from content", () => {
+    render(<BaseEmailViewer content={parsedEmail()} />);
+    expect(screen.getByText("Quarterly report")).toBeTruthy();
+    expect(screen.getByText("Alice <alice@example.com>")).toBeTruthy();
+    expect(screen.getByText("Bob <bob@example.com>")).toBeTruthy();
+    expect(screen.getByText("Numbers attached.")).toBeTruthy();
+  });
+
+  it("should render an html body in a sandboxed iframe", () => {
+    render(
+      <BaseEmailViewer
+        content={parsedEmail({ html: "<p>Hello Bob!</p>", text: undefined })}
+      />,
+    );
+    const iframe = screen.getByTitle("Email body");
+    expect(iframe.getAttribute("sandbox")).toBe("allow-same-origin");
+    expect(iframe.getAttribute("srcdoc")).toBe("<p>Hello Bob!</p>");
+  });
+
+  it("should render from the deprecated email prop", () => {
+    // eslint-disable-next-line @typescript-eslint/no-deprecated -- covers the pre-rename fallback
+    render(<BaseEmailViewer email={parsedEmail()} />);
+    expect(screen.getByText("Quarterly report")).toBeTruthy();
+    expect(screen.getByText("Numbers attached.")).toBeTruthy();
+  });
+
+  it("should prefer content over the deprecated email prop", () => {
+    render(
+      <BaseEmailViewer
+        content={parsedEmail({ subject: "From content" })}
+        // eslint-disable-next-line @typescript-eslint/no-deprecated -- covers the pre-rename fallback
+        email={parsedEmail({ subject: "From email" })}
+      />,
+    );
+    expect(screen.getByText("From content")).toBeTruthy();
+    expect(screen.queryByText("From email")).toBeNull();
+  });
+
+  it("should render the empty state when neither prop is set", () => {
+    render(<BaseEmailViewer />);
+    expect(screen.getByText("No content")).toBeTruthy();
+  });
+});

--- a/packages/react-components/src/email-viewer/__tests__/EmailViewer.test.tsx
+++ b/packages/react-components/src/email-viewer/__tests__/EmailViewer.test.tsx
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { Media } from "@osdk/api";
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { useMediaContents } from "../../shared/hooks/useMediaContents.js";
+import { BaseEmailViewer } from "../BaseEmailViewer.js";
+import { EmailViewer } from "../EmailViewer.js";
+import type { ParsedEmail } from "../EmailViewerApi.js";
+
+vi.mock("../BaseEmailViewer.js", () => ({
+  BaseEmailViewer: vi.fn(() => null),
+}));
+vi.mock("../../shared/hooks/useMediaContents.js", () => ({
+  useMediaContents: vi.fn(),
+}));
+
+const mockedBaseEmailViewer = vi.mocked(BaseEmailViewer);
+const mockedUseMediaContents = vi.mocked(useMediaContents);
+
+const PARSED: ParsedEmail = {
+  subject: "Quarterly report",
+  from: { name: "Alice", address: "alice@example.com" },
+  to: [],
+  cc: [],
+  date: undefined,
+  html: undefined,
+  text: "Numbers attached.",
+};
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+// Pins the prop name the wrapper forwards under. The deprecated `email` alias
+// behaves identically, so without this a revert to the old name would leave
+// every other test green.
+describe("EmailViewer", () => {
+  it("should forward the fetched email as content, not as the deprecated email prop", () => {
+    mockedUseMediaContents.mockReturnValue({
+      data: PARSED,
+      loading: false,
+      error: undefined,
+    });
+
+    render(<EmailViewer media={{} as unknown as Media} />);
+
+    const props = mockedBaseEmailViewer.mock.calls[0]?.[0];
+    expect(props).toMatchObject({ content: PARSED });
+  });
+});


### PR DESCRIPTION
Layer 2 of 4. `BaseEmailViewer` takes its parsed email as `content`. `email` named the prop after the file type, which does not generalise to the next viewer.

### Not Changed

- **Nothing is removed** - `email` is still accepted and `@deprecated`; `content` wins when both are set
- **`EmailViewer`** - the OSDK wrapper still takes `media`

### Worth a look

- **`content` has to be optional** while the alias exists, so the viewer now renders its existing `No content` empty state when neither prop is passed. That is a strict improvement on today, where a missing prop throws on `email.html`
- **First tests for this component** - it had none. Covers both prop names, their precedence, and the empty case
