### PR TITLE
BaseSpreadsheetViewer: rename spreadsheet to content

### DIFF
--- a/.changeset/spreadsheet-viewer-content-prop.md
+++ b/.changeset/spreadsheet-viewer-content-prop.md
@@ -1,0 +1,11 @@
+---
+"@osdk/react-components": minor
+---
+
+`BaseSpreadsheetViewer` takes its parsed workbook as `content`, matching the convention shared by the other viewers.
+
+Nothing is removed. `spreadsheet` is still accepted, is `@deprecated`, and `content` wins when both are set.
+
+```
+BaseSpreadsheetViewer  spreadsheet -> content
+```

--- a/packages/react-components-storybook/src/stories/SpreadsheetViewer/SpreadsheetViewer.stories.tsx
+++ b/packages/react-components-storybook/src/stories/SpreadsheetViewer/SpreadsheetViewer.stories.tsx
@@ -164,7 +164,7 @@ const meta: Meta<BaseSpreadsheetViewerProps> = {
   component: BaseSpreadsheetViewer,
   tags: ["beta"],
   args: {
-    spreadsheet: SAMPLE_SPREADSHEET,
+    content: SAMPLE_SPREADSHEET,
   },
   render: (args: BaseSpreadsheetViewerProps) => (
     <div style={{ height: "500px" }}>
@@ -175,8 +175,8 @@ const meta: Meta<BaseSpreadsheetViewerProps> = {
     controls: { expanded: true },
   },
   argTypes: {
-    spreadsheet: {
-      description: "Parsed spreadsheet data",
+    content: {
+      description: "The parsed spreadsheet to render",
       control: false,
     },
     className: {
@@ -215,7 +215,7 @@ export const WithSpreadsheet: Story = {
       source: {
         code: `import { BaseSpreadsheetViewer } from "@osdk/react-components/experimental/spreadsheet-viewer";
 
-<BaseSpreadsheetViewer spreadsheet={parsedSpreadsheet} />`,
+<BaseSpreadsheetViewer content={parsedSpreadsheet} />`,
       },
     },
   },
@@ -223,7 +223,7 @@ export const WithSpreadsheet: Story = {
 
 export const SingleSheet: Story = {
   args: {
-    spreadsheet: {
+    content: {
       sheets: [SAMPLE_SPREADSHEET.sheets[0]!],
     },
   },

--- a/packages/react-components/docs/SpreadsheetViewer.md
+++ b/packages/react-components/docs/SpreadsheetViewer.md
@@ -30,7 +30,7 @@ import { SpreadsheetViewer } from "@osdk/react-components/experimental/spreadshe
 import { BaseSpreadsheetViewer } from "@osdk/react-components/experimental/spreadsheet-viewer";
 
 <BaseSpreadsheetViewer
-  spreadsheet={{
+  content={{
     sheets: [
       {
         name: "Sheet1",
@@ -51,7 +51,8 @@ import { BaseSpreadsheetViewer } from "@osdk/react-components/experimental/sprea
 
 | Prop          | Type                | Required | Description                           |
 | ------------- | ------------------- | -------- | ------------------------------------- |
-| `spreadsheet` | `ParsedSpreadsheet` | Yes      | Parsed spreadsheet data               |
+| `content`     | `ParsedSpreadsheet` | No       | The parsed spreadsheet to render      |
+| `spreadsheet` | `ParsedSpreadsheet` | No       | **Deprecated** — rename to `content`  |
 | `className`   | `string`            | No       | CSS class applied to the root element |
 
 ### SpreadsheetViewerProps

--- a/packages/react-components/src/spreadsheet-viewer/BaseSpreadsheetViewer.tsx
+++ b/packages/react-components/src/spreadsheet-viewer/BaseSpreadsheetViewer.tsx
@@ -24,6 +24,8 @@ import type {
 
 import styles from "./BaseSpreadsheetViewer.module.css";
 
+const EMPTY_SHEETS: readonly SheetData[] = [];
+
 /**
  * Converts a 0-based column index to a spreadsheet column letter (0=A, 1=B, ..., 25=Z, 26=AA).
  */
@@ -82,20 +84,18 @@ const SheetTable: React.FunctionComponent<{ sheet: SheetData }> = React.memo(
 SheetTable.displayName = "SheetTable";
 
 export function BaseSpreadsheetViewer({
+  content,
   spreadsheet,
   className,
 }: BaseSpreadsheetViewerProps): React.ReactElement {
   const [activeSheetIndex, setActiveSheetIndex] = useState(0);
   const rootClassName = classnames(styles.container, className);
 
-  const safeIndex = Math.min(
-    activeSheetIndex,
-    Math.max(0, spreadsheet.sheets.length - 1),
-  );
-  const activeSheet = useMemo(
-    () => spreadsheet.sheets[safeIndex],
-    [spreadsheet.sheets, safeIndex],
-  );
+  // eslint-disable-next-line @typescript-eslint/no-deprecated -- pre-rename fallback
+  const sheets = (content ?? spreadsheet)?.sheets ?? EMPTY_SHEETS;
+
+  const safeIndex = Math.min(activeSheetIndex, Math.max(0, sheets.length - 1));
+  const activeSheet = useMemo(() => sheets[safeIndex], [sheets, safeIndex]);
 
   const handleTabClick = useCallback((index: number) => {
     setActiveSheetIndex(index);
@@ -108,9 +108,9 @@ export function BaseSpreadsheetViewer({
       ) : (
         <div className={styles.emptySheet}>No sheets</div>
       )}
-      {spreadsheet.sheets.length > 1 && (
+      {sheets.length > 1 && (
         <div className={styles.tabBar}>
-          {spreadsheet.sheets.map((sheet, index) => (
+          {sheets.map((sheet, index) => (
             <button
               key={sheet.name}
               className={classnames(styles.tab, {

--- a/packages/react-components/src/spreadsheet-viewer/SpreadsheetViewer.tsx
+++ b/packages/react-components/src/spreadsheet-viewer/SpreadsheetViewer.tsx
@@ -34,7 +34,7 @@ export function SpreadsheetViewer({
   ...spreadsheetViewerProps
 }: SpreadsheetViewerProps): React.ReactElement {
   const {
-    data: spreadsheet,
+    data: content,
     loading,
     error,
   } = useMediaContents<ParsedSpreadsheet>(
@@ -58,11 +58,8 @@ export function SpreadsheetViewer({
           Failed to load spreadsheet: {error.message}
         </div>
       )}
-      {spreadsheet != null && (
-        <BaseSpreadsheetViewer
-          spreadsheet={spreadsheet}
-          {...spreadsheetViewerProps}
-        />
+      {content != null && (
+        <BaseSpreadsheetViewer content={content} {...spreadsheetViewerProps} />
       )}
     </div>
   );

--- a/packages/react-components/src/spreadsheet-viewer/SpreadsheetViewerApi.ts
+++ b/packages/react-components/src/spreadsheet-viewer/SpreadsheetViewerApi.ts
@@ -29,8 +29,11 @@ export interface ParsedSpreadsheet {
 }
 
 export interface BaseSpreadsheetViewerProps {
-  /** Parsed spreadsheet data */
-  spreadsheet: ParsedSpreadsheet;
+  /** The parsed spreadsheet to render. */
+  // TODO: make this required when `spreadsheet` is removed.
+  content?: ParsedSpreadsheet;
+  /** @deprecated Rename to `content`. */
+  spreadsheet?: ParsedSpreadsheet;
   /** Additional CSS class name for the root element
    * @default undefined */
   className?: string;
@@ -38,7 +41,7 @@ export interface BaseSpreadsheetViewerProps {
 
 export interface SpreadsheetViewerProps extends Omit<
   BaseSpreadsheetViewerProps,
-  "spreadsheet"
+  "content" | "spreadsheet"
 > {
   /** The Media object to fetch spreadsheet contents from */
   media: Media;

--- a/packages/react-components/src/spreadsheet-viewer/__tests__/BaseSpreadsheetViewer.test.tsx
+++ b/packages/react-components/src/spreadsheet-viewer/__tests__/BaseSpreadsheetViewer.test.tsx
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { BaseSpreadsheetViewer } from "../BaseSpreadsheetViewer.js";
+import type { ParsedSpreadsheet } from "../SpreadsheetViewerApi.js";
+
+afterEach(() => {
+  cleanup();
+});
+
+const SINGLE_SHEET: ParsedSpreadsheet = {
+  sheets: [
+    {
+      name: "Revenue",
+      rows: [
+        ["Region", "Total"],
+        ["Europe", "42"],
+      ],
+    },
+  ],
+};
+
+const TWO_SHEETS: ParsedSpreadsheet = {
+  sheets: [
+    { name: "Revenue", rows: [["Team"], ["Platform"]] },
+    { name: "Costs", rows: [["Line item"], ["Hosting"]] },
+  ],
+};
+
+describe("BaseSpreadsheetViewer", () => {
+  it("should render cells from content", () => {
+    render(<BaseSpreadsheetViewer content={SINGLE_SHEET} />);
+    expect(screen.getByText("Region")).toBeTruthy();
+    expect(screen.getByText("Europe")).toBeTruthy();
+    expect(screen.getByText("42")).toBeTruthy();
+  });
+
+  it("should render a tab per sheet when there is more than one", () => {
+    render(<BaseSpreadsheetViewer content={TWO_SHEETS} />);
+    expect(screen.getByRole("button", { name: "Revenue" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Costs" })).toBeTruthy();
+  });
+
+  it("should render from the deprecated spreadsheet prop", () => {
+    // eslint-disable-next-line @typescript-eslint/no-deprecated -- covers the pre-rename fallback
+    render(<BaseSpreadsheetViewer spreadsheet={SINGLE_SHEET} />);
+    expect(screen.getByText("Europe")).toBeTruthy();
+  });
+
+  it("should prefer content over the deprecated spreadsheet prop", () => {
+    render(
+      <BaseSpreadsheetViewer
+        content={SINGLE_SHEET}
+        // eslint-disable-next-line @typescript-eslint/no-deprecated -- covers the pre-rename fallback
+        spreadsheet={TWO_SHEETS}
+      />,
+    );
+    expect(screen.getByText("Total")).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "Costs" })).toBeNull();
+  });
+
+  it("should render the empty state when neither prop is set", () => {
+    render(<BaseSpreadsheetViewer />);
+    expect(screen.getByText("No sheets")).toBeTruthy();
+  });
+});

--- a/packages/react-components/src/spreadsheet-viewer/__tests__/SpreadsheetViewer.test.tsx
+++ b/packages/react-components/src/spreadsheet-viewer/__tests__/SpreadsheetViewer.test.tsx
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { Media } from "@osdk/api";
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { useMediaContents } from "../../shared/hooks/useMediaContents.js";
+import { BaseSpreadsheetViewer } from "../BaseSpreadsheetViewer.js";
+import { SpreadsheetViewer } from "../SpreadsheetViewer.js";
+import type { ParsedSpreadsheet } from "../SpreadsheetViewerApi.js";
+
+vi.mock("../BaseSpreadsheetViewer.js", () => ({
+  BaseSpreadsheetViewer: vi.fn(() => null),
+}));
+vi.mock("../../shared/hooks/useMediaContents.js", () => ({
+  useMediaContents: vi.fn(),
+}));
+
+const mockedBaseSpreadsheetViewer = vi.mocked(BaseSpreadsheetViewer);
+const mockedUseMediaContents = vi.mocked(useMediaContents);
+
+const PARSED: ParsedSpreadsheet = {
+  sheets: [{ name: "Revenue", rows: [["Region"], ["Europe"]] }],
+};
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+// Pins the prop name the wrapper forwards under. The deprecated `spreadsheet`
+// alias behaves identically, so without this a revert to the old name would
+// leave every other test green.
+describe("SpreadsheetViewer", () => {
+  it("should forward the fetched workbook as content, not as the deprecated spreadsheet prop", () => {
+    mockedUseMediaContents.mockReturnValue({
+      data: PARSED,
+      loading: false,
+      error: undefined,
+    });
+
+    render(<SpreadsheetViewer media={{} as unknown as Media} />);
+
+    const props = mockedBaseSpreadsheetViewer.mock.calls[0]?.[0];
+    expect(props).toMatchObject({ content: PARSED });
+  });
+});


### PR DESCRIPTION
Layer 3 of 4, structurally identical to layer 2. `BaseSpreadsheetViewer` takes its parsed workbook as `content`.

### Not Changed

- **Nothing is removed** - `spreadsheet` is still accepted and `@deprecated`; `content` wins when both are set
- **`SpreadsheetViewer`** - the OSDK wrapper still takes `media`

### Worth a look

- **`EMPTY_SHEETS` constant** - the sheet list is read through a module-level constant so the `useMemo` keeps a stable reference when neither prop is passed, rather than allocating a new `[]` per render. Falls through to the existing `No sheets` state
- **First tests for this component** - it had none. Covers both prop names, their precedence, and the empty case
