### PR TITLE
Fix runtime metadata break

### DIFF
--- a/.changeset/plain-donuts-wander.md
+++ b/.changeset/plain-donuts-wander.md
@@ -1,0 +1,5 @@
+---
+"@osdk/generator-converters.preview": patch
+---
+
+Write the TypeScript functions runtime metadata with the plural ontologyRids key required by functions-typescript-runtime 0.311.0 and above

--- a/packages/generator-converters.preview/src/cli/generate-sdk.ts
+++ b/packages/generator-converters.preview/src/cli/generate-sdk.ts
@@ -547,7 +547,7 @@ async function main(): Promise<void> {
     }
 
     const runtimeMetadata = {
-      ontologyRid,
+      ontologyRids: [ontologyRid],
       objectTypeMetadata,
       interfaceTypeMetadata: {},
       magritteSourceMetadata: {},


### PR DESCRIPTION
The "TSv2: Switch to common runtime metadata" PR to typescript-functions-runtime has changed the schema to expect a list of ontologies. This PR fixes the break. 