### PR TITLE
BaseTiffViewer: accept className

### DIFF
--- a/.changeset/tiff-viewer-classname-prop.md
+++ b/.changeset/tiff-viewer-classname-prop.md
@@ -1,0 +1,7 @@
+---
+"@osdk/react-components": minor
+---
+
+`BaseTiffViewer` accepts `className`, like every other base viewer. It renders a root element in every state to carry it, where before it rendered nothing until decoding finished.
+
+`TiffViewerProps` is unchanged for consumers: it now inherits `className` from `BaseTiffViewerProps` instead of declaring its own. `DocumentViewer`'s `tiffViewerProps` omits `className`, matching `pdfViewerProps`, `imageViewerProps` and `videoViewerProps`.

--- a/packages/react-components/docs/TiffViewer.md
+++ b/packages/react-components/docs/TiffViewer.md
@@ -36,11 +36,12 @@ import { BaseTiffViewer } from "@osdk/react-components/experimental/tiff-rendere
 
 ### `BaseTiffViewerProps`
 
-| Prop      | Type         | Default     | Description                         |
-| --------- | ------------ | ----------- | ----------------------------------- |
-| `src`     | `Uint8Array` | `undefined` | TIFF bytes to render                |
-| `content` | `Uint8Array` | `undefined` | **Deprecated** — rename to `src`    |
-| `onError` | `() => void` | `undefined` | Callback fired when rendering fails |
+| Prop        | Type         | Default     | Description                           |
+| ----------- | ------------ | ----------- | ------------------------------------- |
+| `src`       | `Uint8Array` | `undefined` | TIFF bytes to render                  |
+| `content`   | `Uint8Array` | `undefined` | **Deprecated** — rename to `src`      |
+| `className` | `string`     | `undefined` | CSS class applied to the root element |
+| `onError`   | `() => void` | `undefined` | Callback fired when rendering fails   |
 
 ### `TiffViewerProps`
 

--- a/packages/react-components/src/images/tiff-viewer/BaseTiffViewer.module.css
+++ b/packages/react-components/src/images/tiff-viewer/BaseTiffViewer.module.css
@@ -1,3 +1,8 @@
+.container {
+  width: 100%;
+  height: 100%;
+}
+
 .canvas {
   height: 100%;
   object-fit: contain;

--- a/packages/react-components/src/images/tiff-viewer/BaseTiffViewer.tsx
+++ b/packages/react-components/src/images/tiff-viewer/BaseTiffViewer.tsx
@@ -17,6 +17,7 @@
 /* cspell:words ifds */
 
 import { Error as ErrorIcon } from "@blueprintjs/icons";
+import classnames from "classnames";
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import * as UTIF from "utif";
 
@@ -121,7 +122,7 @@ const TiffCanvas: React.FunctionComponent<{ imageData: TiffImageData }> =
   });
 
 export const BaseTiffViewer: React.FunctionComponent<BaseTiffViewerProps> =
-  React.memo(({ src, content, onError }) => {
+  React.memo(({ src, content, className, onError }) => {
     const [result, setResult] = useState<DecodeResult | undefined>(undefined);
     const onErrorRef = useRef(onError);
     onErrorRef.current = onError;
@@ -141,13 +142,14 @@ export const BaseTiffViewer: React.FunctionComponent<BaseTiffViewerProps> =
       }
     }, [bytes]);
 
-    if (result == null) {
-      return null;
-    }
+    const rootClassName = classnames(styles.container, className);
 
-    if (result.status === "error") {
-      return <ErrorMessage message={result.message} />;
-    }
-
-    return <TiffCanvas imageData={result.data} />;
+    return (
+      <div className={rootClassName}>
+        {result?.status === "error" && (
+          <ErrorMessage message={result.message} />
+        )}
+        {result?.status === "ok" && <TiffCanvas imageData={result.data} />}
+      </div>
+    );
   });

--- a/packages/react-components/src/images/tiff-viewer/TiffViewerApi.ts
+++ b/packages/react-components/src/images/tiff-viewer/TiffViewerApi.ts
@@ -22,6 +22,9 @@ export interface BaseTiffViewerProps {
   src?: Uint8Array;
   /** @deprecated Rename to `src`. */
   content?: Uint8Array;
+  /** Additional CSS class name for the root element
+   * @default undefined */
+  className?: string;
   /** Callback fired when rendering fails */
   onError?: () => void;
 }
@@ -32,6 +35,4 @@ export interface TiffViewerProps extends Omit<
 > {
   /** The Media object to fetch TIFF contents from */
   media: Media;
-  /** Additional CSS class name for the root element */
-  className?: string;
 }

--- a/packages/react-components/src/images/tiff-viewer/__tests__/BaseTiffViewer.test.tsx
+++ b/packages/react-components/src/images/tiff-viewer/__tests__/BaseTiffViewer.test.tsx
@@ -165,7 +165,7 @@ describe("BaseTiffViewer", () => {
     expect(decoded.byteLength).toBe(fromSrc.byteLength);
   });
 
-  it("should render nothing when neither prop is set", async () => {
+  it("should render no canvas when neither prop is set", async () => {
     let container: HTMLElement;
     await act(() => {
       ({ container } = render(<BaseTiffViewer />));
@@ -173,5 +173,24 @@ describe("BaseTiffViewer", () => {
 
     expect(container!.querySelector("canvas")).toBeNull();
     expect(mockedDecode).not.toHaveBeenCalled();
+  });
+
+  it("should apply className to the root element", async () => {
+    const mockImage = createMockImage(100, 50);
+    mockedDecode.mockReturnValue([mockImage]);
+    mockedDecodeImage.mockReturnValue(undefined);
+    mockedToRGBA8.mockReturnValue(new Uint8Array(100 * 50 * 4));
+
+    let container: HTMLElement;
+    await act(() => {
+      ({ container } = render(
+        <BaseTiffViewer src={new Uint8Array(100)} className="custom-tiff" />,
+      ));
+    });
+
+    const root = container!.firstElementChild;
+    expect(root?.classList.contains("custom-tiff")).toBe(true);
+    // The container class stays alongside it rather than being replaced.
+    expect(root?.classList.length).toBeGreaterThan(1);
   });
 });


### PR DESCRIPTION
Layer 5 of the stack. `BaseTiffViewer` accepts `className`, like every other base viewer.

### The inconsistency

- **`BaseTiffViewerProps` had no `className`** while the other seven base viewers all do
- **It had no root element either** — it returned `null`, a bare error `div`, or a bare `canvas`, so there was nowhere to put one
- **`TiffViewerProps` re-declared `className` by hand** to compensate
- **`DocumentViewerApi` omitted a `className` key the interface never had.** That omit was not a mistake: `pdfViewerProps`, `imageViewerProps` and `videoViewerProps` all omit `className` too, so the TIFF bag was written for the shape TIFF should have had

### What changed

- **Root element in every state** carrying `classnames(styles.container, className)`, matching `BaseImageViewer`
- **`.container` is layout-only** (`width`/`height: 100%`). Rendering is unchanged: the canvas was already `100%`/`100%` and now resolves against the same grandparent as before, and the shared error styles are plain flex with no positioning or child selectors
- **`TiffViewerProps` drops its hand-rolled `className`** and inherits it, exactly as `ImageViewerProps` does. No change for consumers

### Not Changed

- **No new CSS custom properties.** `BaseImageViewer`'s container also carries a background, border and radius from `--osdk-image-viewer-*`. Giving TIFF the same would be a visible change and needs new tokens plus `CSSVariables.md` entries, so it is left for its own PR

### Worth a look

- **`BaseTiffViewer` no longer early-returns `null`** before decoding finishes. That is required for `className` to apply in every state, and it brings the component in line with the package rule about rendering during loading and error states. The one existing test that asserted this is retitled from "renders nothing" to "renders no canvas"
- **Visual check belongs in CI.** The container is layout-only by construction, but the browsable storybook artifact is the place to confirm the TIFF stories are unchanged
