### PR TITLE
Make e2e depend on build instead of racing it

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -539,7 +539,7 @@ workflows:
       - cspell:
           requires: [install]
       - e2e:
-          requires: [install]
+          requires: [build]
       - bundle-size:
           requires: [build]
           filters:


### PR DESCRIPTION
First of the e2e speed ups. `e2e` was racing `build` and losing about two thirds of the time, which made it rebuild the entire workspace itself.

### Not Changed

- **What e2e proves** - same faux release and faux publish, nothing removed or skipped
- **Every other job** - dependencies and resource classes untouched
- **The publish step** - still `pnpm publish -r`, see Follow Ups

### The problem

`e2e` required `install`, so it started in parallel with `build` and then ran its own `turbo transpile`. Its restore of build's turbo cache found nothing on every run (0.4-0.5s), because build had usually not saved it yet. So `e2e` either won that race and replayed the cache, or lost it and transpiled everything from scratch.

### The numbers

| | transpile | e2e wall clock |
|---|---|---|
| Race won | 12.5s | 130s |
| Race lost | 118-126s | 248-260s |
| **Now** | **3.5-4.9s** | **124-133s** |

- **It lost two of the three runs measured**, and `e2e` is the critical path, so the pipeline swung with it
- **Better than the lucky case**, because `e2e` now gets build's turbo cache through the workspace attach rather than re-restoring it, so the transpile is a pure replay
- **The trade** is about 39s of serialisation waiting for `build`, against 105s of duplicated work removed, and it is now deterministic either way

### Follow Ups

- **Publish is now 59% of the job**, 71-73s for about 47 packages. Three things were measured and ruled out: removing Verdaccio's npmjs uplink (147 upstream requests down to 0, no time change, landed in the previous PR on hermeticity grounds rather than speed), `--workspace-concurrency` (`pnpm publish` rejects it outright as an unknown option), and more cores (xlarge changed nothing). The limit is `pnpm publish`'s own fixed concurrency, which it does not expose
- **Publishing through turbo** would bypass that and allow explicit concurrency, but it needs a `publish` script in ~47 manifests and a `"cache": false` task, since a cached publish would silently skip the work. Much bigger change, worth its own PR
- **Reimplementing publish with `pnpm exec` was attempted and abandoned** - it gets adjustable concurrency, but each round surfaced another `pnpm publish` behaviour to replicate (auth resolution, then prerelease versions needing `--tag`) while running slower than the command it replaced
- **`Setup Verdaccio` at 11-15s and the workspace attach at 14-16s** are both untouched
- **`e2e` and `storybook-interaction-tests` are converging**, 124-133s against 97-113s, so further `e2e` work hits diminishing returns until storybook is looked at too

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
