### PR TITLE
Allow null values in SeedBuilder update function & Remove branded field

### DIFF
--- a/.changeset/light-dolls-show.md
+++ b/.changeset/light-dolls-show.md
@@ -1,0 +1,5 @@
+---
+"@osdk/seed-helpers": minor
+---
+
+allow null values in seed builder update

--- a/packages/seed-helpers/src/types.ts
+++ b/packages/seed-helpers/src/types.ts
@@ -29,16 +29,8 @@ type PartialForOptionalProperties<T> = {
 export type SeedProps<T extends ObjectTypeDefinition> =
   PartialForOptionalProperties<CompileTimeMetadata<T>["props"]>;
 
-/**
- * Unique symbol used to brand {@link SeedRef} instances. A branded type prevents
- * manually constructed objects from satisfying the interface.
- */
-declare const SEED_REF_BRAND: unique symbol;
-
 export type SeedRef<Q extends ObjectTypeDefinition> = Readonly<
-  OsdkBase<Q> & {
-    readonly [SEED_REF_BRAND]: Q;
-  } & SeedProps<Q>
+  OsdkBase<Q> & SeedProps<Q>
 >;
 
 /** A link entry in the seed output. */

--- a/packages/seed-helpers/src/validation.test.ts
+++ b/packages/seed-helpers/src/validation.test.ts
@@ -73,18 +73,6 @@ describe("validateSeedObject", () => {
     ).toThrow(
       /Property 'badProp' on 'Employee' object \(primary key emp-001\) is not defined in the ontology/u,
     );
-    // Null value — and the identity falls back to <unknown> without a primary key.
-    expect(() =>
-      validateSeedObject(
-        { employeeId: "emp-001", firstName: null },
-        employeeType,
-      ),
-    ).toThrow(
-      /Property 'firstName' on 'Employee' object \(primary key emp-001\) is null or undefined/u,
-    );
-    expect(() => validateSeedObject({ firstName: null }, employeeType)).toThrow(
-      /Property 'firstName' on 'Employee' object \(primary key <unknown>\) is null or undefined/u,
-    );
     // JS type mismatch in either direction.
     expect(() =>
       validateSeedObject(

--- a/packages/seed-helpers/src/validation.ts
+++ b/packages/seed-helpers/src/validation.ts
@@ -119,13 +119,6 @@ export function validateSeedObject(
         ` (primary key ${identity}) is not defined in the ontology`,
     );
 
-    invariant(
-      value != null,
-      () =>
-        `Property '${key}' on '${apiName}' object` +
-        ` (primary key ${identity}) is null or undefined`,
-    );
-
     const expectedJsType = EXPECTED_JS_TYPE[wireType];
     invariant(
       expectedJsType === undefined || typeof value === expectedJsType,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -429,7 +429,7 @@ importers:
         version: link:../../packages/e2e.generated.catchall
       '@osdk/foundry':
         specifier: latest
-        version: 2.71.0
+        version: 2.73.0
       '@osdk/oauth':
         specifier: workspace:*
         version: link:../../packages/oauth
@@ -619,7 +619,7 @@ importers:
         version: link:../../packages/client
       '@osdk/foundry':
         specifier: latest
-        version: 2.71.0
+        version: 2.73.0
       '@osdk/oauth':
         specifier: workspace:*
         version: link:../../packages/oauth
@@ -882,7 +882,7 @@ importers:
         version: link:../../packages/e2e.generated.catchall
       '@osdk/foundry':
         specifier: latest
-        version: 2.71.0
+        version: 2.73.0
       '@osdk/oauth':
         specifier: workspace:*
         version: link:../../packages/oauth
@@ -985,7 +985,7 @@ importers:
         version: link:../../packages/client
       '@osdk/foundry':
         specifier: latest
-        version: 2.71.0
+        version: 2.73.0
       '@osdk/oauth':
         specifier: workspace:*
         version: link:../../packages/oauth
@@ -1429,7 +1429,7 @@ importers:
         version: link:../../packages/e2e.generated.catchall
       '@osdk/foundry':
         specifier: latest
-        version: 2.71.0
+        version: 2.73.0
       '@osdk/oauth':
         specifier: workspace:*
         version: link:../../packages/oauth
@@ -1466,7 +1466,7 @@ importers:
         version: link:../../packages/client
       '@osdk/foundry':
         specifier: latest
-        version: 2.71.0
+        version: 2.73.0
       '@osdk/oauth':
         specifier: workspace:*
         version: link:../../packages/oauth
@@ -9091,32 +9091,32 @@ packages:
   '@osdk/foundry.admin@2.70.0':
     resolution: {integrity: sha512-gmViFLPFPA83caE1dfxeWBP96CuTfx2gK7lqxW4bPbFrYlz4mev1IszuxRhQvhG3r5kK3FsgBZ/WfUmuSbRJAw==}
 
-  '@osdk/foundry.admin@2.71.0':
-    resolution: {integrity: sha512-DAIaEF+rpsPEz+NtUhBgGDTEBvT3Jv0Y+HeI1z/0DVz68wSQNooQZbRIqDlmZI2Rz29ki/yUs/IRa25tKY63QQ==}
+  '@osdk/foundry.admin@2.73.0':
+    resolution: {integrity: sha512-R8YvY1W4m0XtxWFPzTTbK9F9AGwXGw9/AKDC/LYwIWSMuFNhT2KL8wLA67MURIWxLniXt7vrnihwUoDe0O+p8g==}
 
   '@osdk/foundry.aipagents@2.70.0':
     resolution: {integrity: sha512-MxVwiVMxzZqgI7A1oGK2uITwxBMYE8KHTefZ9aPmDYkxk+Vl+phuYD8t7SMMxZsfSUI8AoGJHc/+/774JOwwDg==}
 
-  '@osdk/foundry.aipagents@2.71.0':
-    resolution: {integrity: sha512-Z3f5Pho7KKPT0EukRoWXOhyNwAVokLq+m8HlnrDNsPenf1g0p2qAReio+f6241CQWR6kS2LI3SfcqGAA+SuqtA==}
+  '@osdk/foundry.aipagents@2.73.0':
+    resolution: {integrity: sha512-05MYhhNsvmtSC2jFLYPMNkYaLHhZ2aDmOeQOumI3w6i5ZqwVT7uDrt5lPOlmfjDhFEdvxn2xa89Ihgwi0ZYbvw==}
 
   '@osdk/foundry.audit@2.70.0':
     resolution: {integrity: sha512-YY4IFvqT9DjfqApEU+qjfpiZv/KrTDc3b4NpxparuRycXM4fBsSNQ0xoBr7TeFAUiJFaataYk57caeFJnWvIYA==}
 
-  '@osdk/foundry.audit@2.71.0':
-    resolution: {integrity: sha512-Gk5yj3GvtgM+qSaxeCn9GrkCKcAo0R1Tm+hS1HP8xP9aa1vqNYKoYzRLOLOA4BCjSwesPDIMesWLi30R8RhdYw==}
+  '@osdk/foundry.audit@2.73.0':
+    resolution: {integrity: sha512-IKXpZcNqeIwZjj3y9BBe1VgwHMd9eic9ywTmajP4i1CdumXhFGZpqaNCjMYWvMZB57HdM/16OtYr05XLcDO9eg==}
 
   '@osdk/foundry.checkpoints@2.70.0':
     resolution: {integrity: sha512-9B0lL2+V0POI1roUb2QGY79e+6MAUODx1Qv/EyhCsdyiyWp378jHTNQZpFUOxsc3JylBAzsy+4dWkJ0fQJB2hw==}
 
-  '@osdk/foundry.checkpoints@2.71.0':
-    resolution: {integrity: sha512-1+xJfl1l+Ny2JqEbrXI2ywTHTi1VS+4qiWNUNjVA/blOnAX2ih6kXlL5zvrEbmFnKoCMjcodAUUCu3pUWVbdFg==}
+  '@osdk/foundry.checkpoints@2.73.0':
+    resolution: {integrity: sha512-mzgwW3MqP0LyF+kwbTQUZUiEm7q6kUmwy+Zecyom/ORvUdvNEKYTtbWUQ3fr6QGdBYpNgsEkg1I+uP87Pvxj0g==}
 
   '@osdk/foundry.connectivity@2.70.0':
     resolution: {integrity: sha512-8jTgN8d5RpTzLehx7qILBxkppTCxiY+GEFMbZ7pQBcpGnzBnaalGg6Wq3EGw/hAsYsHJFNAOtcl7AJ0kboIz/Q==}
 
-  '@osdk/foundry.connectivity@2.71.0':
-    resolution: {integrity: sha512-Oc1NDgG1Vtbu82QcFe1yT+OKWIK5VOMm3bBL7Op4bxhcPv85aBwcQWgOjlUkjQT+eQEAhS1d5SJZ3DgJSVNNtQ==}
+  '@osdk/foundry.connectivity@2.73.0':
+    resolution: {integrity: sha512-6t537UwFIzkOWbKjzRrdZZr/1rb4PYgDrKpiQo0C3jCswnpeO0g77QqCpGbNN0Fjtz5YT2mXR4tVSsUM+P/3Ag==}
 
   '@osdk/foundry.core@2.44.0':
     resolution: {integrity: sha512-fdDAm2pdf67DWo32sXBcfwujAxb7YOKI4iUQ99C1JW92SQRqNBbQZQlM10RJYQ7LMq6S9P1Gz6Gx7KRV7I5Zpw==}
@@ -9127,14 +9127,14 @@ packages:
   '@osdk/foundry.core@2.70.0':
     resolution: {integrity: sha512-586F4+sfGJZPUybv630RHqgHEOUfSLWWmj3e8HP20mXiGvJLSS5tC2qlU16CmdbQxM2J9IpqV/iT/ufv5+Y64A==}
 
-  '@osdk/foundry.core@2.71.0':
-    resolution: {integrity: sha512-eJ7j6RjfhHciEEfcsO+xiabvjmB1MtVyRXMspfuH6XJzxH9hBN4gbJDBXD3SnibZLtyES8fG6tk4+wcyyiFu7Q==}
+  '@osdk/foundry.core@2.73.0':
+    resolution: {integrity: sha512-wqgDfR+CnuuxeZc1CXcH2cfghkqA0jGOh2Wf7V363GK0kRb1QM+xoGmfbCB4Q9ebc8FEfSrD0k/r1PsFLyxDbw==}
 
   '@osdk/foundry.datahealth@2.70.0':
     resolution: {integrity: sha512-7fgmTufDRyxlFrph6Fhjc+OznyKQlrD6yiCCLo2aUYPZGRlpv9B3Ok8Xb0RQ7t2VKRTZOmo5FY3RTAo4NNeIPQ==}
 
-  '@osdk/foundry.datahealth@2.71.0':
-    resolution: {integrity: sha512-te6yvzfXN9S1ExIXfgRtRsjNx8al8K+Izy9hjYLclKq1b91MP/QYoKCOxr5LqA8BW+kXhhUgNVwoyzi6zplXxQ==}
+  '@osdk/foundry.datahealth@2.73.0':
+    resolution: {integrity: sha512-CAhWjDBh1N4cCVdzgIIoG7h43LDldvZwmpetWAVnCLpmHmkbIk062xkZMPeqi2F58l32EG4E2Z8YhfYnrbb0cg==}
 
   '@osdk/foundry.datasets@2.5.0':
     resolution: {integrity: sha512-W82xleLQgQFUTVnAQS54n26xUFEALayotl1f3LGeRLN6r+2G1dNp+UgRU7/IHc/xzOqgulEOGwwr6ENFcsNP2A==}
@@ -9142,8 +9142,8 @@ packages:
   '@osdk/foundry.datasets@2.70.0':
     resolution: {integrity: sha512-9c29iK+kaZogx5j/NaYjXnkZx6M/GVApxfYE+Eh2oMCYMrVlszIFSvr1U4NajF3jrNsKdtcWPu9BhLNfMfVTGA==}
 
-  '@osdk/foundry.datasets@2.71.0':
-    resolution: {integrity: sha512-U5Reh/Qbj2iuda/5gQ3J4G7IA5+HULDisa15dZ4/r1A45PhZT0X5kH1vecShAQiu30DcxvZkzDW5ACfs3VvXMw==}
+  '@osdk/foundry.datasets@2.73.0':
+    resolution: {integrity: sha512-dCtezCUDmkDb/friCTgkHa14zTH2z5q0XBiPvSYWXbVzBS0SoWfGxnDxrWELhoxzKdT3eTOARh+E1kgK816KUg==}
 
   '@osdk/foundry.filesystem@2.5.0':
     resolution: {integrity: sha512-SJKZSfBc7CroyoIVW3D2SpVyaCCnhv8onzIwHcJWOnufFgSbQ3kqyWoqNiStGlymmnoSbniK3rfUFFYeUbxhDQ==}
@@ -9151,14 +9151,14 @@ packages:
   '@osdk/foundry.filesystem@2.70.0':
     resolution: {integrity: sha512-DdB6bm5ivaIvNJ71zQGPORDyflQouqEkgTmJymEY//Twf/9MVmqnob8pFQTMUt851pxiAjrg+2/eBjkRXYqmtQ==}
 
-  '@osdk/foundry.filesystem@2.71.0':
-    resolution: {integrity: sha512-tM0oMd2QbJ4qcHqFHb45sz3qcFp/dt9pq6xbsrkWPXzgJoS/R2ueybBmX4EsjqFUxglm7bFtq4Ns48zAXOlpow==}
+  '@osdk/foundry.filesystem@2.73.0':
+    resolution: {integrity: sha512-bGm6UtfiA0KlxZbP5gdZ70HtfMZ5VcJtabnfoCxTorA1zX4YPP0WOyTJ+J/e19JF1IUaSLgw07ea2ZH+uv2rCw==}
 
   '@osdk/foundry.functions@2.70.0':
     resolution: {integrity: sha512-uI1KN+JvottagpJhgfm14kJn7qnYFDKd2LfCAN7wYTucooV/Itz4mxMjwUua0s7uljUZZdEH0p3EM1PQjKi14g==}
 
-  '@osdk/foundry.functions@2.71.0':
-    resolution: {integrity: sha512-oWcde9i5+4V8WLVJyO/ir5w27cwXuK3ws88vrRX0JEFNDr10uJPZ+aJBiKbBr36p52D/Fzm3wdZmgEhMFan/2Q==}
+  '@osdk/foundry.functions@2.73.0':
+    resolution: {integrity: sha512-gp8Tk4mgQAYp5uW0vNNq9V/ICTog55iqJhGddssSuu1wAwTQs62FbVXOeqSI1p4qMfAxsdWuQSJ+3uYZCq6Jpg==}
 
   '@osdk/foundry.geo@2.44.0':
     resolution: {integrity: sha512-eXiBR2YAesPJe5amQy6G/pz0i4kmgJXiCAocMSYsgVKm/8kuMaqDUn5UJIFYo7EdjLVJueiMAFyCdN0wpK3SZA==}
@@ -9169,20 +9169,20 @@ packages:
   '@osdk/foundry.geo@2.70.0':
     resolution: {integrity: sha512-c7g8QtFILSwyIoPAl72RXslqT0BWSkGU7qvtcxra6ZjskQIJDJqVR1MfRGQWn2vA9Qi8EAqI2wraZxJz+asvIw==}
 
-  '@osdk/foundry.geo@2.71.0':
-    resolution: {integrity: sha512-WqrE8h2wVQ7ll9cCbAjCbXIFv1+dVx19J2dTGymiJsI/xmZN9auX/xOX6iDSam1t1L7rPQpV/laTjZLV8FKskw==}
+  '@osdk/foundry.geo@2.73.0':
+    resolution: {integrity: sha512-map1LI7ic4s93u16mian0hj1QTads3M/nEa+sgJBh2u6rAdal56hK3YKblgvc9NvE7Bg5urAKIohly+f5RAC6g==}
 
   '@osdk/foundry.geojson@2.70.0':
     resolution: {integrity: sha512-V65OHjywcWbENxaWucUHpL4NCpiFM/AXAR8NYDNaL6YwfZF4jn3gNMG6stiuq5zOnkfKPlAKMve3/wYPyQzpJA==}
 
-  '@osdk/foundry.geojson@2.71.0':
-    resolution: {integrity: sha512-M/TdrAnb19H3ems81jnoXsTJo32L62QyEXisFY+NFx1K5QJviIx6sZQggo12sTL6qSM7eyKWq6TIzdNzXcmOIA==}
+  '@osdk/foundry.geojson@2.73.0':
+    resolution: {integrity: sha512-huWeBypQ3H4RpkPiuhw7mX5kCaDb3KZupUi4IQmb0T1U6Shv+GZsT590lRLqFOoffXvlTXS221vU47hbMG46BA==}
 
   '@osdk/foundry.languagemodels@2.70.0':
     resolution: {integrity: sha512-EO4rXR+TBUMvzJja8ncYMg4/MOFRNAn2aBZcmY37XhQ8+sfR28lryMuVkVq3J0GnsZXOtfTMcv5Jif50GfBrog==}
 
-  '@osdk/foundry.languagemodels@2.71.0':
-    resolution: {integrity: sha512-+hPMd3vRPS83D9pFDCcM34PoQWsFZd53UQqFtfF7J2Xe11E7pZq48Qo57RwfdRf3a1Axs0EtFrBOVpLopki5lQ==}
+  '@osdk/foundry.languagemodels@2.73.0':
+    resolution: {integrity: sha512-HPOQSmfrzMPUS4M0fWr5lH9pT1/fXhRM0e2IpkcmT/gK/48UibK0sp9jl2ZXuw9pjqNg7YP/rPMU6vGx9TyBqA==}
 
   '@osdk/foundry.mediasets@2.44.0':
     resolution: {integrity: sha512-l378lxKUdIMmb1txFs/hOKyPO3bc10OWU4BvaP/LMZjXLbUZPNI/DYAmKrzKTeSMGBnZ2luhqEyfPfZYMGmrhw==}
@@ -9190,20 +9190,20 @@ packages:
   '@osdk/foundry.mediasets@2.70.0':
     resolution: {integrity: sha512-Ag4lm2H0WbIx6loOykYjoJWzxiqxvU2Fva+58XsTISIgg81CEEDvhls6UoLUX3IVq7vhWquYZnJUuogRTOYNeA==}
 
-  '@osdk/foundry.mediasets@2.71.0':
-    resolution: {integrity: sha512-wKkz+Ql5ChX9wrlijEZ1qlwjDGEXWL99KAPoX3dXTiCx+03eqyHKeAc8R10MgxtOIGPQZxiSBzNbRCuxMByQqA==}
+  '@osdk/foundry.mediasets@2.73.0':
+    resolution: {integrity: sha512-ztLsK3QQsSvnkUkzMApZLsf8h38Q4fNFY9pS2Bap/feMHx4vsi+SxMRdcZSgJ9DYuAwNWfYsPcgf7aZNU61C1Q==}
 
   '@osdk/foundry.models@2.70.0':
     resolution: {integrity: sha512-YvBM6UU+0CbIyzWmiShFXSt2nLpGV1+JkHtusjoOy8wd9UGN65SIsHAwGm601Sciqk/yiiD16YNFgX/m0RJgog==}
 
-  '@osdk/foundry.models@2.71.0':
-    resolution: {integrity: sha512-YKjUakMylPGVwA3tJrN7heqNMLvnP24EswwhiTyyxnhV6L4umkmrKxT4oAYGz3DmXsNR8qHsgMPGEwJOzuIzpQ==}
+  '@osdk/foundry.models@2.73.0':
+    resolution: {integrity: sha512-q69O4yr7sJNTo0UCHMAkHgwEa+QKPuqsahF9tCGXVNcYPm8rFxznuP/bjMbwVFmfOJfUR5M3opvwo+qnWSg0fg==}
 
   '@osdk/foundry.notepad@2.70.0':
     resolution: {integrity: sha512-vlOGxmU/jtKaBaY5D7+y0rYHclN/H2XDMKVnjlseMy8lu3JPK2hxlGQ2Vdo3yv/X45kz+sH4VKa/j/kVJgk4cA==}
 
-  '@osdk/foundry.notepad@2.71.0':
-    resolution: {integrity: sha512-/vpDpcLcvF0u72JSRvCRwl90bvR7ngN/A6Nl5Wu8ns1G3r8HKk37NheU6Mfp5eXAut8wiuYKWXXy366yfMTqUw==}
+  '@osdk/foundry.notepad@2.73.0':
+    resolution: {integrity: sha512-+M4/sTtdKxOfNS3tAPZougw8QFCwW1p7dHztpwYX9dGFdM/he4SzQtuZFv3EgJdsAa+H/PNnuKaMAvgE0MY2bA==}
 
   '@osdk/foundry.ontologies@2.44.0':
     resolution: {integrity: sha512-A74NrG3tDiLNC5VW+plchrrMDf5gLekavrdyVnmVqQAkcBc6Z8/Jl+92rJbQ/v6TJnXWpCwuCkc+QQXaYlhHKQ==}
@@ -9211,62 +9211,62 @@ packages:
   '@osdk/foundry.ontologies@2.70.0':
     resolution: {integrity: sha512-QVYx/iJ4Fj6K/USKXg1GwLG0DwYtSuU0ok3Phygeua3iDMzpitQuroto5/Njy+I3dbhKaFdGVsQM5gDAL6fTTg==}
 
-  '@osdk/foundry.ontologies@2.71.0':
-    resolution: {integrity: sha512-Kzo8TI32rTJLbUZwi87op4q4b2cZynHQzxx0FDbYhxyyiC1U06wek3FzALjlY4SzpVx3YmaFkLmfeYXaPnQ/fw==}
+  '@osdk/foundry.ontologies@2.73.0':
+    resolution: {integrity: sha512-eoViI7iiR1PRRpS88/rIkYAIbVMKnVCHDa7TFYtxc6lQbEGVazkHL5OZ8eqnX4n5fPK/KIAk1mGgi4wUVOhHcA==}
 
   '@osdk/foundry.operations@2.70.0':
     resolution: {integrity: sha512-P79/V/SCYZeWchheC764NJB/+SzNPCB5i9cmNAT9hKeya2T44a2J7IpJafsp1CETttmS7hiEupx+de7UplA9mg==}
 
-  '@osdk/foundry.operations@2.71.0':
-    resolution: {integrity: sha512-JjiZQU0zvkoRqwEjN8EqPwiIRsm8zIw6RsfuaM/D2iujt9aYdNbLIuoIzJzD+I/Ijg1P2JXfsRXtb0CKISwFPQ==}
+  '@osdk/foundry.operations@2.73.0':
+    resolution: {integrity: sha512-B99kU3E/l1eIFcEDzbtsFSIAHAAeTI7rkAwkzCeGqDm61zzw4k87fFzlRrFbPScbmuHngHvA8QMFfS9JK5qpFg==}
 
   '@osdk/foundry.orchestration@2.70.0':
     resolution: {integrity: sha512-dUuHqTyPvK5emYuVA2pgQgnzAlg0A/jGxiiQrYjYnwLFeDn/Ok5hTGaLYGiRX8Ngl4qTigHoYumc574XvmNyVg==}
 
-  '@osdk/foundry.orchestration@2.71.0':
-    resolution: {integrity: sha512-z7SLQo3JJxCGbUlHIYERAEBdfhnliSKnX0eIYbOY01Y4u3slpflbMpXTPnpERSITdo20b/qrAUautZX11k/xSQ==}
+  '@osdk/foundry.orchestration@2.73.0':
+    resolution: {integrity: sha512-a91+YtbyLsnWMOG2EfcastBxf9kF6ZFseth/EuC99P1A1/TTS0ovkGXlK6HNQFHF+R8xK8gYMdtfY3zgjoWeBQ==}
 
   '@osdk/foundry.pack@2.70.0':
     resolution: {integrity: sha512-ds86ZKx9dljuKIlMsBM/Doq19cdBvhmR3vOjfZvjGST+qvSVV4aZRVv8vbpkF20V0/s5ueTw4OYO9n2LhVobDA==}
 
-  '@osdk/foundry.pack@2.71.0':
-    resolution: {integrity: sha512-kKAte+aXUAM/YloEE3/1l89sJHiwv/nGOt0431ne8+gQWgOjEakXHa6anKDnINOxieOYQ+EmAfnHnNFvVTe0Yg==}
+  '@osdk/foundry.pack@2.73.0':
+    resolution: {integrity: sha512-CPt0RX8ai/UQc8GqPV8AzqtxfmG66Yo84KUZGWpvsQRAfcvJ70X/jDD1FncRqLCetlY1q3tK8j11/5SRt9v1eQ==}
 
   '@osdk/foundry.publicapis@2.70.0':
     resolution: {integrity: sha512-L3WENihrbpj1/CITW5hp87PD94eZulJvnTlrC33uTGn7HZnQ5072oVXztGS024FZdi1ilmW1NHSyRFxog0w24g==}
 
-  '@osdk/foundry.publicapis@2.71.0':
-    resolution: {integrity: sha512-Vx/xGpNtnsYgTEnGMDX30jWM/TmLasFAC6P2/IvQVqaxSwYZHY3NvbABkcVxCHLORKY/+Aqnmi9A0Hn46IdxVw==}
+  '@osdk/foundry.publicapis@2.73.0':
+    resolution: {integrity: sha512-SjMCayouoNFVeHFcMrFsmts/17ADZ59t1TWzJBn6ZKTlwJ6p66ozdnWQC14YY/+3TMXKZEckHuoLp6wYndDdvQ==}
 
   '@osdk/foundry.sqlqueries@2.70.0':
     resolution: {integrity: sha512-uOS/DvipsqUq/WTlGXMAN9RcQOFxK1u048R40uvClIoVd0HtGUa+PbaieeIhhFDPoLZrn7WJ6lbF8pFMLdPKsA==}
 
-  '@osdk/foundry.sqlqueries@2.71.0':
-    resolution: {integrity: sha512-BIeRygxsXL7EEA8MPWP+9siLTbuFN21S9mVV7YXY3A0N7B1903WOXXOLFpdQfyVj9PUL2dW+0BQszohRFDrmBg==}
+  '@osdk/foundry.sqlqueries@2.73.0':
+    resolution: {integrity: sha512-xFI95P5gF0nM/3VVtL5kDkczaLeDnA/KmvZ4hjQLrjZRqgdgnXvzmA1KEe1aDWQyDSVezSlKp77BYo8SVeMFWw==}
 
   '@osdk/foundry.streams@2.70.0':
     resolution: {integrity: sha512-lFuLFfkjs+1rjAQaf5+aO+Z2R1XA7w4qdrdXIJT9j+Bt5vOrd+SNhNwCOQ1O4tiPboho1dWArDlvVIsrdjrC8g==}
 
-  '@osdk/foundry.streams@2.71.0':
-    resolution: {integrity: sha512-6uQKB7zLlfuNLHKP8PKiTDAFCx4T64qEgZ1UjpmtLtjKAQfMiVipwrDBON2YZt5mFGo2PxeWdsok3aSi++nOAg==}
+  '@osdk/foundry.streams@2.73.0':
+    resolution: {integrity: sha512-gWqAkt2ydzKdkP4bSQR9U1RIfArwmi8bxYQolVEuF7vQ6s5ufqp5H04URoKHspBppgc2+vgmq+qZj5QJC7GMUw==}
 
   '@osdk/foundry.thirdpartyapplications@2.70.0':
     resolution: {integrity: sha512-69VsjXuT1sDxAScFHIryHFIjAOl5+rquN38ELFfvAN0wm4evEnx1HxuN7MhPEY7FZAbxm1nefEuVBh6n5K6Naw==}
 
-  '@osdk/foundry.thirdpartyapplications@2.71.0':
-    resolution: {integrity: sha512-+HZrncX8Kuwr4Qp+lK5gdCRXnbUhkbmHJg+odcIbmC/BYaiIWzpdFnLHoOZjqCFNM20STEUzeWo/VdnsRm+Jpw==}
+  '@osdk/foundry.thirdpartyapplications@2.73.0':
+    resolution: {integrity: sha512-fLb16QgG17gIWFI8ZdQiyUEfZXQN2Kpm/IMEcFOFmUI+s9FjP9lF2UWfljYRFUgdj5STL07LRHPy9DgKDRtEGg==}
 
   '@osdk/foundry.widgets@2.70.0':
     resolution: {integrity: sha512-47xlD8dEqSERTBla/EEk7ETpfPRUUABna66n47W6HoX9Er12aC4fG7IqvvdkdjIl46pgBWvi4hYU9jf17tRgxg==}
 
-  '@osdk/foundry.widgets@2.71.0':
-    resolution: {integrity: sha512-QMjSB2Q2ING7aVWZyPQzpkLEh/f0isyJlXbGNCiSgCMI/3s/MIZMUr++epHa6Pc/+vMUKU598D/2fKQbhN+bEg==}
+  '@osdk/foundry.widgets@2.73.0':
+    resolution: {integrity: sha512-tGhg4+F5/0Fs8leKKkB4jGr9z5jZ777yu1tVx/9tJByMYQG7ghkeqG6TJDEYWIBYwUVlwg1/geX0dOrsdWthVA==}
 
   '@osdk/foundry@2.70.0':
     resolution: {integrity: sha512-5jyCvjoW/hBLVOhjVqGPQc+9so+cprDLGmFx1IsOI/yooUBMjdm4mRwAE4UwNmLuVAk98p1nt4f5cG5acD7vVQ==}
 
-  '@osdk/foundry@2.71.0':
-    resolution: {integrity: sha512-xGJkcOCIZTtWrGYb9ZahdA7RkIYVR3FI3W29fxOyiPJT/MWrof5TIvK1eMxzGvX4/Trp2R+myVdo9+VZz7JWpQ==}
+  '@osdk/foundry@2.73.0':
+    resolution: {integrity: sha512-RzZ4mjo66llOQasGnOyHIMNIQAU0imyiWhpGrnMLLQQFyCB1sbSc5wWk1mLDYeda7rHKXGrjqtzdVCfwZO3w9w==}
 
   '@osdk/gateway@2.4.2':
     resolution: {integrity: sha512-A2WmRHxzCiZKyviYKAQEq9KZwL5DEkhXADLt36lMn2tGixO5qOTU7rLsE+OAA4va+evmd44TfzipJs8ieffP6g==}
@@ -26488,9 +26488,9 @@ snapshots:
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.7.0
 
-  '@osdk/foundry.admin@2.71.0':
+  '@osdk/foundry.admin@2.73.0':
     dependencies:
-      '@osdk/foundry.core': 2.71.0
+      '@osdk/foundry.core': 2.73.0
       '@osdk/shared.client': 1.0.1
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.7.0
@@ -26504,11 +26504,11 @@ snapshots:
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.7.0
 
-  '@osdk/foundry.aipagents@2.71.0':
+  '@osdk/foundry.aipagents@2.73.0':
     dependencies:
-      '@osdk/foundry.core': 2.71.0
-      '@osdk/foundry.functions': 2.71.0
-      '@osdk/foundry.ontologies': 2.71.0
+      '@osdk/foundry.core': 2.73.0
+      '@osdk/foundry.functions': 2.73.0
+      '@osdk/foundry.ontologies': 2.73.0
       '@osdk/shared.client': 1.0.1
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.7.0
@@ -26520,9 +26520,9 @@ snapshots:
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.7.0
 
-  '@osdk/foundry.audit@2.71.0':
+  '@osdk/foundry.audit@2.73.0':
     dependencies:
-      '@osdk/foundry.core': 2.71.0
+      '@osdk/foundry.core': 2.73.0
       '@osdk/shared.client': 1.0.1
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.7.0
@@ -26534,9 +26534,9 @@ snapshots:
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.7.0
 
-  '@osdk/foundry.checkpoints@2.71.0':
+  '@osdk/foundry.checkpoints@2.73.0':
     dependencies:
-      '@osdk/foundry.core': 2.71.0
+      '@osdk/foundry.core': 2.73.0
       '@osdk/shared.client': 1.0.1
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.7.0
@@ -26549,10 +26549,10 @@ snapshots:
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.7.0
 
-  '@osdk/foundry.connectivity@2.71.0':
+  '@osdk/foundry.connectivity@2.73.0':
     dependencies:
-      '@osdk/foundry.core': 2.71.0
-      '@osdk/foundry.filesystem': 2.71.0
+      '@osdk/foundry.core': 2.73.0
+      '@osdk/foundry.filesystem': 2.73.0
       '@osdk/shared.client': 1.0.1
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.7.0
@@ -26578,9 +26578,9 @@ snapshots:
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.7.0
 
-  '@osdk/foundry.core@2.71.0':
+  '@osdk/foundry.core@2.73.0':
     dependencies:
-      '@osdk/foundry.geo': 2.71.0
+      '@osdk/foundry.geo': 2.73.0
       '@osdk/shared.client': 1.0.1
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.7.0
@@ -26592,9 +26592,9 @@ snapshots:
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.7.0
 
-  '@osdk/foundry.datahealth@2.71.0':
+  '@osdk/foundry.datahealth@2.73.0':
     dependencies:
-      '@osdk/foundry.core': 2.71.0
+      '@osdk/foundry.core': 2.73.0
       '@osdk/shared.client': 1.0.1
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.7.0
@@ -26616,11 +26616,11 @@ snapshots:
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.7.0
 
-  '@osdk/foundry.datasets@2.71.0':
+  '@osdk/foundry.datasets@2.73.0':
     dependencies:
-      '@osdk/foundry.core': 2.71.0
-      '@osdk/foundry.datahealth': 2.71.0
-      '@osdk/foundry.filesystem': 2.71.0
+      '@osdk/foundry.core': 2.73.0
+      '@osdk/foundry.datahealth': 2.73.0
+      '@osdk/foundry.filesystem': 2.73.0
       '@osdk/shared.client': 1.0.1
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.7.0
@@ -26639,9 +26639,9 @@ snapshots:
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.7.0
 
-  '@osdk/foundry.filesystem@2.71.0':
+  '@osdk/foundry.filesystem@2.73.0':
     dependencies:
-      '@osdk/foundry.core': 2.71.0
+      '@osdk/foundry.core': 2.73.0
       '@osdk/shared.client': 1.0.1
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.7.0
@@ -26654,10 +26654,10 @@ snapshots:
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.7.0
 
-  '@osdk/foundry.functions@2.71.0':
+  '@osdk/foundry.functions@2.73.0':
     dependencies:
-      '@osdk/foundry.core': 2.71.0
-      '@osdk/foundry.ontologies': 2.71.0
+      '@osdk/foundry.core': 2.73.0
+      '@osdk/foundry.ontologies': 2.73.0
       '@osdk/shared.client': 1.0.1
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.7.0
@@ -26680,7 +26680,7 @@ snapshots:
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.7.0
 
-  '@osdk/foundry.geo@2.71.0':
+  '@osdk/foundry.geo@2.73.0':
     dependencies:
       '@osdk/shared.client': 1.0.1
       '@osdk/shared.client2': 1.0.0
@@ -26692,7 +26692,7 @@ snapshots:
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.7.0
 
-  '@osdk/foundry.geojson@2.71.0':
+  '@osdk/foundry.geojson@2.73.0':
     dependencies:
       '@osdk/shared.client': 1.0.1
       '@osdk/shared.client2': 1.0.0
@@ -26705,9 +26705,9 @@ snapshots:
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.7.0
 
-  '@osdk/foundry.languagemodels@2.71.0':
+  '@osdk/foundry.languagemodels@2.73.0':
     dependencies:
-      '@osdk/foundry.core': 2.71.0
+      '@osdk/foundry.core': 2.73.0
       '@osdk/shared.client': 1.0.1
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.7.0
@@ -26726,9 +26726,9 @@ snapshots:
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.7.0
 
-  '@osdk/foundry.mediasets@2.71.0':
+  '@osdk/foundry.mediasets@2.73.0':
     dependencies:
-      '@osdk/foundry.core': 2.71.0
+      '@osdk/foundry.core': 2.73.0
       '@osdk/shared.client': 1.0.1
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.7.0
@@ -26743,12 +26743,12 @@ snapshots:
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.7.0
 
-  '@osdk/foundry.models@2.71.0':
+  '@osdk/foundry.models@2.73.0':
     dependencies:
-      '@osdk/foundry.core': 2.71.0
-      '@osdk/foundry.filesystem': 2.71.0
-      '@osdk/foundry.ontologies': 2.71.0
-      '@osdk/foundry.orchestration': 2.71.0
+      '@osdk/foundry.core': 2.73.0
+      '@osdk/foundry.filesystem': 2.73.0
+      '@osdk/foundry.ontologies': 2.73.0
+      '@osdk/foundry.orchestration': 2.73.0
       '@osdk/shared.client': 1.0.1
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.7.0
@@ -26762,11 +26762,11 @@ snapshots:
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.7.0
 
-  '@osdk/foundry.notepad@2.71.0':
+  '@osdk/foundry.notepad@2.73.0':
     dependencies:
-      '@osdk/foundry.core': 2.71.0
-      '@osdk/foundry.filesystem': 2.71.0
-      '@osdk/foundry.ontologies': 2.71.0
+      '@osdk/foundry.core': 2.73.0
+      '@osdk/foundry.filesystem': 2.73.0
+      '@osdk/foundry.ontologies': 2.73.0
       '@osdk/shared.client': 1.0.1
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.7.0
@@ -26788,11 +26788,11 @@ snapshots:
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.7.0
 
-  '@osdk/foundry.ontologies@2.71.0':
+  '@osdk/foundry.ontologies@2.73.0':
     dependencies:
-      '@osdk/foundry.core': 2.71.0
-      '@osdk/foundry.datasets': 2.71.0
-      '@osdk/foundry.geo': 2.71.0
+      '@osdk/foundry.core': 2.73.0
+      '@osdk/foundry.datasets': 2.73.0
+      '@osdk/foundry.geo': 2.73.0
       '@osdk/shared.client': 1.0.1
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.7.0
@@ -26805,10 +26805,10 @@ snapshots:
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.7.0
 
-  '@osdk/foundry.operations@2.71.0':
+  '@osdk/foundry.operations@2.73.0':
     dependencies:
-      '@osdk/foundry.core': 2.71.0
-      '@osdk/foundry.ontologies': 2.71.0
+      '@osdk/foundry.core': 2.73.0
+      '@osdk/foundry.ontologies': 2.73.0
       '@osdk/shared.client': 1.0.1
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.7.0
@@ -26822,11 +26822,11 @@ snapshots:
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.7.0
 
-  '@osdk/foundry.orchestration@2.71.0':
+  '@osdk/foundry.orchestration@2.73.0':
     dependencies:
-      '@osdk/foundry.core': 2.71.0
-      '@osdk/foundry.datasets': 2.71.0
-      '@osdk/foundry.filesystem': 2.71.0
+      '@osdk/foundry.core': 2.73.0
+      '@osdk/foundry.datasets': 2.73.0
+      '@osdk/foundry.filesystem': 2.73.0
       '@osdk/shared.client': 1.0.1
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.7.0
@@ -26839,10 +26839,10 @@ snapshots:
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.7.0
 
-  '@osdk/foundry.pack@2.71.0':
+  '@osdk/foundry.pack@2.73.0':
     dependencies:
-      '@osdk/foundry.core': 2.71.0
-      '@osdk/foundry.filesystem': 2.71.0
+      '@osdk/foundry.core': 2.73.0
+      '@osdk/foundry.filesystem': 2.73.0
       '@osdk/shared.client': 1.0.1
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.7.0
@@ -26854,9 +26854,9 @@ snapshots:
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.7.0
 
-  '@osdk/foundry.publicapis@2.71.0':
+  '@osdk/foundry.publicapis@2.73.0':
     dependencies:
-      '@osdk/foundry.core': 2.71.0
+      '@osdk/foundry.core': 2.73.0
       '@osdk/shared.client': 1.0.1
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.7.0
@@ -26870,11 +26870,11 @@ snapshots:
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.7.0
 
-  '@osdk/foundry.sqlqueries@2.71.0':
+  '@osdk/foundry.sqlqueries@2.73.0':
     dependencies:
-      '@osdk/foundry.core': 2.71.0
-      '@osdk/foundry.datasets': 2.71.0
-      '@osdk/foundry.ontologies': 2.71.0
+      '@osdk/foundry.core': 2.73.0
+      '@osdk/foundry.datasets': 2.73.0
+      '@osdk/foundry.ontologies': 2.73.0
       '@osdk/shared.client': 1.0.1
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.7.0
@@ -26888,11 +26888,11 @@ snapshots:
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.7.0
 
-  '@osdk/foundry.streams@2.71.0':
+  '@osdk/foundry.streams@2.73.0':
     dependencies:
-      '@osdk/foundry.core': 2.71.0
-      '@osdk/foundry.datasets': 2.71.0
-      '@osdk/foundry.filesystem': 2.71.0
+      '@osdk/foundry.core': 2.73.0
+      '@osdk/foundry.datasets': 2.73.0
+      '@osdk/foundry.filesystem': 2.73.0
       '@osdk/shared.client': 1.0.1
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.7.0
@@ -26904,9 +26904,9 @@ snapshots:
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.7.0
 
-  '@osdk/foundry.thirdpartyapplications@2.71.0':
+  '@osdk/foundry.thirdpartyapplications@2.73.0':
     dependencies:
-      '@osdk/foundry.core': 2.71.0
+      '@osdk/foundry.core': 2.73.0
       '@osdk/shared.client': 1.0.1
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.7.0
@@ -26918,9 +26918,9 @@ snapshots:
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.7.0
 
-  '@osdk/foundry.widgets@2.71.0':
+  '@osdk/foundry.widgets@2.73.0':
     dependencies:
-      '@osdk/foundry.core': 2.71.0
+      '@osdk/foundry.core': 2.73.0
       '@osdk/shared.client': 1.0.1
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.7.0
@@ -26956,33 +26956,33 @@ snapshots:
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.7.0
 
-  '@osdk/foundry@2.71.0':
+  '@osdk/foundry@2.73.0':
     dependencies:
-      '@osdk/foundry.admin': 2.71.0
-      '@osdk/foundry.aipagents': 2.71.0
-      '@osdk/foundry.audit': 2.71.0
-      '@osdk/foundry.checkpoints': 2.71.0
-      '@osdk/foundry.connectivity': 2.71.0
-      '@osdk/foundry.core': 2.71.0
-      '@osdk/foundry.datahealth': 2.71.0
-      '@osdk/foundry.datasets': 2.71.0
-      '@osdk/foundry.filesystem': 2.71.0
-      '@osdk/foundry.functions': 2.71.0
-      '@osdk/foundry.geo': 2.71.0
-      '@osdk/foundry.geojson': 2.71.0
-      '@osdk/foundry.languagemodels': 2.71.0
-      '@osdk/foundry.mediasets': 2.71.0
-      '@osdk/foundry.models': 2.71.0
-      '@osdk/foundry.notepad': 2.71.0
-      '@osdk/foundry.ontologies': 2.71.0
-      '@osdk/foundry.operations': 2.71.0
-      '@osdk/foundry.orchestration': 2.71.0
-      '@osdk/foundry.pack': 2.71.0
-      '@osdk/foundry.publicapis': 2.71.0
-      '@osdk/foundry.sqlqueries': 2.71.0
-      '@osdk/foundry.streams': 2.71.0
-      '@osdk/foundry.thirdpartyapplications': 2.71.0
-      '@osdk/foundry.widgets': 2.71.0
+      '@osdk/foundry.admin': 2.73.0
+      '@osdk/foundry.aipagents': 2.73.0
+      '@osdk/foundry.audit': 2.73.0
+      '@osdk/foundry.checkpoints': 2.73.0
+      '@osdk/foundry.connectivity': 2.73.0
+      '@osdk/foundry.core': 2.73.0
+      '@osdk/foundry.datahealth': 2.73.0
+      '@osdk/foundry.datasets': 2.73.0
+      '@osdk/foundry.filesystem': 2.73.0
+      '@osdk/foundry.functions': 2.73.0
+      '@osdk/foundry.geo': 2.73.0
+      '@osdk/foundry.geojson': 2.73.0
+      '@osdk/foundry.languagemodels': 2.73.0
+      '@osdk/foundry.mediasets': 2.73.0
+      '@osdk/foundry.models': 2.73.0
+      '@osdk/foundry.notepad': 2.73.0
+      '@osdk/foundry.ontologies': 2.73.0
+      '@osdk/foundry.operations': 2.73.0
+      '@osdk/foundry.orchestration': 2.73.0
+      '@osdk/foundry.pack': 2.73.0
+      '@osdk/foundry.publicapis': 2.73.0
+      '@osdk/foundry.sqlqueries': 2.73.0
+      '@osdk/foundry.streams': 2.73.0
+      '@osdk/foundry.thirdpartyapplications': 2.73.0
+      '@osdk/foundry.widgets': 2.73.0
       '@osdk/shared.client': 1.0.1
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.7.0
@@ -30377,11 +30377,11 @@ snapshots:
       - vite
     optional: true
 
-  '@vitest/browser@3.2.6(msw@2.11.1(@types/node@18.19.124)(typescript@5.5.4))(playwright@1.60.0)(vite@7.3.2(@types/node@18.19.124)(jiti@2.5.1)(less@4.5.1)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(stylus@0.62.0)(terser@5.44.0)(tsx@4.20.5)(yaml@2.9.0))(vitest@3.2.6)':
+  '@vitest/browser@3.2.6(msw@2.11.1(@types/node@18.19.124)(typescript@5.5.4))(playwright@1.60.0)(vite@6.4.2(@types/node@18.19.124)(jiti@2.5.1)(less@4.5.1)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(stylus@0.62.0)(terser@5.44.0)(tsx@4.20.5)(yaml@2.9.0))(vitest@3.2.6)':
     dependencies:
       '@testing-library/dom': 10.4.0
       '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.0)
-      '@vitest/mocker': 3.2.6(msw@2.11.1(@types/node@18.19.124)(typescript@5.5.4))(vite@7.3.2(@types/node@18.19.124)(jiti@2.5.1)(less@4.5.1)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(stylus@0.62.0)(terser@5.44.0)(tsx@4.20.5)(yaml@2.9.0))
+      '@vitest/mocker': 3.2.6(msw@2.11.1(@types/node@18.19.124)(typescript@5.5.4))(vite@6.4.2(@types/node@18.19.124)(jiti@2.5.1)(less@4.5.1)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(stylus@0.62.0)(terser@5.44.0)(tsx@4.20.5)(yaml@2.9.0))
       '@vitest/utils': 3.2.6
       magic-string: 0.30.19
       sirv: 3.0.2
@@ -30421,6 +30421,26 @@ snapshots:
       '@testing-library/dom': 10.4.0
       '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.0)
       '@vitest/mocker': 3.2.6(msw@2.11.1(@types/node@26.1.1)(typescript@5.5.4))(vite@6.4.2(@types/node@26.1.1)(jiti@2.5.1)(less@4.5.1)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(stylus@0.62.0)(terser@5.44.0)(tsx@4.20.5)(yaml@2.9.0))
+      '@vitest/utils': 3.2.6
+      magic-string: 0.30.19
+      sirv: 3.0.2
+      tinyrainbow: 2.0.0
+      vitest: 3.2.6(@types/debug@4.1.12)(@types/node@26.1.1)(@vitest/browser@3.2.6)(happy-dom@16.8.1)(jiti@2.5.1)(jsdom@20.0.3(canvas@2.11.2))(less@4.5.1)(lightningcss@1.32.0)(msw@2.11.1(@types/node@26.1.1)(typescript@5.5.4))(sass-embedded@1.97.3)(sass@1.97.3)(stylus@0.62.0)(terser@5.44.0)(tsx@4.20.5)(yaml@2.9.0)
+      ws: 8.21.0
+    optionalDependencies:
+      playwright: 1.60.0
+    transitivePeerDependencies:
+      - bufferutil
+      - msw
+      - utf-8-validate
+      - vite
+    optional: true
+
+  '@vitest/browser@3.2.6(msw@2.11.1(@types/node@26.1.1)(typescript@5.5.4))(playwright@1.60.0)(vite@7.3.2(@types/node@26.1.1)(jiti@2.5.1)(less@4.5.1)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(stylus@0.62.0)(terser@5.44.0)(tsx@4.20.5)(yaml@2.9.0))(vitest@3.2.6)':
+    dependencies:
+      '@testing-library/dom': 10.4.0
+      '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.0)
+      '@vitest/mocker': 3.2.6(msw@2.11.1(@types/node@26.1.1)(typescript@5.5.4))(vite@7.3.2(@types/node@26.1.1)(jiti@2.5.1)(less@4.5.1)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(stylus@0.62.0)(terser@5.44.0)(tsx@4.20.5)(yaml@2.9.0))
       '@vitest/utils': 3.2.6
       magic-string: 0.30.19
       sirv: 3.0.2
@@ -30596,16 +30616,6 @@ snapshots:
       msw: 2.11.1(@types/node@18.19.124)(typescript@5.5.4)
       vite: 6.4.2(@types/node@18.19.124)(jiti@2.5.1)(less@4.5.1)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(stylus@0.62.0)(terser@5.44.0)(tsx@4.20.5)(yaml@2.9.0)
 
-  '@vitest/mocker@3.2.6(msw@2.11.1(@types/node@18.19.124)(typescript@5.5.4))(vite@7.3.2(@types/node@18.19.124)(jiti@2.5.1)(less@4.5.1)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(stylus@0.62.0)(terser@5.44.0)(tsx@4.20.5)(yaml@2.9.0))':
-    dependencies:
-      '@vitest/spy': 3.2.6
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      msw: 2.11.1(@types/node@18.19.124)(typescript@5.5.4)
-      vite: 7.3.2(@types/node@18.19.124)(jiti@2.5.1)(less@4.5.1)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(stylus@0.62.0)(terser@5.44.0)(tsx@4.20.5)(yaml@2.9.0)
-    optional: true
-
   '@vitest/mocker@3.2.6(msw@2.11.1(@types/node@20.19.13)(typescript@5.5.4))(vite@6.4.2(@types/node@20.19.13)(jiti@2.5.1)(less@4.5.1)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(stylus@0.62.0)(terser@5.44.0)(tsx@4.20.5)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 3.2.6
@@ -30623,6 +30633,16 @@ snapshots:
     optionalDependencies:
       msw: 2.11.1(@types/node@26.1.1)(typescript@5.5.4)
       vite: 6.4.2(@types/node@26.1.1)(jiti@2.5.1)(less@4.5.1)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(stylus@0.62.0)(terser@5.44.0)(tsx@4.20.5)(yaml@2.9.0)
+
+  '@vitest/mocker@3.2.6(msw@2.11.1(@types/node@26.1.1)(typescript@5.5.4))(vite@7.3.2(@types/node@26.1.1)(jiti@2.5.1)(less@4.5.1)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(stylus@0.62.0)(terser@5.44.0)(tsx@4.20.5)(yaml@2.9.0))':
+    dependencies:
+      '@vitest/spy': 3.2.6
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      msw: 2.11.1(@types/node@26.1.1)(typescript@5.5.4)
+      vite: 7.3.2(@types/node@26.1.1)(jiti@2.5.1)(less@4.5.1)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(stylus@0.62.0)(terser@5.44.0)(tsx@4.20.5)(yaml@2.9.0)
+    optional: true
 
   '@vitest/mocker@4.1.9(msw@2.11.1(@types/node@26.1.1)(typescript@5.5.4))(vite@8.0.8(@types/node@26.1.1)(esbuild@0.27.3)(jiti@2.5.1)(less@4.5.1)(sass-embedded@1.97.3)(sass@1.97.3)(stylus@0.62.0)(terser@5.44.0)(tsx@4.20.5)(yaml@2.9.0))':
     dependencies:
@@ -42568,7 +42588,7 @@ snapshots:
     optionalDependencies:
       '@types/debug': 4.1.12
       '@types/node': 18.19.124
-      '@vitest/browser': 3.2.6(msw@2.11.1(@types/node@18.19.124)(typescript@5.5.4))(playwright@1.60.0)(vite@7.3.2(@types/node@18.19.124)(jiti@2.5.1)(less@4.5.1)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(stylus@0.62.0)(terser@5.44.0)(tsx@4.20.5)(yaml@2.9.0))(vitest@3.2.6)
+      '@vitest/browser': 3.2.6(msw@2.11.1(@types/node@18.19.124)(typescript@5.5.4))(playwright@1.60.0)(vite@6.4.2(@types/node@18.19.124)(jiti@2.5.1)(less@4.5.1)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(stylus@0.62.0)(terser@5.44.0)(tsx@4.20.5)(yaml@2.9.0))(vitest@3.2.6)
       happy-dom: 20.8.9
       jsdom: 20.0.3(canvas@2.11.2)
     transitivePeerDependencies:
@@ -42703,7 +42723,7 @@ snapshots:
     optionalDependencies:
       '@types/debug': 4.1.12
       '@types/node': 26.1.1
-      '@vitest/browser': 3.2.6(msw@2.11.1(@types/node@26.1.1)(typescript@5.5.4))(playwright@1.60.0)(vite@6.4.2(@types/node@26.1.1)(jiti@2.5.1)(less@4.5.1)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(stylus@0.62.0)(terser@5.44.0)(tsx@4.20.5)(yaml@2.9.0))(vitest@3.2.6)
+      '@vitest/browser': 3.2.6(msw@2.11.1(@types/node@26.1.1)(typescript@5.5.4))(playwright@1.60.0)(vite@7.3.2(@types/node@26.1.1)(jiti@2.5.1)(less@4.5.1)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(stylus@0.62.0)(terser@5.44.0)(tsx@4.20.5)(yaml@2.9.0))(vitest@3.2.6)
       happy-dom: 20.8.9
       jsdom: 20.0.3(canvas@2.11.2)
     transitivePeerDependencies:


### PR DESCRIPTION
- Seed builder did not allow update functions to take in null values in the validation stage which makes nullifying an existing field impossible, this allows it
- Exporting `createSeedWithMetadata` as default exports was impossible because of the branded type, the branded type is just there to prevent arbitrary reference instantiation-- this resolves the issue.