### PR TITLE
Move pnpm config to workspace file

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,38 +90,6 @@
     "ultracite": "7.8.2",
     "vitest": "^3.2.4"
   },
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "@parcel/watcher",
-      "less",
-      "@swc/core",
-      "@tailwindcss/oxide",
-      "canvas",
-      "core-js",
-      "core-js-pure",
-      "dprint",
-      "esbuild",
-      "msw",
-      "oxfmt",
-      "oxlint",
-      "oxlint-tsgolint",
-      "unrs-resolver"
-    ],
-    "overrides": {
-      "trim@0.0.1": "0.0.3",
-      "cookie@0.6.0": "0.7.2",
-      "cookie@0.7.1": "0.7.2",
-      "esbuild@^0.23.0": "^0.25.0",
-      "esbuild@^0.24.0": "^0.25.0",
-      "react-server-dom-webpack": ">=19.2.2",
-      "webpackbar": "^7.0.0",
-      "@types/react": "^18.3.24",
-      "@types/react-dom": "^18.3.7",
-      "@cspell/dict-css": "^4.0.18",
-      "@cspell/dict-html": "^4.0.12",
-      "@cspell/dict-html-symbol-entities": "^4.0.4"
-    }
-  },
   "engines": {
     "node": ">=18.19.0",
     "pnpm": "=10.27.0"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -32,3 +32,31 @@ catalogs:
     "@osdk/foundry.ontologies": 2.70.0
     "@osdk/foundry.thirdpartyapplications": 2.70.0
     "@osdk/internal.foundry.ontologies": 2.70.0
+allowBuilds:
+    - "@parcel/watcher": true
+    - "less": true
+    - "@swc/core": true
+    - "@tailwindcss/oxide": true
+    - "canvas": true
+    - "core-js": true
+    - "core-js-pure": true
+    - "dprint": true
+    - "esbuild": true
+    - "msw": true
+    - "oxfmt": true
+    - "oxlint": true
+    - "oxlint-tsgolint": true
+    - "unrs-resolver": true
+overrides:
+    "trim@0.0.1": "0.0.3"
+    "cookie@0.6.0": "0.7.2"
+    "cookie@0.7.1": "0.7.2"
+    "esbuild@^0.23.0": "^0.25.0"
+    "esbuild@^0.24.0": "^0.25.0"
+    "react-server-dom-webpack": ">=19.2.2"
+    "webpackbar": "^7.0.0"
+    "@types/react": "^18.3.24"
+    "@types/react-dom": "^18.3.7"
+    "@cspell/dict-css": "^4.0.18"
+    "@cspell/dict-html": "^4.0.12"
+    "@cspell/dict-html-symbol-entities": "^4.0.4"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -43,9 +43,6 @@ allowBuilds:
     "dprint": true
     "esbuild": true
     "msw": true
-    "oxfmt": true
-    "oxlint": true
-    "oxlint-tsgolint": true
     "unrs-resolver": true
 overrides:
     "trim@0.0.1": "0.0.3"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -33,20 +33,20 @@ catalogs:
     "@osdk/foundry.thirdpartyapplications": 2.70.0
     "@osdk/internal.foundry.ontologies": 2.70.0
 allowBuilds:
-    - "@parcel/watcher": true
-    - "less": true
-    - "@swc/core": true
-    - "@tailwindcss/oxide": true
-    - "canvas": true
-    - "core-js": true
-    - "core-js-pure": true
-    - "dprint": true
-    - "esbuild": true
-    - "msw": true
-    - "oxfmt": true
-    - "oxlint": true
-    - "oxlint-tsgolint": true
-    - "unrs-resolver": true
+    "@parcel/watcher": true
+    "less": true
+    "@swc/core": true
+    "@tailwindcss/oxide": true
+    "canvas": true
+    "core-js": true
+    "core-js-pure": true
+    "dprint": true
+    "esbuild": true
+    "msw": true
+    "oxfmt": true
+    "oxlint": true
+    "oxlint-tsgolint": true
+    "unrs-resolver": true
 overrides:
     "trim@0.0.1": "0.0.3"
     "cookie@0.6.0": "0.7.2"


### PR DESCRIPTION
The current pnpm configs are being ignored:
```
[WARN] The "pnpm" field in package.json is no longer read by pnpm. The following keys were ignored: "pnpm.onlyBuiltDependencies", "pnpm.overrides". See https://pnpm.io/settings for the new home of each setting.
```

Moved the pnpm configs into workspace where they are respected.