### PR TITLE
Disable @osdk/integration-testing postinstall script within osdk-ts repo

### DIFF
--- a/.changeset/common-doodles-create.md
+++ b/.changeset/common-doodles-create.md
@@ -1,0 +1,5 @@
+---
+"@osdk/integration-testing": patch
+---
+
+Update postinstall script to skip installation when in development osdk-ts repo

--- a/packages/integration-testing/src/scripts/postinstall.ts
+++ b/packages/integration-testing/src/scripts/postinstall.ts
@@ -22,8 +22,17 @@ import {
   MIN_FOUNDRY_CLI_VERSION,
 } from "../utils/foundry-cli.js";
 import { installFoundryCli } from "./download.js";
+import { readGitRemoteUrl } from "./gitRemote.js";
 
 export const postinstall = async (): Promise<void> => {
+  const remote = await readGitRemoteUrl();
+  if (
+    remote === "git@github.com:palantir/osdk-ts.git" ||
+    remote === "https://github.com/palantir/osdk-ts.git"
+  ) {
+    consola.info(`✅ In osdk-ts repo, skipping installation.`);
+    return;
+  }
   const result = await checkFoundryCliVersion();
   switch (result.type) {
     case "installed":


### PR DESCRIPTION
`@osdk/integration-testing` postinstall script runs within `osdk-ts` repo itself, which is not strictly necessary. The option to disable this as a whole is [available](https://pnpm.io/settings/other#enableprepostscripts), but not as a per-package setting.

The postinstall works as an installation hook in two scenarios:
- As a script to run after installing `@osdk/integration-testing` on a different repo (desired)
- As a script to run after installing dependencies required to run `@osdk/integration-testing` in the `osdk-ts` repo. (side effect)

It will:
- Detect that it is in an osdk-ts repo clone by looking up the git remote
- If it is, short circuits and exits the script