### PR TITLE
catalog version bump to 2.73.0

### DIFF
--- a/.changeset/bump-foundry-platform-2-73.md
+++ b/.changeset/bump-foundry-platform-2-73.md
@@ -1,0 +1,20 @@
+---
+"@osdk/client": patch
+"@osdk/faux": patch
+"@osdk/foundry-sdk-generator": patch
+"@osdk/generator": patch
+"@osdk/generator-converters": patch
+"@osdk/generator-converters.ontologyir": patch
+"@osdk/generator-converters.preview": patch
+"@osdk/maker-experimental": patch
+"@osdk/maker-import": patch
+"@osdk/react": patch
+"@osdk/react-sdk-docs": patch
+"@osdk/seed-compiler": patch
+"@osdk/seed-helpers": patch
+"@osdk/typescript-sdk-docs": patch
+"@osdk/unit-testing": patch
+"@osdk/vite-plugin-oac": patch
+---
+
+Bump the `@osdk/foundry.*` and `@osdk/internal.foundry.*` catalog entries to `2.73.0`. `ObjectTypeInterfaceImplementation` now requires an `actionTypes` field, and the generally available media set `read`, `info`, `metadata` and `uploadMedia` endpoints no longer accept a `preview` parameter.

--- a/packages/client/src/createMediaFromReference.ts
+++ b/packages/client/src/createMediaFromReference.ts
@@ -53,7 +53,6 @@ export function createMediaFromReferenceInternal(
         client,
         mediaSetRid,
         mediaItemRid,
-        { preview: true },
         token ? { ReadToken: token } : undefined,
       );
     },
@@ -63,7 +62,6 @@ export function createMediaFromReferenceInternal(
         client,
         mediaSetRid,
         mediaItemRid,
-        { preview: true },
         token ? { ReadToken: token } : undefined,
       );
 
@@ -82,7 +80,6 @@ export function createMediaFromReferenceInternal(
         client,
         mediaSetRid,
         mediaItemRid,
-        { preview: true },
         token ? { ReadToken: token } : undefined,
       );
       return { itemMetadata: validateMediaItemMetadata(raw) };

--- a/packages/client/src/createMediaReferenceProperty.ts
+++ b/packages/client/src/createMediaReferenceProperty.ts
@@ -85,7 +85,6 @@ export class MediaReferencePropertyImpl implements Media {
       this.#client,
       mediaSetRid,
       mediaItemRid,
-      { preview: true },
       token ? { ReadToken: token } : undefined,
     );
     return { itemMetadata: validateMediaItemMetadata(raw) };

--- a/packages/client/src/util/toDataValue.ts
+++ b/packages/client/src/util/toDataValue.ts
@@ -94,7 +94,6 @@ export async function toDataValue(
   if (isMediaUpload(value)) {
     const mediaRef = await MediaSets.uploadMedia(client, value.data, {
       filename: value.fileName,
-      preview: true,
     });
     return await toDataValue(mediaRef, client, actionMetadata);
   }

--- a/packages/client/src/util/toDataValueQueries.ts
+++ b/packages/client/src/util/toDataValueQueries.ts
@@ -109,7 +109,6 @@ export async function toDataValueQueries(
       if (isMediaUpload(value)) {
         const mediaRef = await MediaSets.uploadMedia(client, value.data, {
           filename: value.fileName,
-          preview: true,
         });
         return mediaRef;
       }

--- a/packages/foundry-sdk-generator/src/ontologyMetadata/__snapshots__/metadataResolver.test.ts.snap
+++ b/packages/foundry-sdk-generator/src/ontologyMetadata/__snapshots__/metadataResolver.test.ts.snap
@@ -288,6 +288,7 @@ exports[`Load Ontologies Metadata > Loads action types with media refs, interfac
         ],
         "implementsInterfaces2": {
           "FooInterface": {
+            "actionTypes": {},
             "links": {},
             "properties": {
               "fooSpt": "fullName",
@@ -618,6 +619,7 @@ exports[`Load Ontologies Metadata > Loads object and action types using only spe
         ],
         "implementsInterfaces2": {
           "FooInterface": {
+            "actionTypes": {},
             "links": {},
             "properties": {
               "fooSpt": "fullName",
@@ -1112,6 +1114,7 @@ exports[`Load Ontologies Metadata > Loads object, action, interface types withou
         ],
         "implementsInterfaces2": {
           "FooInterface": {
+            "actionTypes": {},
             "links": {},
             "properties": {
               "fooSpt": "fullName",

--- a/packages/generator-converters.ontologyir/src/OntologyBlockDataToFullMetadataConverter.ts
+++ b/packages/generator-converters.ontologyir/src/OntologyBlockDataToFullMetadataConverter.ts
@@ -218,6 +218,7 @@ export class OntologyBlockDataToFullMetadataConverter {
           properties: propertyMappings,
           propertiesV2: {},
           links: {},
+          actionTypes: {},
         };
       }
 

--- a/packages/generator-converters.ontologyir/src/OntologyIrToFullMetadataConverter.ts
+++ b/packages/generator-converters.ontologyir/src/OntologyIrToFullMetadataConverter.ts
@@ -815,6 +815,7 @@ export class OntologyIrToFullMetadataConverter {
           properties: propertyMappings,
           propertiesV2: {},
           links: {},
+          actionTypes: {},
         };
       }
 

--- a/packages/generator-converters/src/wireObjectTypeFullMetadataToSdkObjectMetadata.test.ts
+++ b/packages/generator-converters/src/wireObjectTypeFullMetadataToSdkObjectMetadata.test.ts
@@ -154,9 +154,24 @@ describe(wireObjectTypeFullMetadataToSdkObjectMetadata, () => {
     const result = wireObjectTypeFullMetadataToSdkObjectMetadata({
       implementsInterfaces: ["InterfaceZ", "InterfaceA", "InterfaceC"],
       implementsInterfaces2: {
-        "InterfaceZ": { properties: {}, propertiesV2: {}, links: {} },
-        "InterfaceA": { properties: {}, propertiesV2: {}, links: {} },
-        "InterfaceC": { properties: {}, propertiesV2: {}, links: {} },
+        "InterfaceZ": {
+          properties: {},
+          propertiesV2: {},
+          links: {},
+          actionTypes: {},
+        },
+        "InterfaceA": {
+          properties: {},
+          propertiesV2: {},
+          links: {},
+          actionTypes: {},
+        },
+        "InterfaceC": {
+          properties: {},
+          propertiesV2: {},
+          links: {},
+          actionTypes: {},
+        },
       },
       linkTypes: [],
       objectType: {

--- a/packages/generator/src/util/test/TodoWireOntology.ts
+++ b/packages/generator/src/util/test/TodoWireOntology.ts
@@ -145,6 +145,7 @@ export const TodoWireOntology: WireOntologyDefinition = {
           },
           propertiesV2: {},
           links: {},
+          actionTypes: {},
         },
       },
       sharedPropertyTypeMapping: {},

--- a/packages/generator/src/v2.0/generateClientSdkVersionTwoPointZero.test.ts
+++ b/packages/generator/src/v2.0/generateClientSdkVersionTwoPointZero.test.ts
@@ -404,6 +404,7 @@ const referencingOntology: WireOntologyDefinition = {
             "com.example.dep.spt": "body",
           },
           propertiesV2: {},
+          actionTypes: {},
         },
       },
       linkTypes: [],

--- a/packages/react-components-storybook/src/mocks/employeeMetadata.ts
+++ b/packages/react-components-storybook/src/mocks/employeeMetadata.ts
@@ -654,6 +654,7 @@ export const employeeMetadata: TH_ObjectTypeFullMetadata<Employee> = {
         },
       },
       links: {},
+      actionTypes: {},
     },
     Worker: {
       apiName: "Worker",
@@ -678,6 +679,7 @@ export const employeeMetadata: TH_ObjectTypeFullMetadata<Employee> = {
         },
       },
       links: {},
+      actionTypes: {},
     },
   },
   sharedPropertyTypeMapping: {

--- a/packages/shared.test/src/stubs/complexImplementationTypes.ts
+++ b/packages/shared.test/src/stubs/complexImplementationTypes.ts
@@ -263,6 +263,7 @@ export const complexImplementationObjectTypeWithLinkTypes: ObjectTypeFullMetadat
           },
         },
         links: {},
+        actionTypes: {},
       },
     },
     sharedPropertyTypeMapping: {},

--- a/packages/shared.test/src/stubs/objectTypesWithLinkTypes.ts
+++ b/packages/shared.test/src/stubs/objectTypesWithLinkTypes.ts
@@ -56,6 +56,7 @@ export const employeeObjectWithLinkTypes: ObjectTypeFullMetadata = {
         },
       },
       links: {},
+      actionTypes: {},
     },
   },
   sharedPropertyTypeMapping: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,35 +13,35 @@ catalogs:
       specifier: 0.17.0
       version: 0.17.0
     '@osdk/foundry':
-      specifier: 2.70.0
-      version: 2.70.0
+      specifier: 2.73.0
+      version: 2.73.0
     '@osdk/foundry.admin':
-      specifier: 2.70.0
-      version: 2.70.0
+      specifier: 2.73.0
+      version: 2.73.0
     '@osdk/foundry.core':
-      specifier: 2.70.0
-      version: 2.70.0
+      specifier: 2.73.0
+      version: 2.73.0
     '@osdk/foundry.datasets':
       specifier: ~2.5.0
       version: 2.5.0
     '@osdk/foundry.functions':
-      specifier: 2.70.0
-      version: 2.70.0
+      specifier: 2.73.0
+      version: 2.73.0
     '@osdk/foundry.geo':
-      specifier: 2.70.0
-      version: 2.70.0
+      specifier: 2.73.0
+      version: 2.73.0
     '@osdk/foundry.mediasets':
-      specifier: 2.70.0
-      version: 2.70.0
+      specifier: 2.73.0
+      version: 2.73.0
     '@osdk/foundry.ontologies':
-      specifier: 2.70.0
-      version: 2.70.0
+      specifier: 2.73.0
+      version: 2.73.0
     '@osdk/foundry.thirdpartyapplications':
-      specifier: 2.70.0
-      version: 2.70.0
+      specifier: 2.73.0
+      version: 2.73.0
     '@osdk/internal.foundry.ontologies':
-      specifier: 2.70.0
-      version: 2.70.0
+      specifier: 2.73.0
+      version: 2.73.0
 
 overrides:
   trim@0.0.1: 0.0.3
@@ -1972,7 +1972,7 @@ importers:
         version: link:../cli.common
       '@osdk/foundry.ontologies':
         specifier: catalog:foundry-platform-typescript
-        version: 2.70.0
+        version: 2.73.0
       '@osdk/generator':
         specifier: workspace:~
         version: link:../generator
@@ -2055,16 +2055,16 @@ importers:
         version: link:../client.unstable
       '@osdk/foundry.core':
         specifier: catalog:foundry-platform-typescript
-        version: 2.70.0
+        version: 2.73.0
       '@osdk/foundry.functions':
         specifier: catalog:foundry-platform-typescript
-        version: 2.70.0
+        version: 2.73.0
       '@osdk/foundry.mediasets':
         specifier: catalog:foundry-platform-typescript
-        version: 2.70.0
+        version: 2.73.0
       '@osdk/foundry.ontologies':
         specifier: catalog:foundry-platform-typescript
-        version: 2.70.0
+        version: 2.73.0
       '@osdk/generator-converters':
         specifier: workspace:*
         version: link:../generator-converters
@@ -3423,7 +3423,7 @@ importers:
         version: link:../client
       '@osdk/foundry.ontologies':
         specifier: catalog:foundry-platform-typescript
-        version: 2.70.0
+        version: 2.73.0
     devDependencies:
       '@arethetypeswrong/cli':
         specifier: ^0.17.4
@@ -3460,7 +3460,7 @@ importers:
         version: link:../e2e.generated.catchall
       '@osdk/foundry':
         specifier: catalog:foundry-platform-typescript
-        version: 2.70.0
+        version: 2.73.0
       '@osdk/functions':
         specifier: workspace:~
         version: link:../functions
@@ -4013,25 +4013,25 @@ importers:
         version: link:../api
       '@osdk/foundry.admin':
         specifier: catalog:foundry-platform-typescript
-        version: 2.70.0
+        version: 2.73.0
       '@osdk/foundry.core':
         specifier: catalog:foundry-platform-typescript
-        version: 2.70.0
+        version: 2.73.0
       '@osdk/foundry.geo':
         specifier: catalog:foundry-platform-typescript
-        version: 2.70.0
+        version: 2.73.0
       '@osdk/foundry.mediasets':
         specifier: catalog:foundry-platform-typescript
-        version: 2.70.0
+        version: 2.73.0
       '@osdk/foundry.ontologies':
         specifier: catalog:foundry-platform-typescript
-        version: 2.70.0
+        version: 2.73.0
       '@osdk/generator-converters':
         specifier: workspace:~
         version: link:../generator-converters
       '@osdk/internal.foundry.ontologies':
         specifier: catalog:foundry-platform-typescript
-        version: 2.70.0
+        version: 2.73.0
       date-fns:
         specifier: ^4.1.0
         version: 4.1.0
@@ -4126,10 +4126,10 @@ importers:
         version: link:../client.unstable.tpsa
       '@osdk/foundry.ontologies':
         specifier: catalog:foundry-platform-typescript
-        version: 2.70.0
+        version: 2.73.0
       '@osdk/foundry.thirdpartyapplications':
         specifier: catalog:foundry-platform-typescript
-        version: 2.70.0
+        version: 2.73.0
       '@osdk/generator':
         specifier: workspace:*
         version: link:../generator
@@ -4248,7 +4248,7 @@ importers:
         version: link:../api
       '@osdk/foundry.ontologies':
         specifier: catalog:foundry-platform-typescript
-        version: 2.70.0
+        version: 2.73.0
       '@osdk/generator-converters':
         specifier: workspace:~
         version: link:../generator-converters
@@ -4297,7 +4297,7 @@ importers:
         version: link:../api
       '@osdk/foundry.ontologies':
         specifier: catalog:foundry-platform-typescript
-        version: 2.70.0
+        version: 2.73.0
     devDependencies:
       '@osdk/monorepo.api-extractor':
         specifier: workspace:~
@@ -4322,7 +4322,7 @@ importers:
         version: link:../client.unstable
       '@osdk/foundry.ontologies':
         specifier: catalog:foundry-platform-typescript
-        version: 2.70.0
+        version: 2.73.0
       consola:
         specifier: ^3.4.2
         version: 3.4.2
@@ -4356,7 +4356,7 @@ importers:
         version: link:../client.unstable
       '@osdk/foundry.ontologies':
         specifier: catalog:foundry-platform-typescript
-        version: 2.70.0
+        version: 2.73.0
       '@osdk/generator':
         specifier: workspace:~
         version: link:../generator
@@ -4424,7 +4424,7 @@ importers:
     dependencies:
       '@osdk/foundry.ontologies':
         specifier: catalog:foundry-platform-typescript
-        version: 2.70.0
+        version: 2.73.0
       '@osdk/generator-converters.preview':
         specifier: workspace:~
         version: link:../generator-converters.preview
@@ -4574,7 +4574,7 @@ importers:
         version: link:../client.unstable
       '@osdk/foundry.ontologies':
         specifier: catalog:foundry-platform-typescript
-        version: 2.70.0
+        version: 2.73.0
       '@osdk/generator-converters.ontologyir':
         specifier: workspace:~
         version: link:../generator-converters.ontologyir
@@ -4623,7 +4623,7 @@ importers:
         version: link:../client.unstable
       '@osdk/foundry.ontologies':
         specifier: catalog:foundry-platform-typescript
-        version: 2.70.0
+        version: 2.73.0
       '@osdk/maker':
         specifier: workspace:~
         version: link:../maker
@@ -4894,10 +4894,10 @@ importers:
         version: link:../client.test.ontology
       '@osdk/foundry.admin':
         specifier: catalog:foundry-platform-typescript
-        version: 2.70.0
+        version: 2.73.0
       '@osdk/foundry.core':
         specifier: catalog:foundry-platform-typescript
-        version: 2.70.0
+        version: 2.73.0
       '@osdk/monorepo.api-extractor':
         specifier: workspace:~
         version: link:../monorepo.api-extractor
@@ -5285,7 +5285,7 @@ importers:
     dependencies:
       '@osdk/foundry.ontologies':
         specifier: catalog:foundry-platform-typescript
-        version: 2.70.0
+        version: 2.73.0
       '@osdk/seed-helpers':
         specifier: workspace:~
         version: link:../seed-helpers
@@ -5337,7 +5337,7 @@ importers:
         version: link:../client
       '@osdk/foundry.ontologies':
         specifier: catalog:foundry-platform-typescript
-        version: 2.70.0
+        version: 2.73.0
       consola:
         specifier: ^3.4.2
         version: 3.4.2
@@ -5455,19 +5455,19 @@ importers:
         version: link:../api
       '@osdk/foundry.core':
         specifier: catalog:foundry-platform-typescript
-        version: 2.70.0
+        version: 2.73.0
       '@osdk/foundry.geo':
         specifier: catalog:foundry-platform-typescript
-        version: 2.70.0
+        version: 2.73.0
       '@osdk/foundry.ontologies':
         specifier: catalog:foundry-platform-typescript
-        version: 2.70.0
+        version: 2.73.0
       '@osdk/generator-converters':
         specifier: workspace:~
         version: link:../generator-converters
       '@osdk/internal.foundry.ontologies':
         specifier: catalog:foundry-platform-typescript
-        version: 2.70.0
+        version: 2.73.0
       date-fns:
         specifier: ^4.1.0
         version: 4.1.0
@@ -5817,7 +5817,7 @@ importers:
         version: link:../client.test.ontology
       '@osdk/foundry.admin':
         specifier: catalog:foundry-platform-typescript
-        version: 2.70.0
+        version: 2.73.0
       '@osdk/functions':
         specifier: workspace:~
         version: link:../functions
@@ -5893,7 +5893,7 @@ importers:
         version: link:../faux
       '@osdk/foundry.ontologies':
         specifier: catalog:foundry-platform-typescript
-        version: 2.70.0
+        version: 2.73.0
       '@osdk/generator-converters.ontologyir':
         specifier: workspace:*
         version: link:../generator-converters.ontologyir
@@ -9161,32 +9161,17 @@ packages:
   '@osdk/docs-spec-sdk@0.17.0':
     resolution: {integrity: sha512-uiC2wfUf3i2tQ9wQlcgwLOxHObdjxfwwvy4X04N0tZnpnXEIn7zIIa7WJqpcNUMH3g07tJLEu/wZNdUgxCnS2Q==}
 
-  '@osdk/foundry.admin@2.70.0':
-    resolution: {integrity: sha512-gmViFLPFPA83caE1dfxeWBP96CuTfx2gK7lqxW4bPbFrYlz4mev1IszuxRhQvhG3r5kK3FsgBZ/WfUmuSbRJAw==}
-
   '@osdk/foundry.admin@2.73.0':
     resolution: {integrity: sha512-R8YvY1W4m0XtxWFPzTTbK9F9AGwXGw9/AKDC/LYwIWSMuFNhT2KL8wLA67MURIWxLniXt7vrnihwUoDe0O+p8g==}
-
-  '@osdk/foundry.aipagents@2.70.0':
-    resolution: {integrity: sha512-MxVwiVMxzZqgI7A1oGK2uITwxBMYE8KHTefZ9aPmDYkxk+Vl+phuYD8t7SMMxZsfSUI8AoGJHc/+/774JOwwDg==}
 
   '@osdk/foundry.aipagents@2.73.0':
     resolution: {integrity: sha512-05MYhhNsvmtSC2jFLYPMNkYaLHhZ2aDmOeQOumI3w6i5ZqwVT7uDrt5lPOlmfjDhFEdvxn2xa89Ihgwi0ZYbvw==}
 
-  '@osdk/foundry.audit@2.70.0':
-    resolution: {integrity: sha512-YY4IFvqT9DjfqApEU+qjfpiZv/KrTDc3b4NpxparuRycXM4fBsSNQ0xoBr7TeFAUiJFaataYk57caeFJnWvIYA==}
-
   '@osdk/foundry.audit@2.73.0':
     resolution: {integrity: sha512-IKXpZcNqeIwZjj3y9BBe1VgwHMd9eic9ywTmajP4i1CdumXhFGZpqaNCjMYWvMZB57HdM/16OtYr05XLcDO9eg==}
 
-  '@osdk/foundry.checkpoints@2.70.0':
-    resolution: {integrity: sha512-9B0lL2+V0POI1roUb2QGY79e+6MAUODx1Qv/EyhCsdyiyWp378jHTNQZpFUOxsc3JylBAzsy+4dWkJ0fQJB2hw==}
-
   '@osdk/foundry.checkpoints@2.73.0':
     resolution: {integrity: sha512-mzgwW3MqP0LyF+kwbTQUZUiEm7q6kUmwy+Zecyom/ORvUdvNEKYTtbWUQ3fr6QGdBYpNgsEkg1I+uP87Pvxj0g==}
-
-  '@osdk/foundry.connectivity@2.70.0':
-    resolution: {integrity: sha512-8jTgN8d5RpTzLehx7qILBxkppTCxiY+GEFMbZ7pQBcpGnzBnaalGg6Wq3EGw/hAsYsHJFNAOtcl7AJ0kboIz/Q==}
 
   '@osdk/foundry.connectivity@2.73.0':
     resolution: {integrity: sha512-6t537UwFIzkOWbKjzRrdZZr/1rb4PYgDrKpiQo0C3jCswnpeO0g77QqCpGbNN0Fjtz5YT2mXR4tVSsUM+P/3Ag==}
@@ -9197,14 +9182,8 @@ packages:
   '@osdk/foundry.core@2.5.0':
     resolution: {integrity: sha512-LV+m6/3Y+Q0lN16PAwQvoWtutY0xXdntuwOQjMR2ZqdLRlZOK2KSvfwNZnX4q8EKuvF1mJC8iaTtWh3lChpU1Q==}
 
-  '@osdk/foundry.core@2.70.0':
-    resolution: {integrity: sha512-586F4+sfGJZPUybv630RHqgHEOUfSLWWmj3e8HP20mXiGvJLSS5tC2qlU16CmdbQxM2J9IpqV/iT/ufv5+Y64A==}
-
   '@osdk/foundry.core@2.73.0':
     resolution: {integrity: sha512-wqgDfR+CnuuxeZc1CXcH2cfghkqA0jGOh2Wf7V363GK0kRb1QM+xoGmfbCB4Q9ebc8FEfSrD0k/r1PsFLyxDbw==}
-
-  '@osdk/foundry.datahealth@2.70.0':
-    resolution: {integrity: sha512-7fgmTufDRyxlFrph6Fhjc+OznyKQlrD6yiCCLo2aUYPZGRlpv9B3Ok8Xb0RQ7t2VKRTZOmo5FY3RTAo4NNeIPQ==}
 
   '@osdk/foundry.datahealth@2.73.0':
     resolution: {integrity: sha512-CAhWjDBh1N4cCVdzgIIoG7h43LDldvZwmpetWAVnCLpmHmkbIk062xkZMPeqi2F58l32EG4E2Z8YhfYnrbb0cg==}
@@ -9212,23 +9191,14 @@ packages:
   '@osdk/foundry.datasets@2.5.0':
     resolution: {integrity: sha512-W82xleLQgQFUTVnAQS54n26xUFEALayotl1f3LGeRLN6r+2G1dNp+UgRU7/IHc/xzOqgulEOGwwr6ENFcsNP2A==}
 
-  '@osdk/foundry.datasets@2.70.0':
-    resolution: {integrity: sha512-9c29iK+kaZogx5j/NaYjXnkZx6M/GVApxfYE+Eh2oMCYMrVlszIFSvr1U4NajF3jrNsKdtcWPu9BhLNfMfVTGA==}
-
   '@osdk/foundry.datasets@2.73.0':
     resolution: {integrity: sha512-dCtezCUDmkDb/friCTgkHa14zTH2z5q0XBiPvSYWXbVzBS0SoWfGxnDxrWELhoxzKdT3eTOARh+E1kgK816KUg==}
 
   '@osdk/foundry.filesystem@2.5.0':
     resolution: {integrity: sha512-SJKZSfBc7CroyoIVW3D2SpVyaCCnhv8onzIwHcJWOnufFgSbQ3kqyWoqNiStGlymmnoSbniK3rfUFFYeUbxhDQ==}
 
-  '@osdk/foundry.filesystem@2.70.0':
-    resolution: {integrity: sha512-DdB6bm5ivaIvNJ71zQGPORDyflQouqEkgTmJymEY//Twf/9MVmqnob8pFQTMUt851pxiAjrg+2/eBjkRXYqmtQ==}
-
   '@osdk/foundry.filesystem@2.73.0':
     resolution: {integrity: sha512-bGm6UtfiA0KlxZbP5gdZ70HtfMZ5VcJtabnfoCxTorA1zX4YPP0WOyTJ+J/e19JF1IUaSLgw07ea2ZH+uv2rCw==}
-
-  '@osdk/foundry.functions@2.70.0':
-    resolution: {integrity: sha512-uI1KN+JvottagpJhgfm14kJn7qnYFDKd2LfCAN7wYTucooV/Itz4mxMjwUua0s7uljUZZdEH0p3EM1PQjKi14g==}
 
   '@osdk/foundry.functions@2.73.0':
     resolution: {integrity: sha512-gp8Tk4mgQAYp5uW0vNNq9V/ICTog55iqJhGddssSuu1wAwTQs62FbVXOeqSI1p4qMfAxsdWuQSJ+3uYZCq6Jpg==}
@@ -9239,20 +9209,11 @@ packages:
   '@osdk/foundry.geo@2.5.0':
     resolution: {integrity: sha512-kL615eqHvn1MkP0le2r6vx/ub+lit5bKdmoWNRELMqi9s2BlLuoKAQW5H9YDQPqhHuJDjrBJAWiviOin9mUKqw==}
 
-  '@osdk/foundry.geo@2.70.0':
-    resolution: {integrity: sha512-c7g8QtFILSwyIoPAl72RXslqT0BWSkGU7qvtcxra6ZjskQIJDJqVR1MfRGQWn2vA9Qi8EAqI2wraZxJz+asvIw==}
-
   '@osdk/foundry.geo@2.73.0':
     resolution: {integrity: sha512-map1LI7ic4s93u16mian0hj1QTads3M/nEa+sgJBh2u6rAdal56hK3YKblgvc9NvE7Bg5urAKIohly+f5RAC6g==}
 
-  '@osdk/foundry.geojson@2.70.0':
-    resolution: {integrity: sha512-V65OHjywcWbENxaWucUHpL4NCpiFM/AXAR8NYDNaL6YwfZF4jn3gNMG6stiuq5zOnkfKPlAKMve3/wYPyQzpJA==}
-
   '@osdk/foundry.geojson@2.73.0':
     resolution: {integrity: sha512-huWeBypQ3H4RpkPiuhw7mX5kCaDb3KZupUi4IQmb0T1U6Shv+GZsT590lRLqFOoffXvlTXS221vU47hbMG46BA==}
-
-  '@osdk/foundry.languagemodels@2.70.0':
-    resolution: {integrity: sha512-EO4rXR+TBUMvzJja8ncYMg4/MOFRNAn2aBZcmY37XhQ8+sfR28lryMuVkVq3J0GnsZXOtfTMcv5Jif50GfBrog==}
 
   '@osdk/foundry.languagemodels@2.73.0':
     resolution: {integrity: sha512-HPOQSmfrzMPUS4M0fWr5lH9pT1/fXhRM0e2IpkcmT/gK/48UibK0sp9jl2ZXuw9pjqNg7YP/rPMU6vGx9TyBqA==}
@@ -9260,20 +9221,11 @@ packages:
   '@osdk/foundry.mediasets@2.44.0':
     resolution: {integrity: sha512-l378lxKUdIMmb1txFs/hOKyPO3bc10OWU4BvaP/LMZjXLbUZPNI/DYAmKrzKTeSMGBnZ2luhqEyfPfZYMGmrhw==}
 
-  '@osdk/foundry.mediasets@2.70.0':
-    resolution: {integrity: sha512-Ag4lm2H0WbIx6loOykYjoJWzxiqxvU2Fva+58XsTISIgg81CEEDvhls6UoLUX3IVq7vhWquYZnJUuogRTOYNeA==}
-
   '@osdk/foundry.mediasets@2.73.0':
     resolution: {integrity: sha512-ztLsK3QQsSvnkUkzMApZLsf8h38Q4fNFY9pS2Bap/feMHx4vsi+SxMRdcZSgJ9DYuAwNWfYsPcgf7aZNU61C1Q==}
 
-  '@osdk/foundry.models@2.70.0':
-    resolution: {integrity: sha512-YvBM6UU+0CbIyzWmiShFXSt2nLpGV1+JkHtusjoOy8wd9UGN65SIsHAwGm601Sciqk/yiiD16YNFgX/m0RJgog==}
-
   '@osdk/foundry.models@2.73.0':
     resolution: {integrity: sha512-q69O4yr7sJNTo0UCHMAkHgwEa+QKPuqsahF9tCGXVNcYPm8rFxznuP/bjMbwVFmfOJfUR5M3opvwo+qnWSg0fg==}
-
-  '@osdk/foundry.notepad@2.70.0':
-    resolution: {integrity: sha512-vlOGxmU/jtKaBaY5D7+y0rYHclN/H2XDMKVnjlseMy8lu3JPK2hxlGQ2Vdo3yv/X45kz+sH4VKa/j/kVJgk4cA==}
 
   '@osdk/foundry.notepad@2.73.0':
     resolution: {integrity: sha512-+M4/sTtdKxOfNS3tAPZougw8QFCwW1p7dHztpwYX9dGFdM/he4SzQtuZFv3EgJdsAa+H/PNnuKaMAvgE0MY2bA==}
@@ -9281,62 +9233,32 @@ packages:
   '@osdk/foundry.ontologies@2.44.0':
     resolution: {integrity: sha512-A74NrG3tDiLNC5VW+plchrrMDf5gLekavrdyVnmVqQAkcBc6Z8/Jl+92rJbQ/v6TJnXWpCwuCkc+QQXaYlhHKQ==}
 
-  '@osdk/foundry.ontologies@2.70.0':
-    resolution: {integrity: sha512-QVYx/iJ4Fj6K/USKXg1GwLG0DwYtSuU0ok3Phygeua3iDMzpitQuroto5/Njy+I3dbhKaFdGVsQM5gDAL6fTTg==}
-
   '@osdk/foundry.ontologies@2.73.0':
     resolution: {integrity: sha512-eoViI7iiR1PRRpS88/rIkYAIbVMKnVCHDa7TFYtxc6lQbEGVazkHL5OZ8eqnX4n5fPK/KIAk1mGgi4wUVOhHcA==}
-
-  '@osdk/foundry.operations@2.70.0':
-    resolution: {integrity: sha512-P79/V/SCYZeWchheC764NJB/+SzNPCB5i9cmNAT9hKeya2T44a2J7IpJafsp1CETttmS7hiEupx+de7UplA9mg==}
 
   '@osdk/foundry.operations@2.73.0':
     resolution: {integrity: sha512-B99kU3E/l1eIFcEDzbtsFSIAHAAeTI7rkAwkzCeGqDm61zzw4k87fFzlRrFbPScbmuHngHvA8QMFfS9JK5qpFg==}
 
-  '@osdk/foundry.orchestration@2.70.0':
-    resolution: {integrity: sha512-dUuHqTyPvK5emYuVA2pgQgnzAlg0A/jGxiiQrYjYnwLFeDn/Ok5hTGaLYGiRX8Ngl4qTigHoYumc574XvmNyVg==}
-
   '@osdk/foundry.orchestration@2.73.0':
     resolution: {integrity: sha512-a91+YtbyLsnWMOG2EfcastBxf9kF6ZFseth/EuC99P1A1/TTS0ovkGXlK6HNQFHF+R8xK8gYMdtfY3zgjoWeBQ==}
-
-  '@osdk/foundry.pack@2.70.0':
-    resolution: {integrity: sha512-ds86ZKx9dljuKIlMsBM/Doq19cdBvhmR3vOjfZvjGST+qvSVV4aZRVv8vbpkF20V0/s5ueTw4OYO9n2LhVobDA==}
 
   '@osdk/foundry.pack@2.73.0':
     resolution: {integrity: sha512-CPt0RX8ai/UQc8GqPV8AzqtxfmG66Yo84KUZGWpvsQRAfcvJ70X/jDD1FncRqLCetlY1q3tK8j11/5SRt9v1eQ==}
 
-  '@osdk/foundry.publicapis@2.70.0':
-    resolution: {integrity: sha512-L3WENihrbpj1/CITW5hp87PD94eZulJvnTlrC33uTGn7HZnQ5072oVXztGS024FZdi1ilmW1NHSyRFxog0w24g==}
-
   '@osdk/foundry.publicapis@2.73.0':
     resolution: {integrity: sha512-SjMCayouoNFVeHFcMrFsmts/17ADZ59t1TWzJBn6ZKTlwJ6p66ozdnWQC14YY/+3TMXKZEckHuoLp6wYndDdvQ==}
-
-  '@osdk/foundry.sqlqueries@2.70.0':
-    resolution: {integrity: sha512-uOS/DvipsqUq/WTlGXMAN9RcQOFxK1u048R40uvClIoVd0HtGUa+PbaieeIhhFDPoLZrn7WJ6lbF8pFMLdPKsA==}
 
   '@osdk/foundry.sqlqueries@2.73.0':
     resolution: {integrity: sha512-xFI95P5gF0nM/3VVtL5kDkczaLeDnA/KmvZ4hjQLrjZRqgdgnXvzmA1KEe1aDWQyDSVezSlKp77BYo8SVeMFWw==}
 
-  '@osdk/foundry.streams@2.70.0':
-    resolution: {integrity: sha512-lFuLFfkjs+1rjAQaf5+aO+Z2R1XA7w4qdrdXIJT9j+Bt5vOrd+SNhNwCOQ1O4tiPboho1dWArDlvVIsrdjrC8g==}
-
   '@osdk/foundry.streams@2.73.0':
     resolution: {integrity: sha512-gWqAkt2ydzKdkP4bSQR9U1RIfArwmi8bxYQolVEuF7vQ6s5ufqp5H04URoKHspBppgc2+vgmq+qZj5QJC7GMUw==}
-
-  '@osdk/foundry.thirdpartyapplications@2.70.0':
-    resolution: {integrity: sha512-69VsjXuT1sDxAScFHIryHFIjAOl5+rquN38ELFfvAN0wm4evEnx1HxuN7MhPEY7FZAbxm1nefEuVBh6n5K6Naw==}
 
   '@osdk/foundry.thirdpartyapplications@2.73.0':
     resolution: {integrity: sha512-fLb16QgG17gIWFI8ZdQiyUEfZXQN2Kpm/IMEcFOFmUI+s9FjP9lF2UWfljYRFUgdj5STL07LRHPy9DgKDRtEGg==}
 
-  '@osdk/foundry.widgets@2.70.0':
-    resolution: {integrity: sha512-47xlD8dEqSERTBla/EEk7ETpfPRUUABna66n47W6HoX9Er12aC4fG7IqvvdkdjIl46pgBWvi4hYU9jf17tRgxg==}
-
   '@osdk/foundry.widgets@2.73.0':
     resolution: {integrity: sha512-tGhg4+F5/0Fs8leKKkB4jGr9z5jZ777yu1tVx/9tJByMYQG7ghkeqG6TJDEYWIBYwUVlwg1/geX0dOrsdWthVA==}
-
-  '@osdk/foundry@2.70.0':
-    resolution: {integrity: sha512-5jyCvjoW/hBLVOhjVqGPQc+9so+cprDLGmFx1IsOI/yooUBMjdm4mRwAE4UwNmLuVAk98p1nt4f5cG5acD7vVQ==}
 
   '@osdk/foundry@2.73.0':
     resolution: {integrity: sha512-RzZ4mjo66llOQasGnOyHIMNIQAU0imyiWhpGrnMLLQQFyCB1sbSc5wWk1mLDYeda7rHKXGrjqtzdVCfwZO3w9w==}
@@ -9347,17 +9269,17 @@ packages:
   '@osdk/generator-converters@2.7.5':
     resolution: {integrity: sha512-dtvqVN3ufdwgsz2BlQwoTpCHuftnAQMbjAqDA/cT1wnW5wCWeo8ctxhl0ArCfM4jbGhiz9OcspHajuDC07IStw==}
 
-  '@osdk/internal.foundry.core@2.70.0':
-    resolution: {integrity: sha512-4Y7X1+5rybeokNJEjZdVCqTCXKAsnAuKENsW1qB3IA1zaGA867F3OJ3wdQMVCiB8n9mB6MadV5x5IEXx2BrgPA==}
+  '@osdk/internal.foundry.core@2.73.0':
+    resolution: {integrity: sha512-AEEbCI9e/VkqgalPvDF+/XIDgvGWWM8Zd4pXG6LW+lUnRDiHtJ645uRDjhcsbrR2rvz2E8SJPpdZvp3I/H8JFQ==}
 
-  '@osdk/internal.foundry.datasets@2.70.0':
-    resolution: {integrity: sha512-vWolwAh2OdVj35p9ZViKE1GaPIOPa3q1tqCQdvkDjrl+XPmONorq8074tLP4c1ahZyB9s6u5LfDTfd4jsHwYJA==}
+  '@osdk/internal.foundry.datasets@2.73.0':
+    resolution: {integrity: sha512-5wunpMzmvasLLeiE9CE47IbKSMPwNFcDCnAFvdMZBw2C9WnzqKOGT4kY1M151rY9JXyfXDq3449qNIxi+wORbw==}
 
-  '@osdk/internal.foundry.geo@2.70.0':
-    resolution: {integrity: sha512-U/McaTWYqaqZdEpkhi/TTc4r7t7+h5RcUdTj+QKxbCyaY6h8p9aR3cRypPj4Xj0vQPN9LICZUJawSbk0t8AE2g==}
+  '@osdk/internal.foundry.geo@2.73.0':
+    resolution: {integrity: sha512-xH844lIibnwBB6WjfI4QQ9US6kPSYOjvAi5tbRtjmdgH1ynd5n2kHeVhovOemaTnv+VJocz004XS1MQYlRBpnQ==}
 
-  '@osdk/internal.foundry.ontologies@2.70.0':
-    resolution: {integrity: sha512-L2ZYQYUirtkk+Nga0Np0rvqxwYH5UeKvpSN40FcXBdPSPwaXb8BF+CQPGDe9RSGiYqdKzBjE6mrR2W0p0MORXA==}
+  '@osdk/internal.foundry.ontologies@2.73.0':
+    resolution: {integrity: sha512-6A5rQDjTEoW/GfiQq85g5yY0PWuh9Cx+pbzBMnXmrX+Kxbj7PglxzusL5xj34CG5FkVxKp+Bj+ewMmdORDxqBA==}
 
   '@osdk/language-models@0.6.0':
     resolution: {integrity: sha512-cPyJA4YG6BeIKu1TtjKdqRfSCA85SOLoN+o8PCkJHx35Gn7YCUbHe0gWiSqznak0XzA7HjzWcSouPjWYjmdogw==}
@@ -26549,25 +26471,9 @@ snapshots:
     dependencies:
       '@osdk/docs-spec-core': 0.6.0
 
-  '@osdk/foundry.admin@2.70.0':
-    dependencies:
-      '@osdk/foundry.core': 2.70.0
-      '@osdk/shared.client': 1.0.1
-      '@osdk/shared.client2': 1.0.0
-      '@osdk/shared.net.platformapi': 1.7.0
-
   '@osdk/foundry.admin@2.73.0':
     dependencies:
       '@osdk/foundry.core': 2.73.0
-      '@osdk/shared.client': 1.0.1
-      '@osdk/shared.client2': 1.0.0
-      '@osdk/shared.net.platformapi': 1.7.0
-
-  '@osdk/foundry.aipagents@2.70.0':
-    dependencies:
-      '@osdk/foundry.core': 2.70.0
-      '@osdk/foundry.functions': 2.70.0
-      '@osdk/foundry.ontologies': 2.70.0
       '@osdk/shared.client': 1.0.1
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.7.0
@@ -26581,13 +26487,6 @@ snapshots:
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.7.0
 
-  '@osdk/foundry.audit@2.70.0':
-    dependencies:
-      '@osdk/foundry.core': 2.70.0
-      '@osdk/shared.client': 1.0.1
-      '@osdk/shared.client2': 1.0.0
-      '@osdk/shared.net.platformapi': 1.7.0
-
   '@osdk/foundry.audit@2.73.0':
     dependencies:
       '@osdk/foundry.core': 2.73.0
@@ -26595,24 +26494,9 @@ snapshots:
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.7.0
 
-  '@osdk/foundry.checkpoints@2.70.0':
-    dependencies:
-      '@osdk/foundry.core': 2.70.0
-      '@osdk/shared.client': 1.0.1
-      '@osdk/shared.client2': 1.0.0
-      '@osdk/shared.net.platformapi': 1.7.0
-
   '@osdk/foundry.checkpoints@2.73.0':
     dependencies:
       '@osdk/foundry.core': 2.73.0
-      '@osdk/shared.client': 1.0.1
-      '@osdk/shared.client2': 1.0.0
-      '@osdk/shared.net.platformapi': 1.7.0
-
-  '@osdk/foundry.connectivity@2.70.0':
-    dependencies:
-      '@osdk/foundry.core': 2.70.0
-      '@osdk/foundry.filesystem': 2.70.0
       '@osdk/shared.client': 1.0.1
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.7.0
@@ -26639,23 +26523,9 @@ snapshots:
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.1.0
 
-  '@osdk/foundry.core@2.70.0':
-    dependencies:
-      '@osdk/foundry.geo': 2.70.0
-      '@osdk/shared.client': 1.0.1
-      '@osdk/shared.client2': 1.0.0
-      '@osdk/shared.net.platformapi': 1.7.0
-
   '@osdk/foundry.core@2.73.0':
     dependencies:
       '@osdk/foundry.geo': 2.73.0
-      '@osdk/shared.client': 1.0.1
-      '@osdk/shared.client2': 1.0.0
-      '@osdk/shared.net.platformapi': 1.7.0
-
-  '@osdk/foundry.datahealth@2.70.0':
-    dependencies:
-      '@osdk/foundry.core': 2.70.0
       '@osdk/shared.client': 1.0.1
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.7.0
@@ -26675,15 +26545,6 @@ snapshots:
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.1.0
 
-  '@osdk/foundry.datasets@2.70.0':
-    dependencies:
-      '@osdk/foundry.core': 2.70.0
-      '@osdk/foundry.datahealth': 2.70.0
-      '@osdk/foundry.filesystem': 2.70.0
-      '@osdk/shared.client': 1.0.1
-      '@osdk/shared.client2': 1.0.0
-      '@osdk/shared.net.platformapi': 1.7.0
-
   '@osdk/foundry.datasets@2.73.0':
     dependencies:
       '@osdk/foundry.core': 2.73.0
@@ -26700,24 +26561,9 @@ snapshots:
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.1.0
 
-  '@osdk/foundry.filesystem@2.70.0':
-    dependencies:
-      '@osdk/foundry.core': 2.70.0
-      '@osdk/shared.client': 1.0.1
-      '@osdk/shared.client2': 1.0.0
-      '@osdk/shared.net.platformapi': 1.7.0
-
   '@osdk/foundry.filesystem@2.73.0':
     dependencies:
       '@osdk/foundry.core': 2.73.0
-      '@osdk/shared.client': 1.0.1
-      '@osdk/shared.client2': 1.0.0
-      '@osdk/shared.net.platformapi': 1.7.0
-
-  '@osdk/foundry.functions@2.70.0':
-    dependencies:
-      '@osdk/foundry.core': 2.70.0
-      '@osdk/foundry.ontologies': 2.70.0
       '@osdk/shared.client': 1.0.1
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.7.0
@@ -26742,19 +26588,7 @@ snapshots:
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.1.0
 
-  '@osdk/foundry.geo@2.70.0':
-    dependencies:
-      '@osdk/shared.client': 1.0.1
-      '@osdk/shared.client2': 1.0.0
-      '@osdk/shared.net.platformapi': 1.7.0
-
   '@osdk/foundry.geo@2.73.0':
-    dependencies:
-      '@osdk/shared.client': 1.0.1
-      '@osdk/shared.client2': 1.0.0
-      '@osdk/shared.net.platformapi': 1.7.0
-
-  '@osdk/foundry.geojson@2.70.0':
     dependencies:
       '@osdk/shared.client': 1.0.1
       '@osdk/shared.client2': 1.0.0
@@ -26762,13 +26596,6 @@ snapshots:
 
   '@osdk/foundry.geojson@2.73.0':
     dependencies:
-      '@osdk/shared.client': 1.0.1
-      '@osdk/shared.client2': 1.0.0
-      '@osdk/shared.net.platformapi': 1.7.0
-
-  '@osdk/foundry.languagemodels@2.70.0':
-    dependencies:
-      '@osdk/foundry.core': 2.70.0
       '@osdk/shared.client': 1.0.1
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.7.0
@@ -26787,26 +26614,9 @@ snapshots:
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.5.0
 
-  '@osdk/foundry.mediasets@2.70.0':
-    dependencies:
-      '@osdk/foundry.core': 2.70.0
-      '@osdk/shared.client': 1.0.1
-      '@osdk/shared.client2': 1.0.0
-      '@osdk/shared.net.platformapi': 1.7.0
-
   '@osdk/foundry.mediasets@2.73.0':
     dependencies:
       '@osdk/foundry.core': 2.73.0
-      '@osdk/shared.client': 1.0.1
-      '@osdk/shared.client2': 1.0.0
-      '@osdk/shared.net.platformapi': 1.7.0
-
-  '@osdk/foundry.models@2.70.0':
-    dependencies:
-      '@osdk/foundry.core': 2.70.0
-      '@osdk/foundry.filesystem': 2.70.0
-      '@osdk/foundry.ontologies': 2.70.0
-      '@osdk/foundry.orchestration': 2.70.0
       '@osdk/shared.client': 1.0.1
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.7.0
@@ -26817,15 +26627,6 @@ snapshots:
       '@osdk/foundry.filesystem': 2.73.0
       '@osdk/foundry.ontologies': 2.73.0
       '@osdk/foundry.orchestration': 2.73.0
-      '@osdk/shared.client': 1.0.1
-      '@osdk/shared.client2': 1.0.0
-      '@osdk/shared.net.platformapi': 1.7.0
-
-  '@osdk/foundry.notepad@2.70.0':
-    dependencies:
-      '@osdk/foundry.core': 2.70.0
-      '@osdk/foundry.filesystem': 2.70.0
-      '@osdk/foundry.ontologies': 2.70.0
       '@osdk/shared.client': 1.0.1
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.7.0
@@ -26847,15 +26648,6 @@ snapshots:
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.5.0
 
-  '@osdk/foundry.ontologies@2.70.0':
-    dependencies:
-      '@osdk/foundry.core': 2.70.0
-      '@osdk/foundry.datasets': 2.70.0
-      '@osdk/foundry.geo': 2.70.0
-      '@osdk/shared.client': 1.0.1
-      '@osdk/shared.client2': 1.0.0
-      '@osdk/shared.net.platformapi': 1.7.0
-
   '@osdk/foundry.ontologies@2.73.0':
     dependencies:
       '@osdk/foundry.core': 2.73.0
@@ -26865,27 +26657,10 @@ snapshots:
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.7.0
 
-  '@osdk/foundry.operations@2.70.0':
-    dependencies:
-      '@osdk/foundry.core': 2.70.0
-      '@osdk/foundry.ontologies': 2.70.0
-      '@osdk/shared.client': 1.0.1
-      '@osdk/shared.client2': 1.0.0
-      '@osdk/shared.net.platformapi': 1.7.0
-
   '@osdk/foundry.operations@2.73.0':
     dependencies:
       '@osdk/foundry.core': 2.73.0
       '@osdk/foundry.ontologies': 2.73.0
-      '@osdk/shared.client': 1.0.1
-      '@osdk/shared.client2': 1.0.0
-      '@osdk/shared.net.platformapi': 1.7.0
-
-  '@osdk/foundry.orchestration@2.70.0':
-    dependencies:
-      '@osdk/foundry.core': 2.70.0
-      '@osdk/foundry.datasets': 2.70.0
-      '@osdk/foundry.filesystem': 2.70.0
       '@osdk/shared.client': 1.0.1
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.7.0
@@ -26899,14 +26674,6 @@ snapshots:
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.7.0
 
-  '@osdk/foundry.pack@2.70.0':
-    dependencies:
-      '@osdk/foundry.core': 2.70.0
-      '@osdk/foundry.filesystem': 2.70.0
-      '@osdk/shared.client': 1.0.1
-      '@osdk/shared.client2': 1.0.0
-      '@osdk/shared.net.platformapi': 1.7.0
-
   '@osdk/foundry.pack@2.73.0':
     dependencies:
       '@osdk/foundry.core': 2.73.0
@@ -26915,25 +26682,9 @@ snapshots:
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.7.0
 
-  '@osdk/foundry.publicapis@2.70.0':
-    dependencies:
-      '@osdk/foundry.core': 2.70.0
-      '@osdk/shared.client': 1.0.1
-      '@osdk/shared.client2': 1.0.0
-      '@osdk/shared.net.platformapi': 1.7.0
-
   '@osdk/foundry.publicapis@2.73.0':
     dependencies:
       '@osdk/foundry.core': 2.73.0
-      '@osdk/shared.client': 1.0.1
-      '@osdk/shared.client2': 1.0.0
-      '@osdk/shared.net.platformapi': 1.7.0
-
-  '@osdk/foundry.sqlqueries@2.70.0':
-    dependencies:
-      '@osdk/foundry.core': 2.70.0
-      '@osdk/foundry.datasets': 2.70.0
-      '@osdk/foundry.ontologies': 2.70.0
       '@osdk/shared.client': 1.0.1
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.7.0
@@ -26947,27 +26698,11 @@ snapshots:
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.7.0
 
-  '@osdk/foundry.streams@2.70.0':
-    dependencies:
-      '@osdk/foundry.core': 2.70.0
-      '@osdk/foundry.datasets': 2.70.0
-      '@osdk/foundry.filesystem': 2.70.0
-      '@osdk/shared.client': 1.0.1
-      '@osdk/shared.client2': 1.0.0
-      '@osdk/shared.net.platformapi': 1.7.0
-
   '@osdk/foundry.streams@2.73.0':
     dependencies:
       '@osdk/foundry.core': 2.73.0
       '@osdk/foundry.datasets': 2.73.0
       '@osdk/foundry.filesystem': 2.73.0
-      '@osdk/shared.client': 1.0.1
-      '@osdk/shared.client2': 1.0.0
-      '@osdk/shared.net.platformapi': 1.7.0
-
-  '@osdk/foundry.thirdpartyapplications@2.70.0':
-    dependencies:
-      '@osdk/foundry.core': 2.70.0
       '@osdk/shared.client': 1.0.1
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.7.0
@@ -26979,47 +26714,9 @@ snapshots:
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.7.0
 
-  '@osdk/foundry.widgets@2.70.0':
-    dependencies:
-      '@osdk/foundry.core': 2.70.0
-      '@osdk/shared.client': 1.0.1
-      '@osdk/shared.client2': 1.0.0
-      '@osdk/shared.net.platformapi': 1.7.0
-
   '@osdk/foundry.widgets@2.73.0':
     dependencies:
       '@osdk/foundry.core': 2.73.0
-      '@osdk/shared.client': 1.0.1
-      '@osdk/shared.client2': 1.0.0
-      '@osdk/shared.net.platformapi': 1.7.0
-
-  '@osdk/foundry@2.70.0':
-    dependencies:
-      '@osdk/foundry.admin': 2.70.0
-      '@osdk/foundry.aipagents': 2.70.0
-      '@osdk/foundry.audit': 2.70.0
-      '@osdk/foundry.checkpoints': 2.70.0
-      '@osdk/foundry.connectivity': 2.70.0
-      '@osdk/foundry.core': 2.70.0
-      '@osdk/foundry.datahealth': 2.70.0
-      '@osdk/foundry.datasets': 2.70.0
-      '@osdk/foundry.filesystem': 2.70.0
-      '@osdk/foundry.functions': 2.70.0
-      '@osdk/foundry.geo': 2.70.0
-      '@osdk/foundry.geojson': 2.70.0
-      '@osdk/foundry.languagemodels': 2.70.0
-      '@osdk/foundry.mediasets': 2.70.0
-      '@osdk/foundry.models': 2.70.0
-      '@osdk/foundry.notepad': 2.70.0
-      '@osdk/foundry.ontologies': 2.70.0
-      '@osdk/foundry.operations': 2.70.0
-      '@osdk/foundry.orchestration': 2.70.0
-      '@osdk/foundry.pack': 2.70.0
-      '@osdk/foundry.publicapis': 2.70.0
-      '@osdk/foundry.sqlqueries': 2.70.0
-      '@osdk/foundry.streams': 2.70.0
-      '@osdk/foundry.thirdpartyapplications': 2.70.0
-      '@osdk/foundry.widgets': 2.70.0
       '@osdk/shared.client': 1.0.1
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.7.0
@@ -27065,31 +26762,31 @@ snapshots:
       '@osdk/api': 2.7.5
       '@osdk/foundry.ontologies': 2.44.0
 
-  '@osdk/internal.foundry.core@2.70.0':
+  '@osdk/internal.foundry.core@2.73.0':
     dependencies:
-      '@osdk/internal.foundry.geo': 2.70.0
+      '@osdk/internal.foundry.geo': 2.73.0
       '@osdk/shared.client': 1.0.1
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.7.0
 
-  '@osdk/internal.foundry.datasets@2.70.0':
+  '@osdk/internal.foundry.datasets@2.73.0':
     dependencies:
-      '@osdk/internal.foundry.core': 2.70.0
+      '@osdk/internal.foundry.core': 2.73.0
       '@osdk/shared.client': 1.0.1
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.7.0
 
-  '@osdk/internal.foundry.geo@2.70.0':
+  '@osdk/internal.foundry.geo@2.73.0':
     dependencies:
       '@osdk/shared.client': 1.0.1
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.7.0
 
-  '@osdk/internal.foundry.ontologies@2.70.0':
+  '@osdk/internal.foundry.ontologies@2.73.0':
     dependencies:
-      '@osdk/internal.foundry.core': 2.70.0
-      '@osdk/internal.foundry.datasets': 2.70.0
-      '@osdk/internal.foundry.geo': 2.70.0
+      '@osdk/internal.foundry.core': 2.73.0
+      '@osdk/internal.foundry.datasets': 2.73.0
+      '@osdk/internal.foundry.geo': 2.73.0
       '@osdk/shared.client': 1.0.1
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.7.0
@@ -30445,11 +30142,11 @@ snapshots:
       - vite
     optional: true
 
-  '@vitest/browser@3.2.6(msw@2.11.1(@types/node@18.19.124)(typescript@5.5.4))(playwright@1.60.0)(vite@6.4.2(@types/node@18.19.124)(jiti@2.5.1)(less@4.5.1)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(stylus@0.62.0)(terser@5.44.0)(tsx@4.20.5)(yaml@2.9.0))(vitest@3.2.6)':
+  '@vitest/browser@3.2.6(msw@2.11.1(@types/node@18.19.124)(typescript@5.5.4))(playwright@1.60.0)(vite@7.3.2(@types/node@18.19.124)(jiti@2.5.1)(less@4.5.1)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(stylus@0.62.0)(terser@5.44.0)(tsx@4.20.5)(yaml@2.9.0))(vitest@3.2.6)':
     dependencies:
       '@testing-library/dom': 10.4.0
       '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.0)
-      '@vitest/mocker': 3.2.6(msw@2.11.1(@types/node@18.19.124)(typescript@5.5.4))(vite@6.4.2(@types/node@18.19.124)(jiti@2.5.1)(less@4.5.1)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(stylus@0.62.0)(terser@5.44.0)(tsx@4.20.5)(yaml@2.9.0))
+      '@vitest/mocker': 3.2.6(msw@2.11.1(@types/node@18.19.124)(typescript@5.5.4))(vite@7.3.2(@types/node@18.19.124)(jiti@2.5.1)(less@4.5.1)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(stylus@0.62.0)(terser@5.44.0)(tsx@4.20.5)(yaml@2.9.0))
       '@vitest/utils': 3.2.6
       magic-string: 0.30.19
       sirv: 3.0.2
@@ -30683,6 +30380,16 @@ snapshots:
     optionalDependencies:
       msw: 2.11.1(@types/node@18.19.124)(typescript@5.5.4)
       vite: 6.4.2(@types/node@18.19.124)(jiti@2.5.1)(less@4.5.1)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(stylus@0.62.0)(terser@5.44.0)(tsx@4.20.5)(yaml@2.9.0)
+
+  '@vitest/mocker@3.2.6(msw@2.11.1(@types/node@18.19.124)(typescript@5.5.4))(vite@7.3.2(@types/node@18.19.124)(jiti@2.5.1)(less@4.5.1)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(stylus@0.62.0)(terser@5.44.0)(tsx@4.20.5)(yaml@2.9.0))':
+    dependencies:
+      '@vitest/spy': 3.2.6
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      msw: 2.11.1(@types/node@18.19.124)(typescript@5.5.4)
+      vite: 7.3.2(@types/node@18.19.124)(jiti@2.5.1)(less@4.5.1)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(stylus@0.62.0)(terser@5.44.0)(tsx@4.20.5)(yaml@2.9.0)
+    optional: true
 
   '@vitest/mocker@3.2.6(msw@2.11.1(@types/node@20.19.13)(typescript@5.5.4))(vite@6.4.2(@types/node@20.19.13)(jiti@2.5.1)(less@4.5.1)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(stylus@0.62.0)(terser@5.44.0)(tsx@4.20.5)(yaml@2.9.0))':
     dependencies:
@@ -42660,7 +42367,7 @@ snapshots:
     optionalDependencies:
       '@types/debug': 4.1.12
       '@types/node': 18.19.124
-      '@vitest/browser': 3.2.6(msw@2.11.1(@types/node@18.19.124)(typescript@5.5.4))(playwright@1.60.0)(vite@6.4.2(@types/node@18.19.124)(jiti@2.5.1)(less@4.5.1)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(stylus@0.62.0)(terser@5.44.0)(tsx@4.20.5)(yaml@2.9.0))(vitest@3.2.6)
+      '@vitest/browser': 3.2.6(msw@2.11.1(@types/node@18.19.124)(typescript@5.5.4))(playwright@1.60.0)(vite@7.3.2(@types/node@18.19.124)(jiti@2.5.1)(less@4.5.1)(lightningcss@1.32.0)(sass-embedded@1.97.3)(sass@1.97.3)(stylus@0.62.0)(terser@5.44.0)(tsx@4.20.5)(yaml@2.9.0))(vitest@3.2.6)
       happy-dom: 20.8.9
       jsdom: 20.0.3(canvas@2.11.2)
     transitivePeerDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -22,13 +22,13 @@ catalogs:
   foundry-platform-typescript:
     "@osdk/docs-spec-core": 0.6.0
     "@osdk/docs-spec-sdk": 0.17.0
-    "@osdk/foundry": 2.70.0
-    "@osdk/foundry.core": 2.70.0
+    "@osdk/foundry": 2.73.0
+    "@osdk/foundry.core": 2.73.0
     "@osdk/foundry.datasets": ~2.5.0
-    "@osdk/foundry.functions": 2.70.0
-    "@osdk/foundry.geo": 2.70.0
-    "@osdk/foundry.admin": 2.70.0
-    "@osdk/foundry.mediasets": 2.70.0
-    "@osdk/foundry.ontologies": 2.70.0
-    "@osdk/foundry.thirdpartyapplications": 2.70.0
-    "@osdk/internal.foundry.ontologies": 2.70.0
+    "@osdk/foundry.functions": 2.73.0
+    "@osdk/foundry.geo": 2.73.0
+    "@osdk/foundry.admin": 2.73.0
+    "@osdk/foundry.mediasets": 2.73.0
+    "@osdk/foundry.ontologies": 2.73.0
+    "@osdk/foundry.thirdpartyapplications": 2.73.0
+    "@osdk/internal.foundry.ontologies": 2.73.0


### PR DESCRIPTION
## BLUF

bump catalog entries from `2.70.0` -> `2.73.0` to pick up api-gateway change (fix `TranscriptionLanguage` to be `"NO"` instead of the  incorrect `"false"` YAML coercion. 

## Changes in this PR
bump catalog entries to 2.73.0 to pick up api-gateway change

## FLUP

pre-work for media transformation param improvement
