### PR TITLE
[Branching] Make client environment branch-aware

### DIFF
--- a/.changeset/client-branch-aware-environment.md
+++ b/.changeset/client-branch-aware-environment.md
@@ -1,0 +1,7 @@
+---
+"@osdk/client": minor
+---
+
+The client is now branch-aware without configuration. When `UNSTABLE_DO_NOT_USE_BRANCH` is omitted, the branch is read from the `VITE_FOUNDRY_BRANCH_RID` environment variable that Foundry runtimes set to the branch the application is checked out on, so objects, actions, and queries read and write on that branch.
+
+An explicitly supplied branch still wins, and `UNSTABLE_DO_NOT_USE_BRANCH` now accepts `null` to pin the client to the default branch while checked out on a branch.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ on:
       - main
       - release/*
       - next
+      - zka/make-client-branch-aware
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
@@ -76,7 +77,7 @@ jobs:
         run: pnpm exec turbo run build
 
       - name: Update versions for snapshots
-        run: pnpm exec changeset version --snapshot ${GITHUB_REF_NAME//\//__}
+        run: pnpm exec changeset version --snapshot ${GITHUB_REF_NAME//\//-}
 
       - name: Make sure code is up to date
         run: pnpm exec turbo run postVersioning
@@ -85,4 +86,4 @@ jobs:
         run: pnpm exec turbo run build
 
       - name: Publish results
-        run: pnpm exec changeset publish --no-git-tag --tag next-${GITHUB_REF_NAME//\//__}
+        run: pnpm exec changeset publish --no-git-tag --tag next-${GITHUB_REF_NAME//\//-}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,6 @@ on:
       - main
       - release/*
       - next
-      - zka/make-client-branch-aware
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
@@ -77,7 +76,7 @@ jobs:
         run: pnpm exec turbo run build
 
       - name: Update versions for snapshots
-        run: pnpm exec changeset version --snapshot ${GITHUB_REF_NAME//\//-}
+        run: pnpm exec changeset version --snapshot ${GITHUB_REF_NAME//\//__}
 
       - name: Make sure code is up to date
         run: pnpm exec turbo run postVersioning
@@ -86,4 +85,4 @@ jobs:
         run: pnpm exec turbo run build
 
       - name: Publish results
-        run: pnpm exec changeset publish --no-git-tag --tag next-${GITHUB_REF_NAME//\//-}
+        run: pnpm exec changeset publish --no-git-tag --tag next-${GITHUB_REF_NAME//\//__}

--- a/etc/client.report.api.md
+++ b/etc/client.report.api.md
@@ -124,7 +124,7 @@ export function createAttachmentUpload(data: Blob, name: string): AttachmentUplo
 // @public
 export const createClient: (baseUrl: string, ontologyRid: string | Promise<string>, tokenProvider: () => Promise<string>, options?: {
     	logger?: Logger
-    	UNSTABLE_DO_NOT_USE_BRANCH?: string
+    	UNSTABLE_DO_NOT_USE_BRANCH?: string | null
     	headers?: Record<string, string>
 } | undefined, fetchFn?: typeof fetch | undefined) => Client;
 

--- a/packages/client/src/createClient.ts
+++ b/packages/client/src/createClient.ts
@@ -65,6 +65,7 @@ import { ObjectSetListenerWebsocket } from "./objectSet/ObjectSetListenerWebsock
 import { applyQuery } from "./queries/applyQuery.js";
 import type { QuerySignatureFromDef } from "./queries/types.js";
 import type { CreateSubscriptionConnectionFn } from "./SubscriptionConnection.js";
+import { resolveBranch } from "./util/resolveBranch.js";
 
 // We import it this way to keep compatible with CJS. If we referenced the
 // value of `symbolClientContext` directly, then we would have to a dynamic import
@@ -114,7 +115,7 @@ export function createClientInternal(
   options:
     | {
         logger?: Logger;
-        UNSTABLE_DO_NOT_USE_BRANCH?: string;
+        UNSTABLE_DO_NOT_USE_BRANCH?: string | null;
         headers?: Record<string, string>;
       }
     | undefined = undefined,
@@ -144,7 +145,7 @@ export function createClientInternal(
       transactionId: transactionRid,
       flushEdits,
       scenarioRid,
-      branch: options?.UNSTABLE_DO_NOT_USE_BRANCH,
+      branch: resolveBranch(options?.UNSTABLE_DO_NOT_USE_BRANCH),
       createSubscriptionConnection: subscribeConnectionFn,
     },
     fetchFn,
@@ -385,6 +386,12 @@ export function createClientFromContext(clientCtx: MinimalClient) {
  *   manage tokens yourself.
  * @param options - Optional client configuration: a custom `logger`, an experimental `UNSTABLE_DO_NOT_USE_BRANCH`
  *   for branch-aware requests, and additional `headers` to include on every request.
+ *
+ *   The client is branch-aware without configuration. If `UNSTABLE_DO_NOT_USE_BRANCH` is not supplied, the
+ *   branch is read from the `VITE_FOUNDRY_BRANCH_RID` environment variable, which Foundry runtimes set to
+ *   the branch the application is checked out on; objects, actions, and queries then read and write on that
+ *   branch. An explicitly supplied branch always takes precedence, and `null` pins the client to the default
+ *   branch even while checked out on a branch.
  * @param fetchFn - An optional `fetch` implementation to use for all requests. Defaults to the global `fetch`.
  * @example
  * ```ts
@@ -413,8 +420,17 @@ export const createClient: (
   options?:
     | {
         logger?: Logger;
-        /** @beta This is an experimental feature subject to change */
-        UNSTABLE_DO_NOT_USE_BRANCH?: string;
+        /**
+         * The Foundry branch to scope every request to.
+         *
+         * When omitted (or `undefined`), the branch is read from the
+         * `VITE_FOUNDRY_BRANCH_RID` environment variable, which Foundry runtimes
+         * set to the branch the application is checked out on. Pass `null` to
+         * ignore the environment and use the default branch.
+         *
+         * @beta This is an experimental feature subject to change
+         */
+        UNSTABLE_DO_NOT_USE_BRANCH?: string | null;
         headers?: Record<string, string>;
       }
     | undefined,

--- a/packages/client/src/scenarios/ScenarioClient.ts
+++ b/packages/client/src/scenarios/ScenarioClient.ts
@@ -217,7 +217,10 @@ export function buildScenarioClient(
     ctx.tokenProvider,
     {
       logger: ctx.logger,
-      UNSTABLE_DO_NOT_USE_BRANCH: ctx.branch,
+      // `?? null` so the scenario client inherits the parent's already-resolved
+      // branch rather than re-resolving from the environment. A parent that
+      // resolved to no branch must stay on the default branch here too.
+      UNSTABLE_DO_NOT_USE_BRANCH: ctx.branch ?? null,
     },
     ctx.fetch,
   );

--- a/packages/client/src/util/resolveBranch.test.ts
+++ b/packages/client/src/util/resolveBranch.test.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/client/src/util/resolveBranch.test.ts
+++ b/packages/client/src/util/resolveBranch.test.ts
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+
+import { FOUNDRY_BRANCH_RID_ENV_VAR, resolveBranch } from "./resolveBranch.js";
+
+const ENV_BRANCH = "ri.foundry.main.branch.from-environment";
+const EXPLICIT_BRANCH = "ri.foundry.main.branch.from-code";
+
+type Env = Record<string, string | undefined> | undefined;
+
+/**
+ * The environment is injected rather than stubbed: Vite substitutes
+ * `import.meta.env` with a snapshot taken when the bundler (or, here, Vitest)
+ * starts, so `vi.stubEnv` cannot reach the value a source module reads.
+ */
+function envWith(branch: string | undefined): Env {
+  return { [FOUNDRY_BRANCH_RID_ENV_VAR]: branch };
+}
+
+describe(resolveBranch, () => {
+  it.each<[string, string | null | undefined, Env, string | undefined]>([
+    [
+      "falls back to the environment",
+      undefined,
+      envWith(ENV_BRANCH),
+      ENV_BRANCH,
+    ],
+    [
+      "prefers an explicit branch over the environment",
+      EXPLICIT_BRANCH,
+      envWith(ENV_BRANCH),
+      EXPLICIT_BRANCH,
+    ],
+    [
+      "treats null as pinning to the default branch",
+      null,
+      envWith(ENV_BRANCH),
+      undefined,
+    ],
+    [
+      "does not fall back for a blank explicit branch",
+      "  ",
+      envWith(ENV_BRANCH),
+      undefined,
+    ],
+    [
+      "trims the environment value",
+      undefined,
+      envWith(`  ${ENV_BRANCH}\n`),
+      ENV_BRANCH,
+    ],
+    [
+      "treats a blank environment value as unset",
+      undefined,
+      envWith("   "),
+      undefined,
+    ],
+    [
+      // Local development passes a branch name for the backend to resolve, so a
+      // rid-only check would break it.
+      "accepts a branch name that is not a rid",
+      undefined,
+      envWith("my-feature-branch"),
+      "my-feature-branch",
+    ],
+    ["returns undefined when the variable is unset", undefined, {}, undefined],
+    // No `import.meta.env` at all: the CJS build and plain Node ESM.
+    [
+      "returns undefined when there is no environment",
+      undefined,
+      undefined,
+      undefined,
+    ],
+  ])("%s", (_description, explicitBranch, env, expected) => {
+    expect(resolveBranch(explicitBranch, env)).toBe(expected);
+  });
+});

--- a/packages/client/src/util/resolveBranch.ts
+++ b/packages/client/src/util/resolveBranch.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/packages/client/src/util/resolveBranch.ts
+++ b/packages/client/src/util/resolveBranch.ts
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * The environment variable that a Foundry runtime sets to the RID of the branch
+ * the application is currently checked out on.
+ *
+ * It is set by the in-platform dev server, by CI when building a pull request
+ * preview, and by local tooling. When it is absent the application is running
+ * against the default (`main`) branch.
+ */
+export const FOUNDRY_BRANCH_RID_ENV_VAR: string = "VITE_FOUNDRY_BRANCH_RID";
+
+/**
+ * Reads `import.meta.env` defensively.
+ *
+ * `import.meta.env` is read as a whole here, and never as a direct member
+ * access (`import.meta.env.SOME_VAR`), because this file is published in three
+ * shapes and only this form is safe in all of them:
+ *
+ * - `build/esm` and `build/browser` are per-file Babel transpiler, so
+ *   `import.meta` survives verbatim and the consuming application's bundler
+ *   substitutes it. Vite in lines an object literal at build time and prepends an
+ *   `import.meta.env = {...}` assignment to the pre-bundled dependency in dev.
+ *   Both substitute the whole expression, so reading it as a whole works.
+ * - `build/cjs` is bundled by esbuild, which cannot represent `import.meta` in
+ *   CJS and replaces it with `{}`. Reading `.env` off that yields `undefined`
+ *   (safe), whereas `import.meta.env.SOME_VAR` would throw a `TypeError`.
+ * - Plain Node ESM has a real `import.meta` with no `env` property, which again
+ *   yields `undefined`.
+ *
+ * So branch detection is only active in bundled applications that define
+ * `import.meta.env` (notably Vite). Elsewhere it degrades to "no branch" rather
+ * than failing, and callers can always pass the branch explicitly.
+ *
+ * The value is fixed when the bundler runs, not when this function is called:
+ * Vite substitutes a snapshot of the environment taken at build time or at dev
+ * server startup. Mutating `process.env` afterwards has no effect, which is why
+ * {@link resolveBranch} takes the environment as an injectable parameter rather
+ * than being tested by stubbing the ambient environment.
+ */
+function getImportMetaEnv(): Record<string, string | undefined> | undefined {
+  return (
+    import.meta as ImportMeta & { env?: Record<string, string | undefined> }
+  ).env;
+}
+
+/**
+ * Treats a blank value as absent, so an unpopulated environment variable or
+ * template placeholder does not produce an empty `branch` query parameter.
+ */
+function normalizeBranch(
+  branch: string | null | undefined,
+): string | undefined {
+  if (typeof branch !== "string") {
+    return undefined;
+  }
+  const trimmed = branch.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+/**
+ * Determines the branch a client should use.
+ *
+ * An explicitly supplied branch always wins, so application code and any
+ * existing `fetch` or client overrides keep their current behavior. `null`
+ * explicitly means "no branch", which is how a caller pins to the default
+ * branch while checked out on a branch.
+ *
+ * `undefined` — including the `undefined` that a generated SDK's `$branch`
+ * export carries when the SDK was generated against the default branch — falls
+ * back to {@link FOUNDRY_BRANCH_RID_ENV_VAR}. That fallback is the point: a
+ * repository checked out on a branch reads that branch's data even if its
+ * generated SDK predates the checkout.
+ *
+ * @param explicitBranch - the branch supplied by the caller, if any
+ * @param env - the environment to read from. Defaults to `import.meta.env`;
+ *   supply it to test without depending on the ambient environment.
+ */
+export function resolveBranch(
+  explicitBranch: string | null | undefined,
+  env: Record<string, string | undefined> | undefined = getImportMetaEnv(),
+): string | undefined {
+  return explicitBranch !== undefined
+    ? normalizeBranch(explicitBranch)
+    : normalizeBranch(env?.[FOUNDRY_BRANCH_RID_ENV_VAR]);
+}

--- a/packages/client/src/util/resolveBranch.ts
+++ b/packages/client/src/util/resolveBranch.ts
@@ -25,32 +25,8 @@
 export const FOUNDRY_BRANCH_RID_ENV_VAR: string = "VITE_FOUNDRY_BRANCH_RID";
 
 /**
- * Reads `import.meta.env` defensively.
- *
- * `import.meta.env` is read as a whole here, and never as a direct member
- * access (`import.meta.env.SOME_VAR`), because this file is published in three
- * shapes and only this form is safe in all of them:
- *
- * - `build/esm` and `build/browser` are per-file Babel transpiler, so
- *   `import.meta` survives verbatim and the consuming application's bundler
- *   substitutes it. Vite in lines an object literal at build time and prepends an
- *   `import.meta.env = {...}` assignment to the pre-bundled dependency in dev.
- *   Both substitute the whole expression, so reading it as a whole works.
- * - `build/cjs` is bundled by esbuild, which cannot represent `import.meta` in
- *   CJS and replaces it with `{}`. Reading `.env` off that yields `undefined`
- *   (safe), whereas `import.meta.env.SOME_VAR` would throw a `TypeError`.
- * - Plain Node ESM has a real `import.meta` with no `env` property, which again
- *   yields `undefined`.
- *
- * So branch detection is only active in bundled applications that define
- * `import.meta.env` (notably Vite). Elsewhere it degrades to "no branch" rather
- * than failing, and callers can always pass the branch explicitly.
- *
- * The value is fixed when the bundler runs, not when this function is called:
- * Vite substitutes a snapshot of the environment taken at build time or at dev
- * server startup. Mutating `process.env` afterwards has no effect, which is why
- * {@link resolveBranch} takes the environment as an injectable parameter rather
- * than being tested by stubbing the ambient environment.
+ * Reads the whole `import.meta.env` object so builds without it safely return
+ * `undefined`. A direct member access would fail in the CommonJS build.
  */
 function getImportMetaEnv(): Record<string, string | undefined> | undefined {
   return (
@@ -59,8 +35,8 @@ function getImportMetaEnv(): Record<string, string | undefined> | undefined {
 }
 
 /**
- * Treats a blank value as absent, so an unpopulated environment variable or
- * template placeholder does not produce an empty `branch` query parameter.
+ * Trims branch values and treats blanks as absent to avoid sending an empty
+ * `branch` query parameter.
  */
 function normalizeBranch(
   branch: string | null | undefined,


### PR DESCRIPTION
 ## Summary

  Make `@osdk/client` automatically use the Foundry branch associated with the current application environment.

  When `UNSTABLE_DO_NOT_USE_BRANCH` is omitted, the client now reads the branch from `VITE_FOUNDRY_BRANCH_RID`. Explicit branch configuration continues to take precedence, while passing `null` pins the client to the default branch.

  Scenario clients inherit the parent client’s resolved branch.