### PR TITLE
Prefetch interface metadata during page loads

### DIFF
--- a/.changeset/fast-pages-fetch.md
+++ b/.changeset/fast-pages-fetch.md
@@ -1,0 +1,5 @@
+---
+"@osdk/client": patch
+---
+
+Prefetch interface metadata while loading object set pages

--- a/packages/client/src/createClient.test.ts
+++ b/packages/client/src/createClient.test.ts
@@ -16,6 +16,7 @@
 
 import { BarInterface } from "@osdk/client.test.ontology";
 import * as SharedClientContext from "@osdk/shared.client.impl";
+import { stubData } from "@osdk/shared.test";
 import type { MockedFunction } from "vitest";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
@@ -35,6 +36,14 @@ export function mockFetchResponse(
     status: 200,
     ok: true,
   } as any);
+}
+
+export function mockInterfaceFetchPageResponse(
+  fetch: MockedFunction<typeof globalThis.fetch>,
+  response: any,
+): void {
+  mockFetchResponse(fetch, stubData.BarInterface);
+  mockFetchResponse(fetch, response);
 }
 
 describe(createClient, () => {
@@ -57,22 +66,24 @@ describe(createClient, () => {
       undefined,
       fetchFunction,
     );
-
-    mockFetchResponse(fetchFunction, { data: [] });
   });
 
   describe("user agent passing", () => {
-    function getUserAgentPartsFromMockedFetch() {
-      const userAgent = (
-        fetchFunction.mock.calls[0][1]?.headers as Headers
-      ).get("Fetch-User-Agent");
+    function getUserAgentPartsFromMockedFetch(fetch = fetchFunction) {
+      const loadCall = fetch.mock.calls.find(([input]) =>
+        String(input).includes("objectSets/loadObjects"),
+      );
+      const userAgent = (loadCall?.[1]?.headers as Headers).get(
+        "Fetch-User-Agent",
+      );
       const parts = userAgent?.split(" ") ?? [];
       return parts;
     }
 
     it("works for objects", async () => {
+      mockInterfaceFetchPageResponse(fetchFunction, { data: [] });
       await client(BarInterface).fetchPage();
-      expect(fetchFunction).toHaveBeenCalledTimes(1);
+      expect(fetchFunction).toHaveBeenCalledTimes(2);
 
       const parts = getUserAgentPartsFromMockedFetch();
       expect(parts).toEqual([
@@ -83,7 +94,7 @@ describe(createClient, () => {
 
     it("includes custom Fetch-User-Agent from headers option", async () => {
       const customFetch = vi.fn<typeof globalThis.fetch>();
-      mockFetchResponse(customFetch, { data: [] });
+      mockInterfaceFetchPageResponse(customFetch, { data: [] });
 
       const clientWithHeaders = createClient(
         "https://mock.com",
@@ -94,12 +105,9 @@ describe(createClient, () => {
       );
 
       await clientWithHeaders(BarInterface).fetchPage();
-      expect(customFetch).toHaveBeenCalledTimes(1);
+      expect(customFetch).toHaveBeenCalledTimes(2);
 
-      const userAgent = (customFetch.mock.calls[0][1]?.headers as Headers).get(
-        "Fetch-User-Agent",
-      );
-      const parts = userAgent?.split(" ") ?? [];
+      const parts = getUserAgentPartsFromMockedFetch(customFetch);
       expect(parts).toEqual([
         ...BarInterface.osdkMetadata!.extraUserAgent.split(" "),
         USER_AGENT,
@@ -181,12 +189,14 @@ describe(createClient, () => {
         fetchFunction,
       );
 
-      mockFetchResponse(fetchFunction, { data: [] });
+      mockInterfaceFetchPageResponse(fetchFunction, { data: [] });
 
       await clientWithTransaction(BarInterface).fetchPage();
 
-      expect(fetchFunction).toHaveBeenCalledTimes(1);
-      const url = fetchFunction.mock.calls[0][0];
+      expect(fetchFunction).toHaveBeenCalledTimes(2);
+      const url = fetchFunction.mock.calls.find(([input]) =>
+        String(input).includes("objectSets/loadObjects"),
+      )?.[0];
       expect(url).toBeDefined();
 
       const parsedUrl = new URL(url as string, "https://mock.com");

--- a/packages/client/src/object/fetchPage.test.ts
+++ b/packages/client/src/object/fetchPage.test.ts
@@ -25,7 +25,8 @@ import type {
 } from "@osdk/api";
 import { Employee, FooInterface, Todo } from "@osdk/client.test.ontology";
 import type { SearchJsonQueryV2 } from "@osdk/foundry.ontologies";
-import { describe, expect, expectTypeOf, it } from "vitest";
+import { LegacyFauxFoundry, startNodeApiServer } from "@osdk/shared.test";
+import { describe, expect, expectTypeOf, it, vi } from "vitest";
 
 import { createMinimalClient } from "../createMinimalClient.js";
 import {
@@ -586,6 +587,85 @@ describe(fetchPage, () => {
         propertyIdentifier: { type: "property", apiName: "myStruct" },
         loadLevel: { type: "extractMainValue" },
       });
+    });
+  });
+  describe("metadata fetch", () => {
+    it("prefetches object metadata before conversion", async () => {
+      const testSetup = startNodeApiServer(new LegacyFauxFoundry());
+      const fetchFn = vi.fn(globalThis.fetch);
+      const client = createMinimalClient(
+        { ontologyRid: testSetup.fauxFoundry.defaultOntologyRid },
+        testSetup.fauxFoundry.baseUrl,
+        testSetup.auth,
+        {},
+        fetchFn,
+      );
+
+      try {
+        const result = await fetchPage(client, Employee, {});
+        const requestUrls = fetchFn.mock.calls.map(([input]) => String(input));
+        const employeeMetadataRequestIndex = requestUrls.findIndex((url) =>
+          url.includes("objectTypes/Employee/fullMetadata"),
+        );
+        const fetchPageRequestIndex = requestUrls.findIndex((url) =>
+          url.includes("objectSets/loadObjects"),
+        );
+        const employeeMetadataRequests = fetchFn.mock.calls.filter(([input]) =>
+          String(input).includes("objectTypes/Employee/fullMetadata"),
+        );
+
+        expect(employeeMetadataRequestIndex).toBeGreaterThanOrEqual(0);
+        expect(fetchPageRequestIndex).toBeGreaterThan(
+          employeeMetadataRequestIndex,
+        );
+        expect(result.data).not.toHaveLength(0);
+        expect(result.data[0].$apiName).toBe("Employee");
+        expect(result.data[0].$objectType).toBe("Employee");
+        expect(employeeMetadataRequests).toHaveLength(1);
+      } finally {
+        testSetup.apiServer.close();
+      }
+    });
+
+    it("prefetches interface and implementing object metadata before conversion", async () => {
+      const testSetup = startNodeApiServer(new LegacyFauxFoundry());
+      const fetchFn = vi.fn(globalThis.fetch);
+      const client = createMinimalClient(
+        { ontologyRid: testSetup.fauxFoundry.defaultOntologyRid },
+        testSetup.fauxFoundry.baseUrl,
+        testSetup.auth,
+        {},
+        fetchFn,
+      );
+
+      try {
+        const result = await fetchPage(client, FooInterface, {});
+        const requestUrls = fetchFn.mock.calls.map(([input]) => String(input));
+        const interfaceMetadataRequestIndex = requestUrls.findIndex((url) =>
+          url.includes("interfaceTypes/FooInterface"),
+        );
+        const fetchPageRequestIndex = requestUrls.findIndex((url) =>
+          url.includes("objectSets/loadObjects"),
+        );
+        const interfaceMetadataRequests = fetchFn.mock.calls.filter(([input]) =>
+          String(input).includes("interfaceTypes/FooInterface"),
+        );
+        const employeeMetadataRequests = fetchFn.mock.calls.filter(([input]) =>
+          String(input).includes("objectTypes/Employee/fullMetadata"),
+        );
+
+        expect(interfaceMetadataRequestIndex).toBeGreaterThanOrEqual(0);
+        expect(fetchPageRequestIndex).toBeGreaterThan(
+          interfaceMetadataRequestIndex,
+        );
+        expect(result.data).not.toHaveLength(0);
+        expect(result.data[0].$apiName).toBe("FooInterface");
+        expect(result.data[0].$objectType).toBe("Employee");
+        expect(interfaceMetadataRequests).toHaveLength(1);
+        expect(employeeMetadataRequests).toHaveLength(1);
+      } finally {
+        testSetup.apiServer.close();
+      }
     });
   });
 });

--- a/packages/client/src/object/fetchPage.test.ts
+++ b/packages/client/src/object/fetchPage.test.ts
@@ -26,6 +26,7 @@ import type {
 import { Employee, FooInterface, Todo } from "@osdk/client.test.ontology";
 import type { SearchJsonQueryV2 } from "@osdk/foundry.ontologies";
 import { LegacyFauxFoundry, startNodeApiServer } from "@osdk/shared.test";
+import pDefer from "p-defer";
 import { describe, expect, expectTypeOf, it, vi } from "vitest";
 
 import { createMinimalClient } from "../createMinimalClient.js";
@@ -627,9 +628,20 @@ describe(fetchPage, () => {
       }
     });
 
-    it("prefetches interface and implementing object metadata before conversion", async () => {
+    it("prefetches implementing object metadata while the interface page loads", async () => {
       const testSetup = startNodeApiServer(new LegacyFauxFoundry());
-      const fetchFn = vi.fn(globalThis.fetch);
+      const interfaceMetadataResponse = pDefer<void>();
+      const fetchPageResponse = pDefer<void>();
+      const fetchFn = vi.fn<typeof globalThis.fetch>(async (input, init) => {
+        const response = await globalThis.fetch(input, init);
+        const url = String(input);
+        if (url.includes("interfaceTypes/FooInterface")) {
+          await interfaceMetadataResponse.promise;
+        } else if (url.includes("objectSets/loadObjects")) {
+          await fetchPageResponse.promise;
+        }
+        return response;
+      });
       const client = createMinimalClient(
         { ontologyRid: testSetup.fauxFoundry.defaultOntologyRid },
         testSetup.fauxFoundry.baseUrl,
@@ -639,31 +651,46 @@ describe(fetchPage, () => {
       );
 
       try {
-        const result = await fetchPage(client, FooInterface, {});
-        const requestUrls = fetchFn.mock.calls.map(([input]) => String(input));
-        const interfaceMetadataRequestIndex = requestUrls.findIndex((url) =>
-          url.includes("interfaceTypes/FooInterface"),
-        );
-        const fetchPageRequestIndex = requestUrls.findIndex((url) =>
-          url.includes("objectSets/loadObjects"),
-        );
-        const interfaceMetadataRequests = fetchFn.mock.calls.filter(([input]) =>
-          String(input).includes("interfaceTypes/FooInterface"),
-        );
-        const employeeMetadataRequests = fetchFn.mock.calls.filter(([input]) =>
-          String(input).includes("objectTypes/Employee/fullMetadata"),
+        let fetchPageSettled = false;
+        const resultPromise = fetchPage(client, FooInterface, {}).finally(
+          () => {
+            fetchPageSettled = true;
+          },
         );
 
-        expect(interfaceMetadataRequestIndex).toBeGreaterThanOrEqual(0);
-        expect(fetchPageRequestIndex).toBeGreaterThan(
-          interfaceMetadataRequestIndex,
-        );
+        await vi.waitFor(() => {
+          expect(
+            fetchFn.mock.calls.filter(([input]) =>
+              String(input).includes("interfaceTypes/FooInterface"),
+            ),
+          ).toHaveLength(1);
+          expect(
+            fetchFn.mock.calls.filter(([input]) =>
+              String(input).includes("objectSets/loadObjects"),
+            ),
+          ).toHaveLength(1);
+        });
+
+        interfaceMetadataResponse.resolve();
+
+        await vi.waitFor(() => {
+          expect(
+            fetchFn.mock.calls.filter(([input]) =>
+              String(input).includes("objectTypes/Employee/fullMetadata"),
+            ),
+          ).toHaveLength(1);
+        });
+
+        expect(fetchPageSettled).toBe(false);
+        fetchPageResponse.resolve();
+
+        const result = await resultPromise;
         expect(result.data).not.toHaveLength(0);
         expect(result.data[0].$apiName).toBe("FooInterface");
         expect(result.data[0].$objectType).toBe("Employee");
-        expect(interfaceMetadataRequests).toHaveLength(1);
-        expect(employeeMetadataRequests).toHaveLength(1);
       } finally {
+        interfaceMetadataResponse.resolve();
+        fetchPageResponse.resolve();
         testSetup.apiServer.close();
       }
     });

--- a/packages/client/src/object/fetchPage.ts
+++ b/packages/client/src/object/fetchPage.ts
@@ -334,14 +334,13 @@ async function fetchInterfacePage<
     // Swallowing the error is ok because we await the metadata load in the objectFactory later anyways which eventually bubbles up the error to the user
     void client.ontologyProvider
       .getInterfaceDefinition(interfaceType.apiName)
-      .then((def) => {
-        def.implementedBy?.forEach((implementedBy) =>
-          // oxlint-disable-next-line promise/no-nesting
-          client.ontologyProvider
-            .getObjectDefinition(implementedBy)
-            .catch(() => {}),
-        );
-      })
+      .then((def) =>
+        Promise.allSettled(
+          def.implementedBy?.map((implementedBy) =>
+            client.ontologyProvider.getObjectDefinition(implementedBy),
+          ) ?? [],
+        ),
+      )
       .catch(() => {});
   }
 

--- a/packages/client/src/object/fetchPage.ts
+++ b/packages/client/src/object/fetchPage.ts
@@ -330,9 +330,17 @@ async function fetchInterfacePage<
     );
     allProperties = ifaceDef ? Object.keys(ifaceDef.properties) : undefined;
   } else {
-    void prefetchInterfaceMetadata(client, interfaceType.apiName).catch(
-      () => {},
-    );
+    void client.ontologyProvider
+      .getInterfaceDefinition(interfaceType.apiName)
+      .then((def) => {
+        def.implementedBy?.forEach((implementedBy) =>
+          // oxlint-disable-next-line promise/no-nesting
+          client.ontologyProvider
+            .getObjectDefinition(implementedBy)
+            .catch(() => {}),
+        );
+      })
+      .catch(() => {});
   }
 
   const selectV2 = buildSelectV2(
@@ -773,17 +781,4 @@ export async function fetchObjectPage<
     nextPageToken: r.nextPageToken,
     totalCount: r.totalCount,
   }) as unknown as Promise<FetchPageResult<Q, L, R, S, T, ORDER_BY_OPTIONS>>;
-}
-
-async function prefetchInterfaceMetadata(
-  client: MinimalClient,
-  interfaceApiName: string,
-): Promise<void> {
-  const def =
-    await client.ontologyProvider.getInterfaceDefinition(interfaceApiName);
-  await Promise.all(
-    def.implementedBy?.map((implementedBy) =>
-      client.ontologyProvider.getObjectDefinition(implementedBy),
-    ) ?? [],
-  );
 }

--- a/packages/client/src/object/fetchPage.ts
+++ b/packages/client/src/object/fetchPage.ts
@@ -330,6 +330,8 @@ async function fetchInterfacePage<
     );
     allProperties = ifaceDef ? Object.keys(ifaceDef.properties) : undefined;
   } else {
+    // We have empty catches here so that if this call errors before we await later, we won't have an unhandled promise rejection that would crash the process
+    // Swallowing the error is ok because we await the metadata load in the objectFactory later anyways which eventually bubbles up the error to the user
     void client.ontologyProvider
       .getInterfaceDefinition(interfaceType.apiName)
       .then((def) => {

--- a/packages/client/src/object/fetchPage.ts
+++ b/packages/client/src/object/fetchPage.ts
@@ -329,6 +329,10 @@ async function fetchInterfacePage<
       interfaceType.apiName,
     );
     allProperties = ifaceDef ? Object.keys(ifaceDef.properties) : undefined;
+  } else {
+    void prefetchInterfaceMetadata(client, interfaceType.apiName).catch(
+      () => {},
+    );
   }
 
   const selectV2 = buildSelectV2(
@@ -769,4 +773,17 @@ export async function fetchObjectPage<
     nextPageToken: r.nextPageToken,
     totalCount: r.totalCount,
   }) as unknown as Promise<FetchPageResult<Q, L, R, S, T, ORDER_BY_OPTIONS>>;
+}
+
+async function prefetchInterfaceMetadata(
+  client: MinimalClient,
+  interfaceApiName: string,
+): Promise<void> {
+  const def =
+    await client.ontologyProvider.getInterfaceDefinition(interfaceApiName);
+  await Promise.all(
+    def.implementedBy?.map((implementedBy) =>
+      client.ontologyProvider.getObjectDefinition(implementedBy),
+    ) ?? [],
+  );
 }

--- a/packages/client/src/scenarios/createScenario.test.ts
+++ b/packages/client/src/scenarios/createScenario.test.ts
@@ -24,7 +24,10 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { Client } from "../Client.js";
 import { createClient, createClientWithTransaction } from "../createClient.js";
-import { mockFetchResponse } from "../createClient.test.js";
+import {
+  mockFetchResponse,
+  mockInterfaceFetchPageResponse,
+} from "../createClient.test.js";
 import { createScenario } from "./createScenario.js";
 import { withScenario } from "./withScenario.js";
 
@@ -66,12 +69,12 @@ describe("createScenario", () => {
     const loadResponse: LoadObjectSetV2MultipleObjectTypesResponse = {
       data: [],
     };
-    mockFetchResponse(fetchFunction, loadResponse);
+    mockInterfaceFetchPageResponse(fetchFunction, loadResponse);
     await scenario(BarInterface).fetchPage();
-    const url = new URL(
-      fetchFunction.mock.calls[1][0] as string,
-      "https://mock.com",
+    const loadCall = fetchFunction.mock.calls.find(([input]) =>
+      String(input).includes("objectSets/loadObjects"),
     );
+    const url = new URL(loadCall?.[0] as string, "https://mock.com");
     expect(url.searchParams.get("scenarioRid")).toBe(newScenarioRid);
   });
 

--- a/packages/client/src/scenarios/withScenario.test.ts
+++ b/packages/client/src/scenarios/withScenario.test.ts
@@ -21,7 +21,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { Client } from "../Client.js";
 import { createClient, createClientWithTransaction } from "../createClient.js";
-import { mockFetchResponse } from "../createClient.test.js";
+import { mockInterfaceFetchPageResponse } from "../createClient.test.js";
 import { withScenario } from "./withScenario.js";
 
 describe("withScenario", () => {
@@ -54,15 +54,15 @@ describe("withScenario", () => {
   it("forwards scenarioRid as a query param on fetchPage", async () => {
     const scenario = withScenario(client, "ri.actions..scenario.abc");
     const mock: LoadObjectSetV2MultipleObjectTypesResponse = { data: [] };
-    mockFetchResponse(fetchFunction, mock);
+    mockInterfaceFetchPageResponse(fetchFunction, mock);
 
     await scenario(BarInterface).fetchPage();
 
-    expect(fetchFunction).toHaveBeenCalledTimes(1);
-    const url = new URL(
-      fetchFunction.mock.calls[0][0] as string,
-      "https://mock.com",
+    expect(fetchFunction).toHaveBeenCalledTimes(2);
+    const loadCall = fetchFunction.mock.calls.find(([input]) =>
+      String(input).includes("objectSets/loadObjects"),
     );
+    const url = new URL(loadCall?.[0] as string, "https://mock.com");
     expect(url.searchParams.get("scenarioRid")).toBe(
       "ri.actions..scenario.abc",
     );


### PR DESCRIPTION
## Summary
- prefetch interface and implementing object metadata while loading interface pages
- reuse in-flight cached metadata during object conversion
- verify metadata requests start before object-set loads and occur only once

## Testing
- `pnpm exec vitest run src/object/fetchPage.test.ts`
- pre-commit lint, format, and spelling checks