### PR TITLE
Support object set arithmetic in unit testing mocks

### DIFF
--- a/.changeset/mock-object-set-unions.md
+++ b/.changeset/mock-object-set-unions.md
@@ -1,0 +1,5 @@
+---
+"@osdk/unit-testing": patch
+---
+
+Add support for stubbing unioned, intersected, and subtracted mock object sets.

--- a/packages/unit-testing/src/example-function-tests/objectSetArithmetic/objectSetArithmetic.test.ts
+++ b/packages/unit-testing/src/example-function-tests/objectSetArithmetic/objectSetArithmetic.test.ts
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Employee } from "@osdk/client.test.ontology";
+import { describe, expect, it } from "vitest";
+
+import { createMockClient } from "../../mock/createMockClient.js";
+import { createMockObjectSet } from "../../mock/createMockObjectSet.js";
+import { createMockOsdkObject } from "../../mock/createMockOsdkObject.js";
+import { objectSetArithmetic } from "./objectSetArithmetic.js";
+
+describe("objectSetArithmetic", () => {
+  it("stubs union, intersect, and subtract with a standalone mock object set", async () => {
+    const mockClient = createMockClient();
+    const empSet = createMockObjectSet(Employee);
+    const unionEmployee = createMockOsdkObject(Employee, { employeeId: 1 });
+    const standaloneUnionEmployee = createMockOsdkObject(Employee, {
+      employeeId: 2,
+    });
+    const intersectEmployee = createMockOsdkObject(Employee, { employeeId: 3 });
+    const subtractEmployee = createMockOsdkObject(Employee, { employeeId: 4 });
+
+    mockClient
+      .when((client) => client(Employee).union(empSet).fetchPage())
+      .thenReturnObjects([unionEmployee]);
+    mockClient
+      .whenObjectSet(empSet, (objectSet) =>
+        objectSet.union(mockClient(Employee)).fetchPage(),
+      )
+      .thenReturnObjects([standaloneUnionEmployee]);
+    mockClient
+      .when((client) => client(Employee).intersect(empSet).fetchPage())
+      .thenReturnObjects([intersectEmployee]);
+    mockClient
+      .when((client) => client(Employee).subtract(empSet).fetchPage())
+      .thenReturnObjects([subtractEmployee]);
+
+    const result = await objectSetArithmetic(mockClient, empSet);
+
+    expect(result).toEqual({
+      union: [unionEmployee],
+      standaloneUnion: [standaloneUnionEmployee],
+      intersect: [intersectEmployee],
+      subtract: [subtractEmployee],
+    });
+  });
+});

--- a/packages/unit-testing/src/example-function-tests/objectSetArithmetic/objectSetArithmetic.ts
+++ b/packages/unit-testing/src/example-function-tests/objectSetArithmetic/objectSetArithmetic.ts
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { ObjectSet, Osdk } from "@osdk/api";
+import type { Client } from "@osdk/client";
+import { Employee } from "@osdk/client.test.ontology";
+
+export async function objectSetArithmetic(
+  client: Client,
+  employees: ObjectSet<Employee>,
+): Promise<{
+  union: Array<Osdk.Instance<Employee>>;
+  standaloneUnion: Array<Osdk.Instance<Employee>>;
+  intersect: Array<Osdk.Instance<Employee>>;
+  subtract: Array<Osdk.Instance<Employee>>;
+}> {
+  const employeeSet = client(Employee);
+  const [union, standaloneUnion, intersect, subtract] = await Promise.all([
+    employeeSet.union(employees).fetchPage(),
+    employees.union(employeeSet).fetchPage(),
+    employeeSet.intersect(employees).fetchPage(),
+    employeeSet.subtract(employees).fetchPage(),
+  ]);
+
+  return {
+    union: union.data,
+    standaloneUnion: standaloneUnion.data,
+    intersect: intersect.data,
+    subtract: subtract.data,
+  };
+}

--- a/packages/unit-testing/src/mock/__tests__/createMockClient.test.ts
+++ b/packages/unit-testing/src/mock/__tests__/createMockClient.test.ts
@@ -26,6 +26,8 @@ import { createMockClient } from "../createMockClient.js";
 import { createMockObjectSet } from "../createMockObjectSet.js";
 import { createMockOsdkObject } from "../createMockOsdkObject.js";
 
+const setOperations = ["union", "intersect", "subtract"] as const;
+
 describe("createMockClient", () => {
   describe("fetchPage", () => {
     it("returns stubbed objects", async () => {
@@ -381,6 +383,71 @@ describe("createMockClient", () => {
     });
   });
 
+  describe("set arithmetic", () => {
+    it("matches multiple union operands", async () => {
+      const mockClient = createMockClient();
+      const emp = createMockOsdkObject(Employee, { employeeId: 1 });
+
+      mockClient
+        .when((c) =>
+          c(Employee)
+            .where({ office: { $eq: "NYC" } })
+            .union(
+              c(Employee).where({ office: { $eq: "LA" } }),
+              c(Employee).where({ office: { $eq: "LONDON" } }),
+            )
+            .fetchPage(),
+        )
+        .thenReturnObjects([emp]);
+
+      const result = await mockClient(Employee)
+        .where({ office: { $eq: "NYC" } })
+        .union(
+          mockClient(Employee).where({ office: { $eq: "LA" } }),
+          mockClient(Employee).where({ office: { $eq: "LONDON" } }),
+        )
+        .fetchPage();
+
+      expect(result.data).toEqual([emp]);
+    });
+
+    it("distinguishes object set operands", async () => {
+      const mockClient = createMockClient();
+
+      mockClient
+        .when((c) =>
+          c(Employee)
+            .union(c(Employee).where({ office: { $eq: "NYC" } }))
+            .fetchPage(),
+        )
+        .thenReturnObjects([]);
+
+      await expect(
+        mockClient(Employee)
+          .union(mockClient(Employee).where({ office: { $eq: "LA" } }))
+          .fetchPage(),
+      ).rejects.toThrow();
+    });
+
+    it.each(setOperations)(
+      "matches %s with a standalone mock object set",
+      async (operation) => {
+        const mockClient = createMockClient();
+        const empSet = createMockObjectSet(Employee);
+        const emp = createMockOsdkObject(Employee, { employeeId: 1 });
+
+        mockClient
+          .when((c) => c(Employee)[operation](empSet).fetchPage())
+          .thenReturnObjects([emp]);
+
+        const employeeSet = mockClient(Employee);
+        const result = await employeeSet[operation](empSet).fetchPage();
+
+        expect(result.data).toEqual([emp]);
+      },
+    );
+  });
+
   describe("clearStubs", () => {
     it("removes all stubs", async () => {
       const mockClient = createMockClient();
@@ -645,6 +712,27 @@ describe("createMockClient", () => {
       expect(result.data).toHaveLength(1);
       expect(result.data[0].office).toBe("NYC");
     });
+
+    it.each(setOperations)(
+      "stubs %s + fetchPage on a standalone mock object set",
+      async (operation) => {
+        const mockClient = createMockClient();
+        const empSet = createMockObjectSet(Employee);
+        const emp = createMockOsdkObject(Employee, { employeeId: 1 });
+
+        mockClient
+          .whenObjectSet(empSet, (os) =>
+            os[operation](os.where({ office: { $eq: "NYC" } })).fetchPage(),
+          )
+          .thenReturnObjects([emp]);
+
+        const result = await empSet[operation](
+          empSet.where({ office: { $eq: "NYC" } }),
+        ).fetchPage();
+
+        expect(result.data).toEqual([emp]);
+      },
+    );
 
     it("throws when no stub matches on standalone object set", async () => {
       createMockClient();

--- a/packages/unit-testing/src/mock/createMockObjectSetWithResolver.ts
+++ b/packages/unit-testing/src/mock/createMockObjectSetWithResolver.ts
@@ -31,6 +31,12 @@ export type Resolver = (calls: Call[]) => unknown;
 
 export type Stub = { calls: Call[]; value: unknown };
 
+type MockObjectSetDefinition = {
+  calls: Call[];
+};
+
+const mockObjectSetDefinitions = new WeakMap<object, MockObjectSetDefinition>();
+
 export function createMockObjectSetWithResolver<
   Q extends ObjectOrInterfaceDefinition,
 >(objectType: Q, resolver: Resolver, calls: Call[] = []): ObjectSet<Q> {
@@ -43,15 +49,27 @@ export function createMockObjectSetWithResolver<
   const terminal = <T>(method: string, args: unknown): T =>
     resolver([...calls, [method, args]]) as T;
 
-  // All methods should execute synchronously even if marked as async
-  return {
+  const setOperation = (
+    method: "union" | "intersect" | "subtract",
+    objectSets: ReadonlyArray<ObjectSet<Q>>,
+  ): ObjectSet<Q> =>
+    chain(
+      method,
+      objectSets.map((operand) => {
+        const definition = mockObjectSetDefinitions.get(operand);
+        invariant(definition, `${method} only supports mock object sets`);
+        return definition;
+      }),
+    );
+
+  const objectSet = {
     where: (clause: WhereClause<Q>) => chain("where", clause),
-    union: () =>
-      void invariant(false, "union is not supported in mocks") as any,
-    intersect: () =>
-      void invariant(false, "intersect is not supported in mocks") as any,
-    subtract: () =>
-      void invariant(false, "subtract is not supported in mocks") as any,
+    union: (...objectSets: ReadonlyArray<ObjectSet<Q>>) =>
+      setOperation("union", objectSets) as any,
+    intersect: (...objectSets: ReadonlyArray<ObjectSet<Q>>) =>
+      setOperation("intersect", objectSets) as any,
+    subtract: (...objectSets: ReadonlyArray<ObjectSet<Q>>) =>
+      setOperation("subtract", objectSets) as any,
     pivotTo: (link: string) => chain("pivotTo", link) as any,
     narrowToType: (type: ObjectOrInterfaceDefinition) =>
       chain("narrowToType", type) as any,
@@ -110,6 +128,12 @@ export function createMockObjectSetWithResolver<
       def: {} as Q,
     },
   } satisfies ObjectSet<Q>;
+
+  mockObjectSetDefinitions.set(objectSet, {
+    calls,
+  });
+
+  return objectSet;
 }
 
 export function resolveStub(

--- a/packages/unit-testing/src/mock/createMockObjectSetWithResolver.ts
+++ b/packages/unit-testing/src/mock/createMockObjectSetWithResolver.ts
@@ -65,11 +65,11 @@ export function createMockObjectSetWithResolver<
   const objectSet = {
     where: (clause: WhereClause<Q>) => chain("where", clause),
     union: (...objectSets: ReadonlyArray<ObjectSet<Q>>) =>
-      setOperation("union", objectSets) as any,
+      setOperation("union", objectSets),
     intersect: (...objectSets: ReadonlyArray<ObjectSet<Q>>) =>
-      setOperation("intersect", objectSets) as any,
+      setOperation("intersect", objectSets),
     subtract: (...objectSets: ReadonlyArray<ObjectSet<Q>>) =>
-      setOperation("subtract", objectSets) as any,
+      setOperation("subtract", objectSets),
     pivotTo: (link: string) => chain("pivotTo", link) as any,
     narrowToType: (type: ObjectOrInterfaceDefinition) =>
       chain("narrowToType", type) as any,


### PR DESCRIPTION
## Summary
- record mock object set operands structurally for set arithmetic stubs
- support union, intersect, and subtract for client and standalone mock object sets
- add an object set arithmetic example function and focused coverage

## Testing
- `pnpm --filter @osdk/unit-testing typecheck`
- `pnpm --filter @osdk/unit-testing test`
- `pnpm --filter @osdk/unit-testing lint`