### PR TITLE
add osdk oac generate for maker ir

### DIFF
--- a/.changeset/oac-generate-command.md
+++ b/.changeset/oac-generate-command.md
@@ -1,0 +1,7 @@
+---
+"@osdk/cli": minor
+"@osdk/generator": minor
+"@osdk/generator-converters.ontologyir": minor
+---
+
+add osdk oac generate for maker ir

--- a/.changeset/oac-generate-command.md
+++ b/.changeset/oac-generate-command.md
@@ -1,6 +1,5 @@
 ---
 "@osdk/cli": minor
-"@osdk/generator": minor
 "@osdk/generator-converters.ontologyir": minor
 ---
 

--- a/.changeset/oac-generate-command.md
+++ b/.changeset/oac-generate-command.md
@@ -1,6 +1,7 @@
 ---
 "@osdk/cli": minor
+"@osdk/generator": minor
 "@osdk/generator-converters.ontologyir": minor
 ---
 
-add osdk oac generate for maker ir
+add osdk oac generate for maker envelopes

--- a/packages/cli.cmd.typescript/package.json
+++ b/packages/cli.cmd.typescript/package.json
@@ -36,8 +36,10 @@
   "dependencies": {
     "@arethetypeswrong/cli": "^0.17.4",
     "@osdk/cli.common": "workspace:~",
+    "@osdk/client.unstable": "workspace:~",
     "@osdk/foundry.ontologies": "catalog:foundry-platform-typescript",
     "@osdk/generator": "workspace:~",
+    "@osdk/generator-converters.ontologyir": "workspace:~",
     "@osdk/shared.client.impl": "workspace:~",
     "consola": "^3.4.2",
     "fast-deep-equal": "^3.1.3",

--- a/packages/cli.cmd.typescript/package.json
+++ b/packages/cli.cmd.typescript/package.json
@@ -45,6 +45,7 @@
     "fast-deep-equal": "^3.1.3",
     "find-up": "^7.0.0",
     "tslib": "^2.8.1",
+    "yaml": "^2.8.1",
     "yargs": "^17.7.2"
   },
   "devDependencies": {

--- a/packages/cli.cmd.typescript/src/oac/handleOacGenerate.test.ts
+++ b/packages/cli.cmd.typescript/src/oac/handleOacGenerate.test.ts
@@ -66,7 +66,7 @@ const importedMakerIr = {
     valueTypes: [
       {
         metadata: {
-          apiName: "headingValue",
+          apiName: "externalCategory",
           displayMetadata: { displayName: "Heading Value" },
           packageNamespace: "example",
           status: { type: "active", active: {} },
@@ -163,7 +163,7 @@ describe(handleOacGenerate, () => {
         "    apiName: com.example.TrackedEntity",
         '    package: "@example/core-sdk"',
         "  - kind: valueType",
-        "    apiName: headingValue",
+        "    apiName: externalCategory",
         '    package: "@example/core-sdk"',
         "",
       ].join("\n"),
@@ -190,7 +190,7 @@ describe(handleOacGenerate, () => {
       },
       {
         kind: "valueType",
-        apiName: "headingValue",
+        apiName: "externalCategory",
         package: "@example/core-sdk",
       },
     ]);

--- a/packages/cli.cmd.typescript/src/oac/handleOacGenerate.test.ts
+++ b/packages/cli.cmd.typescript/src/oac/handleOacGenerate.test.ts
@@ -66,6 +66,7 @@ describe(handleOacGenerate, () => {
         ir: irPath,
         outDir: join(dir, "out"),
         version: "0.0.0-dev",
+        packageName: "@example/item-sdk",
         packageType: "module",
         ontologyIdentity: "portable",
       }),
@@ -93,12 +94,60 @@ describe(handleOacGenerate, () => {
         ir: irPath,
         outDir: join(dir, "out"),
         version: "0.0.0-dev",
+        packageName: "@example/item-sdk",
         packageType: "module",
         ontologyIdentity: "portable",
       }),
     ).rejects.toThrow(
       "IR must be a complete Maker document with ontology, importedOntology, valueTypes, and importedValueTypes",
     );
+  });
+
+  it("reads typed imports from yaml", async () => {
+    const dir = await makeTempDir();
+    const irPath = join(dir, "ir.json");
+    const importMapPath = join(dir, "osdk-projection.yaml");
+    const outDir = join(dir, "out");
+    await writeFile(irPath, JSON.stringify(emptyMakerIr));
+    await writeFile(
+      importMapPath,
+      [
+        "imports:",
+        "  - kind: interface",
+        "    apiName: com.example.TrackedEntity",
+        '    package: "@example/core-sdk"',
+        "  - kind: valueType",
+        "    apiName: headingValue",
+        '    package: "@example/core-sdk"',
+        "",
+      ].join("\n"),
+    );
+
+    await handleOacGenerate({
+      ir: irPath,
+      outDir,
+      version: "0.0.0-dev",
+      packageName: "@example/item-sdk",
+      packageType: "module",
+      ontologyIdentity: "portable",
+      importMap: importMapPath,
+    });
+
+    const manifest = JSON.parse(
+      await readFile(join(outDir, "semantic-manifest.json"), "utf8"),
+    );
+    expect(manifest.imports).toEqual([
+      {
+        kind: "interface",
+        apiName: "com.example.TrackedEntity",
+        package: "@example/core-sdk",
+      },
+      {
+        kind: "valueType",
+        apiName: "headingValue",
+        package: "@example/core-sdk",
+      },
+    ]);
   });
 
   it("writes the same portable tree twice and omits ontology ids", async () => {
@@ -113,7 +162,7 @@ describe(handleOacGenerate, () => {
       ir: irPath,
       outDir: firstOut,
       version: "0.0.0-dev",
-      packageName: "@palantir/defense-ontology-sdk",
+      packageName: "@example/item-sdk",
       packageType: "module",
       ontologyIdentity: "portable",
       clean: true,
@@ -122,7 +171,7 @@ describe(handleOacGenerate, () => {
       ir: irPath,
       outDir: secondOut,
       version: "0.0.0-dev",
-      packageName: "@palantir/defense-ontology-sdk",
+      packageName: "@example/item-sdk",
       packageType: "module",
       ontologyIdentity: "portable",
       clean: true,
@@ -151,9 +200,65 @@ describe(handleOacGenerate, () => {
     expect(firstManifest).toBe(secondManifest);
     expect(JSON.parse(firstManifest)).toMatchObject({
       version: 1,
-      packageName: "@palantir/defense-ontology-sdk",
+      packageName: "@example/item-sdk",
       packageVersion: "0.0.0-dev",
       ontologyIdentity: "portable",
     });
+  });
+
+  it("rejects malformed import map yaml", async () => {
+    const dir = await makeTempDir();
+    const irPath = join(dir, "ir.json");
+    const importMapPath = join(dir, "osdk-projection.yaml");
+    await writeFile(irPath, JSON.stringify(emptyMakerIr));
+    await writeFile(importMapPath, "imports: [");
+
+    await expect(
+      handleOacGenerate({
+        ir: irPath,
+        outDir: join(dir, "out"),
+        version: "0.0.0-dev",
+        packageName: "@example/item-sdk",
+        packageType: "module",
+        ontologyIdentity: "portable",
+        importMap: importMapPath,
+      }),
+    ).rejects.toThrow(
+      "Import map must be valid YAML: { imports: [{ kind, apiName, package }] }",
+    );
+  });
+
+  it("rejects duplicate import keys", async () => {
+    const dir = await makeTempDir();
+    const irPath = join(dir, "ir.json");
+    const importMapPath = join(dir, "osdk-projection.yaml");
+    await writeFile(irPath, JSON.stringify(emptyMakerIr));
+    await writeFile(
+      importMapPath,
+      [
+        "imports:",
+        "  - kind: interface",
+        "    apiName: imported.Parent",
+        '    package: "@example/core-sdk"',
+        "  - kind: interface",
+        "    apiName: imported.Parent",
+        '    package: "@example/other-sdk"',
+        "",
+      ].join("\n"),
+    );
+
+    await expect(
+      handleOacGenerate({
+        ir: irPath,
+        outDir: join(dir, "out"),
+        version: "0.0.0-dev",
+        packageName: "@example/item-sdk",
+        packageType: "module",
+        ontologyIdentity: "portable",
+        importMap: importMapPath,
+      }),
+    ).rejects.toThrow(
+      "Import map must be { imports: [{ kind, apiName, package }] }",
+    );
   });
 });

--- a/packages/cli.cmd.typescript/src/oac/handleOacGenerate.test.ts
+++ b/packages/cli.cmd.typescript/src/oac/handleOacGenerate.test.ts
@@ -38,6 +38,52 @@ const emptyMakerIr = {
   randomnessKey: "test-randomness-key",
 };
 
+const importedMakerIr = {
+  ...emptyMakerIr,
+  importedOntology: {
+    ...emptyOntologyBlock,
+    interfaceTypes: {
+      "com.example.TrackedEntity": {
+        interfaceType: {
+          apiName: "com.example.TrackedEntity",
+          actionTypeConstraints: [],
+          displayMetadata: {
+            displayName: "Tracked Entity",
+          },
+          extendsInterfaces: [],
+          extendsInterfacesMetadata: [],
+          links: [],
+          properties: [],
+          propertiesV2: {},
+          propertiesV3: {},
+          searchable: true,
+          status: { type: "active", active: {} },
+        },
+      },
+    },
+  },
+  importedValueTypes: {
+    valueTypes: [
+      {
+        metadata: {
+          apiName: "headingValue",
+          displayMetadata: { displayName: "Heading Value" },
+          packageNamespace: "example",
+          status: { type: "active", active: {} },
+        },
+        versions: [
+          {
+            baseType: { type: "double", double: {} },
+            constraints: [],
+            exampleValues: [],
+            version: "1.0.0",
+          },
+        ],
+      },
+    ],
+  },
+};
+
 const tempDirs: string[] = [];
 
 afterEach(async () => {
@@ -108,7 +154,7 @@ describe(handleOacGenerate, () => {
     const irPath = join(dir, "ir.json");
     const importMapPath = join(dir, "osdk-projection.yaml");
     const outDir = join(dir, "out");
-    await writeFile(irPath, JSON.stringify(emptyMakerIr));
+    await writeFile(irPath, JSON.stringify(importedMakerIr));
     await writeFile(
       importMapPath,
       [
@@ -148,6 +194,53 @@ describe(handleOacGenerate, () => {
         package: "@example/core-sdk",
       },
     ]);
+  });
+
+  it("rejects an import that does not match imported metadata", async () => {
+    const dir = await makeTempDir();
+    const irPath = join(dir, "ir.json");
+    const importMapPath = join(dir, "osdk-projection.yaml");
+    await writeFile(irPath, JSON.stringify(importedMakerIr));
+    await writeFile(
+      importMapPath,
+      [
+        "imports:",
+        "  - kind: interface",
+        "    apiName: com.example.TrackedEntityTypo",
+        '    package: "@example/core-sdk"',
+        "",
+      ].join("\n"),
+    );
+
+    await expect(
+      handleOacGenerate({
+        ir: irPath,
+        outDir: join(dir, "out"),
+        version: "0.0.0-dev",
+        packageName: "@example/item-sdk",
+        packageType: "module",
+        ontologyIdentity: "portable",
+        importMap: importMapPath,
+      }),
+    ).rejects.toThrow("Import 'interface:com.example.TrackedEntityTypo'");
+  });
+
+  it("rejects protected output directories", async () => {
+    const dir = await makeTempDir();
+    const irPath = join(dir, "ir.json");
+    await writeFile(irPath, JSON.stringify(emptyMakerIr));
+
+    await expect(
+      handleOacGenerate({
+        ir: irPath,
+        outDir: process.cwd(),
+        version: "0.0.0-dev",
+        packageName: "@example/item-sdk",
+        packageType: "module",
+        ontologyIdentity: "portable",
+        clean: true,
+      }),
+    ).rejects.toThrow("Refusing to generate into protected directory");
   });
 
   it("writes the same portable tree twice and omits ontology ids", async () => {

--- a/packages/cli.cmd.typescript/src/oac/handleOacGenerate.test.ts
+++ b/packages/cli.cmd.typescript/src/oac/handleOacGenerate.test.ts
@@ -1,0 +1,159 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { afterEach, describe, expect, it } from "vitest";
+
+import { handleOacGenerate } from "./handleOacGenerate.js";
+
+const emptyOntologyBlock = {
+  actionTypes: {},
+  interfaceTypes: {},
+  linkTypes: {},
+  objectTypes: {},
+  sharedPropertyTypes: {},
+};
+
+const emptyMakerIr = {
+  ontology: emptyOntologyBlock,
+  importedOntology: emptyOntologyBlock,
+  valueTypes: { valueTypes: [] },
+  importedValueTypes: { valueTypes: [] },
+  randomnessKey: "test-randomness-key",
+};
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })),
+  );
+});
+
+async function makeTempDir(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "oac-generate-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+describe(handleOacGenerate, () => {
+  it("rejects a blockData document", async () => {
+    const dir = await makeTempDir();
+    const irPath = join(dir, "ir.json");
+    await writeFile(
+      irPath,
+      JSON.stringify({ blockData: { interfaceTypes: {} } }),
+    );
+
+    await expect(
+      handleOacGenerate({
+        ir: irPath,
+        outDir: join(dir, "out"),
+        version: "0.0.0-dev",
+        packageType: "module",
+        ontologyIdentity: "portable",
+      }),
+    ).rejects.toThrow(
+      "IR must be a complete Maker document with ontology, importedOntology, valueTypes, and importedValueTypes",
+    );
+  });
+
+  it("rejects a single ontology block", async () => {
+    const dir = await makeTempDir();
+    const irPath = join(dir, "ir.json");
+    await writeFile(
+      irPath,
+      JSON.stringify({
+        actionTypes: {},
+        interfaceTypes: {},
+        linkTypes: {},
+        objectTypes: {},
+        sharedPropertyTypes: {},
+      }),
+    );
+
+    await expect(
+      handleOacGenerate({
+        ir: irPath,
+        outDir: join(dir, "out"),
+        version: "0.0.0-dev",
+        packageType: "module",
+        ontologyIdentity: "portable",
+      }),
+    ).rejects.toThrow(
+      "IR must be a complete Maker document with ontology, importedOntology, valueTypes, and importedValueTypes",
+    );
+  });
+
+  it("writes the same portable tree twice and omits ontology ids", async () => {
+    const dir = await makeTempDir();
+    const firstOut = join(dir, "first");
+    const secondOut = join(dir, "second");
+
+    const irPath = join(dir, "ir.json");
+    await writeFile(irPath, JSON.stringify(emptyMakerIr));
+
+    await handleOacGenerate({
+      ir: irPath,
+      outDir: firstOut,
+      version: "0.0.0-dev",
+      packageName: "@palantir/defense-ontology-sdk",
+      packageType: "module",
+      ontologyIdentity: "portable",
+      clean: true,
+    });
+    await handleOacGenerate({
+      ir: irPath,
+      outDir: secondOut,
+      version: "0.0.0-dev",
+      packageName: "@palantir/defense-ontology-sdk",
+      packageType: "module",
+      ontologyIdentity: "portable",
+      clean: true,
+    });
+
+    const firstMetadata = await readFile(
+      join(firstOut, "OntologyMetadata.ts"),
+      "utf-8",
+    );
+    const secondMetadata = await readFile(
+      join(secondOut, "OntologyMetadata.ts"),
+      "utf-8",
+    );
+    expect(firstMetadata).toBe(secondMetadata);
+    expect(firstMetadata).not.toContain("$ontologyRid");
+    expect(firstMetadata).not.toContain("$branch");
+
+    const firstManifest = await readFile(
+      join(firstOut, "semantic-manifest.json"),
+      "utf-8",
+    );
+    const secondManifest = await readFile(
+      join(secondOut, "semantic-manifest.json"),
+      "utf-8",
+    );
+    expect(firstManifest).toBe(secondManifest);
+    expect(JSON.parse(firstManifest)).toMatchObject({
+      version: 1,
+      packageName: "@palantir/defense-ontology-sdk",
+      packageVersion: "0.0.0-dev",
+      ontologyIdentity: "portable",
+    });
+  });
+});

--- a/packages/cli.cmd.typescript/src/oac/handleOacGenerate.test.ts
+++ b/packages/cli.cmd.typescript/src/oac/handleOacGenerate.test.ts
@@ -134,7 +134,7 @@ describe(handleOacGenerate, () => {
     });
 
     const manifest = JSON.parse(
-      await readFile(join(outDir, "semantic-manifest.json"), "utf8"),
+      await readFile(join(outDir, "semantic-manifest.json"), "utf-8"),
     );
     expect(manifest.imports).toEqual([
       {

--- a/packages/cli.cmd.typescript/src/oac/handleOacGenerate.ts
+++ b/packages/cli.cmd.typescript/src/oac/handleOacGenerate.ts
@@ -17,7 +17,7 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 
-import { ExitProcessError, YargsCheckError } from "@osdk/cli.common";
+import { ExitProcessError } from "@osdk/cli.common";
 import type { OntologyIr } from "@osdk/client.unstable";
 import { generateClientSdkVersionTwoPointZero } from "@osdk/generator";
 import {
@@ -27,63 +27,72 @@ import {
   OntologyIrToFullMetadataConverter,
 } from "@osdk/generator-converters.ontologyir";
 import { consola } from "consola";
+import { parse as parseYaml } from "yaml";
 
 import type { OacGenerateArgs } from "./oacGenerate.js";
 
 const USER_AGENT = `osdk-oac/${process.env.PACKAGE_VERSION ?? "dev"}`;
 
 export async function handleOacGenerate(args: OacGenerateArgs): Promise<void> {
-  const ir = await readMakerIr(args.ir);
-  const imports = args.importMap ? await readImportMap(args.importMap) : [];
-  const metadata =
-    OntologyIrToFullMetadataConverter.getFullMetadataFromEnvelope(ir);
+  try {
+    const ir = await readMakerIr(args.ir);
+    const imports = args.importMap ? await readImportMap(args.importMap) : [];
+    const metadata =
+      OntologyIrToFullMetadataConverter.getFullMetadataFromEnvelope(ir);
 
-  if (args.clean) {
-    await fs.promises.rm(args.outDir, { recursive: true, force: true });
+    if (args.clean) {
+      await fs.promises.rm(args.outDir, { recursive: true, force: true });
+    }
+    await fs.promises.mkdir(args.outDir, { recursive: true });
+
+    const externalObjects = toExternalMap(imports, "object");
+    const externalInterfaces = toExternalMap(imports, "interface");
+    const externalSpts = toExternalMap(imports, "sharedPropertyType");
+
+    await generateClientSdkVersionTwoPointZero(
+      metadata,
+      getUserAgent(args.version),
+      {
+        writeFile: async (filePath, contents) => {
+          await fs.promises.writeFile(filePath, contents);
+        },
+        mkdir: async (dirPath, options) => {
+          await fs.promises.mkdir(dirPath, options);
+        },
+        readdir: async (dirPath) => {
+          return await fs.promises.readdir(dirPath);
+        },
+      },
+      args.outDir,
+      "module",
+      externalObjects,
+      externalInterfaces,
+      externalSpts,
+      false,
+      [],
+      false,
+      args.ontologyIdentity === "portable",
+    );
+
+    const manifest = buildSemanticManifest(metadata, {
+      packageName: args.packageName,
+      packageVersion: args.version,
+      ontologyIdentity: args.ontologyIdentity,
+      imports,
+    });
+    await fs.promises.writeFile(
+      path.join(args.outDir, "semantic-manifest.json"),
+      `${JSON.stringify(manifest, null, 2)}\n`,
+    );
+
+    consola.info("OSDK generated from Maker IR");
+  } catch (err) {
+    if (err instanceof ExitProcessError) {
+      throw err;
+    }
+    const message = err instanceof Error ? err.message : String(err);
+    throw new ExitProcessError(1, message);
   }
-  await fs.promises.mkdir(args.outDir, { recursive: true });
-
-  const externalObjects = toExternalMap(imports, "object");
-  const externalInterfaces = toExternalMap(imports, "interface");
-  const externalSpts = toExternalMap(imports, "sharedPropertyType");
-
-  await generateClientSdkVersionTwoPointZero(
-    metadata,
-    getUserAgent(args.version),
-    {
-      writeFile: async (filePath, contents) => {
-        await fs.promises.writeFile(filePath, contents);
-      },
-      mkdir: async (dirPath, options) => {
-        await fs.promises.mkdir(dirPath, options);
-      },
-      readdir: async (dirPath) => {
-        return await fs.promises.readdir(dirPath);
-      },
-    },
-    args.outDir,
-    "module",
-    externalObjects,
-    externalInterfaces,
-    externalSpts,
-    false,
-    [],
-    false,
-    args.ontologyIdentity === "portable",
-  );
-
-  const manifest = buildSemanticManifest(metadata, {
-    packageName: args.packageName,
-    packageVersion: args.version,
-    ontologyIdentity: args.ontologyIdentity,
-    imports,
-  });
-  await fs.promises.writeFile(
-    path.join(args.outDir, "semantic-manifest.json"),
-    `${JSON.stringify(manifest, null, 2)}\n`,
-  );
-
-  consola.info("OSDK generated from Maker IR");
 }
 
 function getUserAgent(version: string): string {
@@ -111,11 +120,15 @@ async function readMakerIr(irPath: string): Promise<OntologyIr> {
     throw new ExitProcessError(1, `Maker IR file does not exist: ${irPath}`);
   }
 
-  const parsed: unknown = JSON.parse(
-    await fs.promises.readFile(irPath, "utf-8"),
-  );
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(await fs.promises.readFile(irPath, "utf-8"));
+  } catch {
+    throw new ExitProcessError(1, `Maker IR is not valid JSON: ${irPath}`);
+  }
   if (!isOntologyIr(parsed)) {
-    throw new YargsCheckError(
+    throw new ExitProcessError(
+      1,
       "IR must be a complete Maker document with ontology, importedOntology, valueTypes, and importedValueTypes",
     );
   }
@@ -132,11 +145,18 @@ async function readImportMap(
     );
   }
 
-  const parsed: unknown = JSON.parse(
-    await fs.promises.readFile(importMapPath, "utf-8"),
-  );
+  let parsed: unknown;
+  try {
+    parsed = parseYaml(await fs.promises.readFile(importMapPath, "utf8"));
+  } catch {
+    throw new ExitProcessError(
+      1,
+      "Import map must be valid YAML: { imports: [{ kind, apiName, package }] }",
+    );
+  }
   if (!isImportMap(parsed)) {
-    throw new YargsCheckError(
+    throw new ExitProcessError(
+      1,
       "Import map must be { imports: [{ kind, apiName, package }] }",
     );
   }
@@ -201,18 +221,31 @@ function isImportedEntityKind(value: unknown): value is ImportedEntityKind {
   return false;
 }
 
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.length > 0;
+}
+
 function isImportMap(
   value: unknown,
 ): value is { imports: ImportedEntityMapping[] } {
   if (!isRecord(value) || !Array.isArray(value.imports)) {
     return false;
   }
-  return value.imports.every((entry) => {
-    return (
-      isRecord(entry) &&
-      isImportedEntityKind(entry.kind) &&
-      typeof entry.apiName === "string" &&
-      typeof entry.package === "string"
-    );
-  });
+  const seen = new Set<string>();
+  for (const entry of value.imports) {
+    if (
+      !isRecord(entry)
+      || !isImportedEntityKind(entry.kind)
+      || !isNonEmptyString(entry.apiName)
+      || !isNonEmptyString(entry.package)
+    ) {
+      return false;
+    }
+    const key = `${entry.kind}:${entry.apiName}`;
+    if (seen.has(key)) {
+      return false;
+    }
+    seen.add(key);
+  }
+  return true;
 }

--- a/packages/cli.cmd.typescript/src/oac/handleOacGenerate.ts
+++ b/packages/cli.cmd.typescript/src/oac/handleOacGenerate.ts
@@ -34,16 +34,16 @@ import type { OacGenerateArgs } from "./oacGenerate.js";
 const USER_AGENT = `osdk-oac/${process.env.PACKAGE_VERSION ?? "dev"}`;
 
 export async function handleOacGenerate(args: OacGenerateArgs): Promise<void> {
+  let stagingDir: string | undefined;
   try {
     const ir = await readMakerIr(args.ir);
     const imports = args.importMap ? await readImportMap(args.importMap) : [];
+    validateImports(imports, ir, args.importMap);
     const metadata =
       OntologyIrToFullMetadataConverter.getFullMetadataFromEnvelope(ir);
-
-    if (args.clean) {
-      await fs.promises.rm(args.outDir, { recursive: true, force: true });
-    }
-    await fs.promises.mkdir(args.outDir, { recursive: true });
+    const outDir = protectedOutputDirectory(args.outDir);
+    await fs.promises.mkdir(path.dirname(outDir), { recursive: true });
+    stagingDir = await fs.promises.mkdtemp(`${outDir}.tmp-`);
 
     const externalObjects = toExternalMap(imports, "object");
     const externalInterfaces = toExternalMap(imports, "interface");
@@ -63,8 +63,8 @@ export async function handleOacGenerate(args: OacGenerateArgs): Promise<void> {
           return await fs.promises.readdir(dirPath);
         },
       },
-      args.outDir,
-      "module",
+      stagingDir,
+      args.packageType,
       externalObjects,
       externalInterfaces,
       externalSpts,
@@ -81,10 +81,12 @@ export async function handleOacGenerate(args: OacGenerateArgs): Promise<void> {
       imports,
     });
     await fs.promises.writeFile(
-      path.join(args.outDir, "semantic-manifest.json"),
+      path.join(stagingDir, "semantic-manifest.json"),
       `${JSON.stringify(manifest, null, 2)}\n`,
     );
 
+    await replaceOutputDirectory(stagingDir, outDir, args.clean === true);
+    stagingDir = undefined;
     consola.info("OSDK generated from Maker IR");
   } catch (err) {
     if (err instanceof ExitProcessError) {
@@ -92,6 +94,78 @@ export async function handleOacGenerate(args: OacGenerateArgs): Promise<void> {
     }
     const message = err instanceof Error ? err.message : String(err);
     throw new ExitProcessError(1, message);
+  } finally {
+    if (stagingDir !== undefined) {
+      await fs.promises.rm(stagingDir, { recursive: true, force: true });
+    }
+  }
+}
+
+function protectedOutputDirectory(outDir: string): string {
+  const resolved = path.resolve(outDir);
+  const root = path.parse(resolved).root;
+  const cwd = process.cwd();
+  const relativeCwd = path.relative(resolved, cwd);
+  if (
+    resolved === root ||
+    relativeCwd === "" ||
+    (!relativeCwd.startsWith("..") && !path.isAbsolute(relativeCwd))
+  ) {
+    throw new ExitProcessError(
+      1,
+      `Refusing to generate into protected directory: ${resolved}`,
+    );
+  }
+  return resolved;
+}
+
+async function uniqueBackupPath(outDir: string): Promise<string> {
+  const placeholder = await fs.promises.mkdtemp(`${outDir}.backup-`);
+  await fs.promises.rmdir(placeholder);
+  return placeholder;
+}
+
+async function replaceOutputDirectory(
+  stagingDir: string,
+  outDir: string,
+  clean: boolean,
+): Promise<void> {
+  if (!clean && fs.existsSync(outDir)) {
+    try {
+      await fs.promises.rmdir(outDir);
+    } catch (error) {
+      const code =
+        isRecord(error) && typeof error.code === "string"
+          ? error.code
+          : undefined;
+      if (code === "ENOTEMPTY" || code === "EEXIST") {
+        throw new ExitProcessError(
+          1,
+          `Output directory must be empty unless --clean is used: ${outDir}`,
+        );
+      }
+      throw error;
+    }
+    await fs.promises.rename(stagingDir, outDir);
+    return;
+  }
+
+  const backupDir = await uniqueBackupPath(outDir);
+  let movedExisting = false;
+  if (fs.existsSync(outDir)) {
+    await fs.promises.rename(outDir, backupDir);
+    movedExisting = true;
+  }
+  try {
+    await fs.promises.rename(stagingDir, outDir);
+    if (movedExisting) {
+      await fs.promises.rm(backupDir, { recursive: true, force: true });
+    }
+  } catch (error) {
+    if (movedExisting && !fs.existsSync(outDir)) {
+      await fs.promises.rename(backupDir, outDir);
+    }
+    throw error;
   }
 }
 
@@ -100,6 +174,84 @@ function getUserAgent(version: string): string {
     return "osdk-oac/dev";
   }
   return `${USER_AGENT} typescript-sdk/${version}`;
+}
+
+function validateImports(
+  imports: ReadonlyArray<ImportedEntityMapping>,
+  ir: OntologyIr,
+  importMapPath: string | undefined,
+): void {
+  for (const entry of imports) {
+    if (!hasImportedEntity(ir, entry)) {
+      const source = importMapPath ?? "import map";
+      throw new ExitProcessError(
+        1,
+        `Import '${entry.kind}:${entry.apiName}' from ${source} does not match an imported Maker entity`,
+      );
+    }
+  }
+}
+
+function hasImportedEntity(
+  ir: OntologyIr,
+  entry: ImportedEntityMapping,
+): boolean {
+  switch (entry.kind) {
+    case "interface":
+      return Object.hasOwn(ir.importedOntology.interfaceTypes, entry.apiName);
+    case "object":
+      return Object.hasOwn(ir.importedOntology.objectTypes, entry.apiName);
+    case "sharedPropertyType":
+      return Object.hasOwn(
+        ir.importedOntology.sharedPropertyTypes,
+        entry.apiName,
+      );
+    case "valueType":
+      return (
+        ir.importedValueTypes.valueTypes.some(
+          (valueType) => valueType.metadata.apiName === entry.apiName,
+        ) || importedEmbeddedValueTypes(ir).has(entry.apiName)
+      );
+  }
+}
+
+function importedEmbeddedValueTypes(ir: OntologyIr): Set<string> {
+  const apiNames = new Set<string>();
+  for (const block of Object.values(ir.importedOntology.objectTypes)) {
+    for (const property of Object.values(block.objectType.propertyTypes)) {
+      if (property.valueType) {
+        apiNames.add(property.valueType.apiName);
+      }
+    }
+  }
+  for (const block of Object.values(ir.importedOntology.sharedPropertyTypes)) {
+    if (block.sharedPropertyType.valueType) {
+      apiNames.add(block.sharedPropertyType.valueType.apiName);
+    }
+  }
+  for (const block of Object.values(ir.importedOntology.interfaceTypes)) {
+    for (const property of Object.values(block.interfaceType.propertiesV2)) {
+      if (property.sharedPropertyType.valueType) {
+        apiNames.add(property.sharedPropertyType.valueType.apiName);
+      }
+    }
+    for (const property of Object.values(block.interfaceType.propertiesV3)) {
+      if (property.type === "interfaceDefinedPropertyType") {
+        const valueType =
+          property.interfaceDefinedPropertyType.constraints.valueType;
+        if (valueType) {
+          apiNames.add(valueType.apiName);
+        }
+      } else {
+        const valueType =
+          property.sharedPropertyBasedPropertyType.sharedPropertyType.valueType;
+        if (valueType) {
+          apiNames.add(valueType.apiName);
+        }
+      }
+    }
+  }
+  return apiNames;
 }
 
 function toExternalMap(
@@ -222,7 +374,9 @@ function isImportedEntityKind(value: unknown): value is ImportedEntityKind {
 }
 
 function isNonEmptyString(value: unknown): value is string {
-  return typeof value === "string" && value.length > 0;
+  return (
+    typeof value === "string" && value.length > 0 && value === value.trim()
+  );
 }
 
 function isImportMap(
@@ -234,10 +388,10 @@ function isImportMap(
   const seen = new Set<string>();
   for (const entry of value.imports) {
     if (
-      !isRecord(entry)
-      || !isImportedEntityKind(entry.kind)
-      || !isNonEmptyString(entry.apiName)
-      || !isNonEmptyString(entry.package)
+      !isRecord(entry) ||
+      !isImportedEntityKind(entry.kind) ||
+      !isNonEmptyString(entry.apiName) ||
+      !isNonEmptyString(entry.package)
     ) {
       return false;
     }

--- a/packages/cli.cmd.typescript/src/oac/handleOacGenerate.ts
+++ b/packages/cli.cmd.typescript/src/oac/handleOacGenerate.ts
@@ -1,0 +1,218 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+import { ExitProcessError, YargsCheckError } from "@osdk/cli.common";
+import type { OntologyIr } from "@osdk/client.unstable";
+import { generateClientSdkVersionTwoPointZero } from "@osdk/generator";
+import {
+  buildSemanticManifest,
+  type ImportedEntityKind,
+  type ImportedEntityMapping,
+  OntologyIrToFullMetadataConverter,
+} from "@osdk/generator-converters.ontologyir";
+import { consola } from "consola";
+
+import type { OacGenerateArgs } from "./oacGenerate.js";
+
+const USER_AGENT = `osdk-oac/${process.env.PACKAGE_VERSION ?? "dev"}`;
+
+export async function handleOacGenerate(args: OacGenerateArgs): Promise<void> {
+  const ir = await readMakerIr(args.ir);
+  const imports = args.importMap ? await readImportMap(args.importMap) : [];
+  const metadata =
+    OntologyIrToFullMetadataConverter.getFullMetadataFromEnvelope(ir);
+
+  if (args.clean) {
+    await fs.promises.rm(args.outDir, { recursive: true, force: true });
+  }
+  await fs.promises.mkdir(args.outDir, { recursive: true });
+
+  const externalObjects = toExternalMap(imports, "object");
+  const externalInterfaces = toExternalMap(imports, "interface");
+  const externalSpts = toExternalMap(imports, "sharedPropertyType");
+
+  await generateClientSdkVersionTwoPointZero(
+    metadata,
+    getUserAgent(args.version),
+    {
+      writeFile: async (filePath, contents) => {
+        await fs.promises.writeFile(filePath, contents);
+      },
+      mkdir: async (dirPath, options) => {
+        await fs.promises.mkdir(dirPath, options);
+      },
+      readdir: async (dirPath) => {
+        return await fs.promises.readdir(dirPath);
+      },
+    },
+    args.outDir,
+    "module",
+    externalObjects,
+    externalInterfaces,
+    externalSpts,
+    false,
+    [],
+    false,
+    args.ontologyIdentity === "portable",
+  );
+
+  const manifest = buildSemanticManifest(metadata, {
+    packageName: args.packageName,
+    packageVersion: args.version,
+    ontologyIdentity: args.ontologyIdentity,
+    imports,
+  });
+  await fs.promises.writeFile(
+    path.join(args.outDir, "semantic-manifest.json"),
+    `${JSON.stringify(manifest, null, 2)}\n`,
+  );
+
+  consola.info("OSDK generated from Maker IR");
+}
+
+function getUserAgent(version: string): string {
+  if (version === "dev") {
+    return "osdk-oac/dev";
+  }
+  return `${USER_AGENT} typescript-sdk/${version}`;
+}
+
+function toExternalMap(
+  imports: ReadonlyArray<ImportedEntityMapping>,
+  kind: ImportedEntityKind,
+): Map<string, string> {
+  const map = new Map<string, string>();
+  for (const entry of imports) {
+    if (entry.kind === kind) {
+      map.set(entry.apiName, entry.package);
+    }
+  }
+  return map;
+}
+
+async function readMakerIr(irPath: string): Promise<OntologyIr> {
+  if (!fs.existsSync(irPath)) {
+    throw new ExitProcessError(1, `Maker IR file does not exist: ${irPath}`);
+  }
+
+  const parsed: unknown = JSON.parse(
+    await fs.promises.readFile(irPath, "utf-8"),
+  );
+  if (!isOntologyIr(parsed)) {
+    throw new YargsCheckError(
+      "IR must be a complete Maker document with ontology, importedOntology, valueTypes, and importedValueTypes",
+    );
+  }
+  return parsed;
+}
+
+async function readImportMap(
+  importMapPath: string,
+): Promise<ImportedEntityMapping[]> {
+  if (!fs.existsSync(importMapPath)) {
+    throw new ExitProcessError(
+      1,
+      `Import map file does not exist: ${importMapPath}`,
+    );
+  }
+
+  const parsed: unknown = JSON.parse(
+    await fs.promises.readFile(importMapPath, "utf-8"),
+  );
+  if (!isImportMap(parsed)) {
+    throw new YargsCheckError(
+      "Import map must be { imports: [{ kind, apiName, package }] }",
+    );
+  }
+  return parsed.imports;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value != null && !Array.isArray(value);
+}
+
+function isOntologyBlock(value: unknown): boolean {
+  if (!isRecord(value)) {
+    return false;
+  }
+  return (
+    isRecord(value.actionTypes) &&
+    isRecord(value.interfaceTypes) &&
+    isRecord(value.linkTypes) &&
+    isRecord(value.objectTypes) &&
+    isRecord(value.sharedPropertyTypes)
+  );
+}
+
+function isValueTypeBlock(value: unknown): boolean {
+  return isRecord(value) && Array.isArray(value.valueTypes);
+}
+
+function isOntologyIr(value: unknown): value is OntologyIr {
+  if (!isRecord(value)) {
+    return false;
+  }
+  if ("blockData" in value && !("ontology" in value)) {
+    return false;
+  }
+  if (
+    value.randomnessKey !== undefined &&
+    typeof value.randomnessKey !== "string"
+  ) {
+    return false;
+  }
+  return (
+    isOntologyBlock(value.ontology) &&
+    isOntologyBlock(value.importedOntology) &&
+    isValueTypeBlock(value.valueTypes) &&
+    isValueTypeBlock(value.importedValueTypes)
+  );
+}
+
+const importedEntityKinds: ReadonlyArray<ImportedEntityKind> = [
+  "interface",
+  "object",
+  "sharedPropertyType",
+  "valueType",
+];
+
+function isImportedEntityKind(value: unknown): value is ImportedEntityKind {
+  for (const kind of importedEntityKinds) {
+    if (value === kind) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function isImportMap(
+  value: unknown,
+): value is { imports: ImportedEntityMapping[] } {
+  if (!isRecord(value) || !Array.isArray(value.imports)) {
+    return false;
+  }
+  return value.imports.every((entry) => {
+    return (
+      isRecord(entry) &&
+      isImportedEntityKind(entry.kind) &&
+      typeof entry.apiName === "string" &&
+      typeof entry.package === "string"
+    );
+  });
+}

--- a/packages/cli.cmd.typescript/src/oac/handleOacGenerate.ts
+++ b/packages/cli.cmd.typescript/src/oac/handleOacGenerate.ts
@@ -147,7 +147,7 @@ async function readImportMap(
 
   let parsed: unknown;
   try {
-    parsed = parseYaml(await fs.promises.readFile(importMapPath, "utf8"));
+    parsed = parseYaml(await fs.promises.readFile(importMapPath, "utf-8"));
   } catch {
     throw new ExitProcessError(
       1,

--- a/packages/cli.cmd.typescript/src/oac/oacCommand.ts
+++ b/packages/cli.cmd.typescript/src/oac/oacCommand.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Palantir Technologies, Inc. All rights reserved.
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,16 @@
  * limitations under the License.
  */
 
-export { cli } from "./cli.js";
-export type { TypescriptGenerateArgs } from "./generate/TypescriptGenerateArgs.js";
-export { oacCommand } from "./oac/oacCommand.js";
-export { typescriptCommand as default } from "./typescriptCommand.js";
+import type { CliCommonArgs } from "@osdk/cli.common";
+import type * as yargs from "yargs";
+
+import { oacGenerateCommand } from "./oacGenerate.js";
+
+export const oacCommand: yargs.CommandModule<CliCommonArgs, CliCommonArgs> = {
+  command: "oac",
+  describe: "Generate from Ontology as Code",
+  builder: (argv) => {
+    return argv.command(oacGenerateCommand).demandCommand();
+  },
+  handler: async (_args) => {},
+};

--- a/packages/cli.cmd.typescript/src/oac/oacGenerate.test.ts
+++ b/packages/cli.cmd.typescript/src/oac/oacGenerate.test.ts
@@ -20,7 +20,7 @@ import yargs from "yargs";
 import { oacGenerateCommand } from "./oacGenerate.js";
 
 describe("oac generate", () => {
-  it("requires a package name", async () => {
+  it("requires a package name", () => {
     expect(() =>
       yargs([
         "generate",
@@ -41,7 +41,7 @@ describe("oac generate", () => {
     ).toThrow("Missing required argument: packageName");
   });
 
-  it("rejects an empty package name", async () => {
+  it("rejects an empty package name", () => {
     expect(() =>
       yargs([
         "generate",

--- a/packages/cli.cmd.typescript/src/oac/oacGenerate.test.ts
+++ b/packages/cli.cmd.typescript/src/oac/oacGenerate.test.ts
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+import yargs from "yargs";
+
+import { oacGenerateCommand } from "./oacGenerate.js";
+
+describe("oac generate", () => {
+  it("requires a package name", async () => {
+    expect(() =>
+      yargs([
+        "generate",
+        "--ir",
+        "ontology.json",
+        "--outDir",
+        "generated",
+        "--version",
+        "0.0.0-dev",
+      ])
+        .version(false)
+        .exitProcess(false)
+        .fail((message) => {
+          throw new Error(message);
+        })
+        .command(oacGenerateCommand)
+        .parse()
+    ).toThrow("Missing required argument: packageName");
+  });
+});

--- a/packages/cli.cmd.typescript/src/oac/oacGenerate.test.ts
+++ b/packages/cli.cmd.typescript/src/oac/oacGenerate.test.ts
@@ -40,4 +40,27 @@ describe("oac generate", () => {
         .parse()
     ).toThrow("Missing required argument: packageName");
   });
+
+  it("rejects an empty package name", async () => {
+    expect(() =>
+      yargs([
+        "generate",
+        "--ir",
+        "ontology.json",
+        "--outDir",
+        "generated",
+        "--version",
+        "0.0.0-dev",
+        "--packageName",
+        "",
+      ])
+        .version(false)
+        .exitProcess(false)
+        .fail((_message, error) => {
+          throw error;
+        })
+        .command(oacGenerateCommand)
+        .parse()
+    ).toThrow("packageName must not be empty");
+  });
 });

--- a/packages/cli.cmd.typescript/src/oac/oacGenerate.test.ts
+++ b/packages/cli.cmd.typescript/src/oac/oacGenerate.test.ts
@@ -37,11 +37,11 @@ describe("oac generate", () => {
           throw new Error(message);
         })
         .command(oacGenerateCommand)
-        .parse()
+        .parse(),
     ).toThrow("Missing required argument: packageName");
   });
 
-  it("rejects an empty package name", () => {
+  it.each(["", "   "])("rejects package name %j", (packageName) => {
     expect(() =>
       yargs([
         "generate",
@@ -52,7 +52,7 @@ describe("oac generate", () => {
         "--version",
         "0.0.0-dev",
         "--packageName",
-        "",
+        packageName,
       ])
         .version(false)
         .exitProcess(false)
@@ -60,7 +60,33 @@ describe("oac generate", () => {
           throw error;
         })
         .command(oacGenerateCommand)
-        .parse()
+        .parse(),
     ).toThrow("packageName must not be empty");
   });
+
+  it.each([" 1.2.3 ", "v1.2.3"])(
+    "rejects non-canonical version %j",
+    (version) => {
+      expect(() =>
+        yargs([
+          "generate",
+          "--ir",
+          "ontology.json",
+          "--outDir",
+          "generated",
+          "--version",
+          version,
+          "--packageName",
+          "@example/item-sdk",
+        ])
+          .version(false)
+          .exitProcess(false)
+          .fail((_message, error) => {
+            throw error;
+          })
+          .command(oacGenerateCommand)
+          .parse(),
+      ).toThrow("Version must be 'dev' or a valid semver version");
+    },
+  );
 });

--- a/packages/cli.cmd.typescript/src/oac/oacGenerate.ts
+++ b/packages/cli.cmd.typescript/src/oac/oacGenerate.ts
@@ -76,6 +76,9 @@ export const oacGenerateCommand: CommandModule<{}, OacGenerateArgs> = {
         },
       } as const)
       .check((args) => {
+        if (args.packageName.length === 0) {
+          throw new YargsCheckError("packageName must not be empty");
+        }
         if (args.version !== "dev" && !isValidSemver(args.version)) {
           throw new YargsCheckError(
             "Version must be 'dev' or a valid semver version",

--- a/packages/cli.cmd.typescript/src/oac/oacGenerate.ts
+++ b/packages/cli.cmd.typescript/src/oac/oacGenerate.ts
@@ -76,10 +76,15 @@ export const oacGenerateCommand: CommandModule<{}, OacGenerateArgs> = {
         },
       } as const)
       .check((args) => {
-        if (args.packageName.length === 0) {
+        if (args.packageName.trim().length === 0) {
           throw new YargsCheckError("packageName must not be empty");
         }
-        if (args.version !== "dev" && !isValidSemver(args.version)) {
+        if (
+          args.version !== "dev" &&
+          (args.version !== args.version.trim() ||
+            args.version.startsWith("v") ||
+            !isValidSemver(args.version))
+        ) {
           throw new YargsCheckError(
             "Version must be 'dev' or a valid semver version",
           );

--- a/packages/cli.cmd.typescript/src/oac/oacGenerate.ts
+++ b/packages/cli.cmd.typescript/src/oac/oacGenerate.ts
@@ -21,7 +21,7 @@ export interface OacGenerateArgs {
   ir: string;
   outDir: string;
   version: string;
-  packageName?: string;
+  packageName: string;
   packageType: "module";
   clean?: boolean;
   ontologyIdentity: "portable" | "installationSpecific";
@@ -52,6 +52,7 @@ export const oacGenerateCommand: CommandModule<{}, OacGenerateArgs> = {
         packageName: {
           type: "string",
           description: "Name of the package to generate",
+          demandOption: true,
         },
         packageType: {
           default: "module",
@@ -71,7 +72,7 @@ export const oacGenerateCommand: CommandModule<{}, OacGenerateArgs> = {
         importMap: {
           type: "string",
           description:
-            "Path to a JSON import map of { imports: [{ kind, apiName, package }] }",
+            "Path to a YAML import map of { imports: [{ kind, apiName, package }] }",
         },
       } as const)
       .check((args) => {

--- a/packages/cli.cmd.typescript/src/oac/oacGenerate.ts
+++ b/packages/cli.cmd.typescript/src/oac/oacGenerate.ts
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { isValidSemver, YargsCheckError } from "@osdk/cli.common";
+import type { CommandModule } from "yargs";
+
+export interface OacGenerateArgs {
+  ir: string;
+  outDir: string;
+  version: string;
+  packageName?: string;
+  packageType: "module";
+  clean?: boolean;
+  ontologyIdentity: "portable" | "installationSpecific";
+  importMap?: string;
+}
+
+export const oacGenerateCommand: CommandModule<{}, OacGenerateArgs> = {
+  command: "generate",
+  describe: "Generate a TypeScript SDK from Maker IR",
+  builder: (argv) => {
+    return argv
+      .options({
+        ir: {
+          type: "string",
+          description: "Path to the complete Maker IR json",
+          demandOption: true,
+        },
+        outDir: {
+          type: "string",
+          description: "Where to place the generated files",
+          demandOption: true,
+        },
+        version: {
+          type: "string",
+          description: "Version of the generated code, or 'dev'",
+          demandOption: true,
+        },
+        packageName: {
+          type: "string",
+          description: "Name of the package to generate",
+        },
+        packageType: {
+          default: "module",
+          choices: ["module"],
+        },
+        clean: {
+          type: "boolean",
+          description: "Clean the output directory before generating",
+        },
+        ontologyIdentity: {
+          type: "string",
+          choices: ["portable", "installationSpecific"],
+          default: "portable",
+          description:
+            "portable omits installation-specific ontology and branch ids",
+        },
+        importMap: {
+          type: "string",
+          description:
+            "Path to a JSON import map of { imports: [{ kind, apiName, package }] }",
+        },
+      } as const)
+      .check((args) => {
+        if (args.version !== "dev" && !isValidSemver(args.version)) {
+          throw new YargsCheckError(
+            "Version must be 'dev' or a valid semver version",
+          );
+        }
+        return true;
+      });
+  },
+  handler: async (args) => {
+    const command = await import("./handleOacGenerate.js");
+    await command.handleOacGenerate(args);
+  },
+};

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import typescript from "@osdk/cli.cmd.typescript";
+import typescript, { oacCommand } from "@osdk/cli.cmd.typescript";
 import type { CliCommonArgs } from "@osdk/cli.common";
 import { ExitProcessError, getYargsBase } from "@osdk/cli.common";
 import { consola } from "consola";
@@ -37,6 +37,7 @@ export async function cli(
     return await base
       .command(site)
       .command(widgetSet)
+      .command(oacCommand)
       .command({
         command: "unstable",
         aliases: ["experimental"],

--- a/packages/generator-converters.ontologyir/src/index.ts
+++ b/packages/generator-converters.ontologyir/src/index.ts
@@ -42,3 +42,9 @@ export {
   OntologyIrToFullMetadataConverter,
 } from "./OntologyIrToFullMetadataConverter.js";
 export { toStructFieldRid, toUuid } from "./ridUtils.js";
+export {
+  buildSemanticManifest,
+  type ImportedEntityKind,
+  type ImportedEntityMapping,
+  type SemanticManifest,
+} from "./semanticManifest.js";

--- a/packages/generator-converters.ontologyir/src/semanticManifest.test.ts
+++ b/packages/generator-converters.ontologyir/src/semanticManifest.test.ts
@@ -80,7 +80,7 @@ describe(buildSemanticManifest, () => {
       imports: [
         {
           kind: "valueType",
-          apiName: "headingValue",
+          apiName: "externalCategory",
           package: "@example/core-sdk",
         },
         {
@@ -92,18 +92,18 @@ describe(buildSemanticManifest, () => {
     });
 
     expect(manifest.valueTypes).toContainEqual({
-      apiName: "trackQuality",
+      apiName: "recordState",
       version: "1.0.0",
       narrowed: true,
     });
     expect(manifest.valueTypes).toContainEqual({
-      apiName: "headingValue",
+      apiName: "externalCategory",
       version: "1.0.0",
       narrowed: false,
     });
     expect(manifest.externalPackages).toEqual({
       "interface:imported.Parent": "@example/core-sdk",
-      "valueType:headingValue": "@example/core-sdk",
+      "valueType:externalCategory": "@example/core-sdk",
     });
     expect(manifest.interfaces.map((entry) => entry.apiName)).not.toContain(
       "imported.Parent",
@@ -177,8 +177,8 @@ describe(buildSemanticManifest, () => {
       sharedPropertyTypes: {},
     });
     const valueType: Ontologies.OntologyValueType = {
-      apiName: "maybeFlag",
-      displayName: "Maybe Flag",
+      apiName: "optionalToggle",
+      displayName: "Optional Toggle",
       rid: "ri.ontology.main.value-type.maybe-flag",
       fieldType: { type: "boolean" },
       version: "1.0.0",
@@ -190,7 +190,7 @@ describe(buildSemanticManifest, () => {
 
     const manifest = buildSemanticManifest({
       ...metadata,
-      valueTypes: { maybeFlag: valueType },
+      valueTypes: { optionalToggle: valueType },
     }, {
       packageName: "@example/sdk",
       packageVersion: "1.0.0",
@@ -198,7 +198,7 @@ describe(buildSemanticManifest, () => {
     });
 
     expect(manifest.valueTypes).toContainEqual({
-      apiName: "maybeFlag",
+      apiName: "optionalToggle",
       version: "1.0.0",
       narrowed: false,
     });

--- a/packages/generator-converters.ontologyir/src/semanticManifest.test.ts
+++ b/packages/generator-converters.ontologyir/src/semanticManifest.test.ts
@@ -15,6 +15,7 @@
  */
 
 import type { OntologyIr } from "@osdk/client.unstable";
+import type * as Ontologies from "@osdk/foundry.ontologies";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
@@ -30,41 +31,176 @@ function isOntologyIr(value: object): value is OntologyIr {
     && value.importedOntology != null;
 }
 
-describe(buildSemanticManifest, () => {
-  it("records interface-link operations and unknown implementers", () => {
-    const parsed: object = JSON.parse(
-      readFileSync(
-        fileURLToPath(
-          new URL("./__fixtures__/defenseLike/ontology.json", import.meta.url),
-        ),
-        "utf8",
+function envelopeMetadata(): Ontologies.OntologyFullMetadata {
+  const parsed: object = JSON.parse(
+    readFileSync(
+      fileURLToPath(
+        new URL("./__fixtures__/envelope/ontology.json", import.meta.url),
       ),
-    );
-    if (!isOntologyIr(parsed)) {
-      throw new Error("Invalid fixture");
-    }
-    const metadata = OntologyIrToFullMetadataConverter
-      .getFullMetadataFromEnvelope(parsed);
+      "utf8",
+    ),
+  );
+  if (!isOntologyIr(parsed)) {
+    throw new Error("Invalid fixture");
+  }
+  return OntologyIrToFullMetadataConverter.getFullMetadataFromEnvelope(parsed);
+}
 
-    const manifest = buildSemanticManifest(metadata, {
-      packageName: "@palantir/defense-ontology-sdk",
+describe(buildSemanticManifest, () => {
+  it("records interface-link operations from official action operations", () => {
+    const manifest = buildSemanticManifest(envelopeMetadata(), {
+      packageName: "@example/item-sdk",
       packageVersion: "0.0.0-dev",
       ontologyIdentity: "portable",
     });
 
     expect(
-      manifest.interfaces.find((entry) =>
-        entry.apiName === "defense.TrackedAsset"
-      ),
+      manifest.interfaces.find((entry) => entry.apiName === "local.Item"),
     ).toMatchObject({
-      implementerCompleteness: "unknown",
+      apiName: "local.Item",
+      extends: ["imported.Parent"],
     });
     expect(
-      manifest.actions.find((entry) =>
-        entry.apiName === "createTrackedAssetObservation"
-      )?.operations[0],
-    ).toMatchObject({
+      manifest.interfaces.find((entry) => entry.apiName === "local.Item"),
+    ).not.toHaveProperty("implementerCompleteness");
+    expect(
+      manifest.actions.find((entry) => entry.apiName === "createItemLink")
+        ?.operations,
+    ).toContainEqual({
       type: "createInterfaceLink",
+      target: "local.Item.observations",
+    });
+  });
+
+  it("sorts imports and records value-type narrowing", () => {
+    const manifest = buildSemanticManifest(envelopeMetadata(), {
+      packageName: "@example/item-sdk",
+      packageVersion: "0.0.0-dev",
+      ontologyIdentity: "portable",
+      imports: [
+        {
+          kind: "valueType",
+          apiName: "headingValue",
+          package: "@example/core-sdk",
+        },
+        {
+          kind: "interface",
+          apiName: "imported.Parent",
+          package: "@example/core-sdk",
+        },
+      ],
+    });
+
+    expect(manifest.valueTypes).toContainEqual({
+      apiName: "trackQuality",
+      version: "1.0.0",
+      narrowed: true,
+    });
+    expect(manifest.valueTypes).toContainEqual({
+      apiName: "headingValue",
+      version: "1.0.0",
+      narrowed: false,
+    });
+    expect(manifest.externalPackages).toEqual({
+      "interface:imported.Parent": "@example/core-sdk",
+      "valueType:headingValue": "@example/core-sdk",
+    });
+    expect(manifest.interfaces.map((entry) => entry.apiName)).not.toContain(
+      "imported.Parent",
+    );
+    expect(manifest.exclusions).toEqual([]);
+  });
+
+  it("records standard action operations", () => {
+    const metadata = OntologyIrToFullMetadataConverter.getFullMetadataFromIr({
+      actionTypes: {
+        createRestaurant: {
+          actionType: {
+            metadata: {
+              apiName: "createRestaurant",
+              displayMetadata: {
+                applyingMessage: [],
+                description: "Create a restaurant",
+                displayName: "Create restaurant",
+                successMessage: [],
+                typeClasses: [],
+              },
+              formContentOrdering: [],
+              parameterOrdering: [],
+              parameters: {},
+              sections: {},
+              status: { type: "active", active: {} },
+            },
+            actionTypeLogic: {
+              logic: {
+                rules: [{
+                  type: "addObjectRule",
+                  addObjectRule: {
+                    objectTypeId: "Restaurant",
+                    propertyValues: {},
+                    structFieldValues: {},
+                  },
+                }],
+              },
+              validation: {
+                actionTypeLevelValidation: { rules: {} },
+                parameterValidations: {},
+                sectionValidations: {},
+              },
+            },
+          },
+        },
+      },
+      interfaceTypes: {},
+      linkTypes: {},
+      objectTypes: {},
+      sharedPropertyTypes: {},
+    });
+
+    const manifest = buildSemanticManifest(metadata, {
+      packageName: "@example/sdk",
+      packageVersion: "1.0.0",
+      ontologyIdentity: "portable",
+    });
+
+    expect(manifest.actions[0]?.operations).toEqual([
+      { type: "createObject", target: "Restaurant" },
+    ]);
+  });
+
+  it("does not mark null-only boolean enums as narrowed", () => {
+    const metadata = OntologyIrToFullMetadataConverter.getFullMetadataFromIr({
+      actionTypes: {},
+      interfaceTypes: {},
+      linkTypes: {},
+      objectTypes: {},
+      sharedPropertyTypes: {},
+    });
+    const valueType: Ontologies.OntologyValueType = {
+      apiName: "maybeFlag",
+      displayName: "Maybe Flag",
+      rid: "ri.ontology.main.value-type.maybe-flag",
+      fieldType: { type: "boolean" },
+      version: "1.0.0",
+      constraints: [{
+        type: "enum",
+        options: [undefined],
+      }],
+    };
+
+    const manifest = buildSemanticManifest({
+      ...metadata,
+      valueTypes: { maybeFlag: valueType },
+    }, {
+      packageName: "@example/sdk",
+      packageVersion: "1.0.0",
+      ontologyIdentity: "portable",
+    });
+
+    expect(manifest.valueTypes).toContainEqual({
+      apiName: "maybeFlag",
+      version: "1.0.0",
+      narrowed: false,
     });
   });
 });

--- a/packages/generator-converters.ontologyir/src/semanticManifest.test.ts
+++ b/packages/generator-converters.ontologyir/src/semanticManifest.test.ts
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { OntologyIr } from "@osdk/client.unstable";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, it } from "vitest";
+import { OntologyIrToFullMetadataConverter } from "./OntologyIrToFullMetadataConverter.js";
+import { buildSemanticManifest } from "./semanticManifest.js";
+
+function isOntologyIr(value: object): value is OntologyIr {
+  return "ontology" in value
+    && typeof value.ontology === "object"
+    && value.ontology != null
+    && "importedOntology" in value
+    && typeof value.importedOntology === "object"
+    && value.importedOntology != null;
+}
+
+describe(buildSemanticManifest, () => {
+  it("records interface-link operations and unknown implementers", () => {
+    const parsed: object = JSON.parse(
+      readFileSync(
+        fileURLToPath(
+          new URL("./__fixtures__/defenseLike/ontology.json", import.meta.url),
+        ),
+        "utf8",
+      ),
+    );
+    if (!isOntologyIr(parsed)) {
+      throw new Error("Invalid fixture");
+    }
+    const metadata = OntologyIrToFullMetadataConverter
+      .getFullMetadataFromEnvelope(parsed);
+
+    const manifest = buildSemanticManifest(metadata, {
+      packageName: "@palantir/defense-ontology-sdk",
+      packageVersion: "0.0.0-dev",
+      ontologyIdentity: "portable",
+    });
+
+    expect(
+      manifest.interfaces.find((entry) =>
+        entry.apiName === "defense.TrackedAsset"
+      ),
+    ).toMatchObject({
+      implementerCompleteness: "unknown",
+    });
+    expect(
+      manifest.actions.find((entry) =>
+        entry.apiName === "createTrackedAssetObservation"
+      )?.operations[0],
+    ).toMatchObject({
+      type: "createInterfaceLink",
+    });
+  });
+});

--- a/packages/generator-converters.ontologyir/src/semanticManifest.ts
+++ b/packages/generator-converters.ontologyir/src/semanticManifest.ts
@@ -1,0 +1,173 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type * as Ontologies from "@osdk/foundry.ontologies";
+import type { OacActionOperation } from "./OntologyIrToFullMetadataConverter.js";
+
+export type ImportedEntityKind =
+  | "interface"
+  | "object"
+  | "sharedPropertyType"
+  | "valueType";
+
+export interface ImportedEntityMapping {
+  kind: ImportedEntityKind;
+  apiName: string;
+  package: string;
+}
+
+export interface SemanticManifest {
+  version: 1;
+  packageName?: string;
+  packageVersion: string;
+  ontologyIdentity: "portable" | "installationSpecific";
+  interfaces: Array<{
+    apiName: string;
+    extends: string[];
+    implementerCompleteness: "unknown" | "complete";
+    properties: Array<{
+      apiName: string;
+      required: boolean;
+      valueTypeApiName?: string;
+    }>;
+    links: Array<{
+      apiName: string;
+      cardinality: string;
+      target: string;
+    }>;
+  }>;
+  valueTypes: Array<{
+    apiName: string;
+    version: string;
+  }>;
+  actions: Array<{
+    apiName: string;
+    parameters: string[];
+    operations: ReadonlyArray<OacActionOperation>;
+  }>;
+  imports: ImportedEntityMapping[];
+}
+
+function compareApiName(
+  left: { apiName: string },
+  right: { apiName: string },
+): number {
+  return left.apiName.localeCompare(right.apiName);
+}
+
+function implementerCompletenessOf(
+  interfaceType: Ontologies.InterfaceType,
+): "unknown" | "complete" {
+  if (
+    "implementedByCompleteness" in interfaceType
+    && interfaceType.implementedByCompleteness === "complete"
+  ) {
+    return "complete";
+  }
+  return "unknown";
+}
+
+function actionOperationsOf(
+  action: Ontologies.ActionTypeV2,
+): ReadonlyArray<OacActionOperation> {
+  if (
+    "oacOperations" in action
+    && Array.isArray(action.oacOperations)
+  ) {
+    return action.oacOperations;
+  }
+  return [];
+}
+
+export function buildSemanticManifest(
+  metadata: Ontologies.OntologyFullMetadata,
+  options: {
+    packageName?: string;
+    packageVersion: string;
+    ontologyIdentity: "portable" | "installationSpecific";
+    imports?: ReadonlyArray<ImportedEntityMapping>;
+  },
+): SemanticManifest {
+  const imports = options.imports ?? [];
+  return {
+    version: 1,
+    ...(options.packageName ? { packageName: options.packageName } : {}),
+    packageVersion: options.packageVersion,
+    ontologyIdentity: options.ontologyIdentity,
+    interfaces: Object.values(metadata.interfaceTypes)
+      .map((interfaceType) => {
+        const properties = interfaceType.allPropertiesV2
+            && Object.keys(interfaceType.allPropertiesV2).length > 0
+          ? Object.values(interfaceType.allPropertiesV2).map((property) => ({
+            apiName: property.apiName,
+            required: property.requireImplementation,
+            ...(property.valueTypeApiName
+              ? { valueTypeApiName: property.valueTypeApiName }
+              : {}),
+          }))
+          : Object.values(
+            interfaceType.allProperties ?? interfaceType.properties,
+          ).map((property) => ({
+            apiName: property.apiName,
+            required: property.required,
+            ...(property.valueTypeApiName
+              ? { valueTypeApiName: property.valueTypeApiName }
+              : {}),
+          }));
+        const links = Object.values(
+          interfaceType.allLinks ?? interfaceType.links,
+        ).map((link) => ({
+          apiName: link.apiName,
+          cardinality: link.cardinality,
+          target: link.linkedEntityApiName.apiName,
+        }));
+        return {
+          apiName: interfaceType.apiName,
+          extends: [...interfaceType.extendsInterfaces].sort((a, b) =>
+            a.localeCompare(b)
+          ),
+          implementerCompleteness: implementerCompletenessOf(interfaceType),
+          properties: properties.sort(compareApiName),
+          links: links.sort(compareApiName),
+        };
+      })
+      .sort(compareApiName),
+    valueTypes: Object.values(metadata.valueTypes)
+      .map((valueType) => ({
+        apiName: valueType.apiName,
+        version: valueType.version,
+      }))
+      .sort(compareApiName),
+    actions: Object.values(metadata.actionTypes)
+      .map((action) => {
+        return {
+          apiName: action.apiName,
+          parameters: Object.keys(action.parameters).sort((a, b) =>
+            a.localeCompare(b)
+          ),
+          operations: actionOperationsOf(action),
+        };
+      })
+      .sort(compareApiName),
+    imports: [...imports].sort((left, right) => {
+      const kindOrder = left.kind.localeCompare(right.kind);
+      if (kindOrder !== 0) {
+        return kindOrder;
+      }
+      return left.apiName.localeCompare(right.apiName);
+    }),
+  };
+}

--- a/packages/generator-converters.ontologyir/src/semanticManifest.ts
+++ b/packages/generator-converters.ontologyir/src/semanticManifest.ts
@@ -15,7 +15,6 @@
  */
 
 import type * as Ontologies from "@osdk/foundry.ontologies";
-import type { OacActionOperation } from "./OntologyIrToFullMetadataConverter.js";
 
 export type ImportedEntityKind =
   | "interface"
@@ -29,15 +28,31 @@ export interface ImportedEntityMapping {
   package: string;
 }
 
+interface SemanticOperation {
+  type: string;
+  target: string;
+}
+
+type InterfaceLinkOperation =
+  | {
+    type: "createInterfaceLink";
+    interfaceTypeApiName: string;
+    interfaceLinkTypeApiName: string;
+  }
+  | {
+    type: "deleteInterfaceLink";
+    interfaceTypeApiName: string;
+    interfaceLinkTypeApiName: string;
+  };
+
 export interface SemanticManifest {
   version: 1;
-  packageName?: string;
+  packageName: string;
   packageVersion: string;
   ontologyIdentity: "portable" | "installationSpecific";
   interfaces: Array<{
     apiName: string;
     extends: string[];
-    implementerCompleteness: "unknown" | "complete";
     properties: Array<{
       apiName: string;
       required: boolean;
@@ -52,62 +67,175 @@ export interface SemanticManifest {
   valueTypes: Array<{
     apiName: string;
     version: string;
+    narrowed: boolean;
   }>;
   actions: Array<{
     apiName: string;
     parameters: string[];
-    operations: ReadonlyArray<OacActionOperation>;
+    operations: SemanticOperation[];
   }>;
   imports: ImportedEntityMapping[];
+  externalPackages: Record<string, string>;
+  exclusions: string[];
+}
+
+function compareText(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0;
 }
 
 function compareApiName(
   left: { apiName: string },
   right: { apiName: string },
 ): number {
-  return left.apiName.localeCompare(right.apiName);
+  return compareText(left.apiName, right.apiName);
 }
 
-function implementerCompletenessOf(
-  interfaceType: Ontologies.InterfaceType,
-): "unknown" | "complete" {
-  if (
-    "implementedByCompleteness" in interfaceType
-    && interfaceType.implementedByCompleteness === "complete"
-  ) {
-    return "complete";
-  }
-  return "unknown";
+function compareOperation(
+  left: SemanticOperation,
+  right: SemanticOperation,
+): number {
+  const typeComparison = compareText(left.type, right.type);
+  return typeComparison !== 0
+    ? typeComparison
+    : compareText(left.target, right.target);
 }
 
-function actionOperationsOf(
+function semanticOperations(
   action: Ontologies.ActionTypeV2,
-): ReadonlyArray<OacActionOperation> {
-  if (
-    "oacOperations" in action
-    && Array.isArray(action.oacOperations)
-  ) {
-    return action.oacOperations;
+): SemanticOperation[] {
+  const operations: Array<Ontologies.LogicRule | InterfaceLinkOperation> =
+    action.operations;
+  const result: SemanticOperation[] = [];
+  for (const operation of operations) {
+    switch (operation.type) {
+      case "createObject":
+      case "modifyObject":
+      case "deleteObject":
+        result.push({
+          type: operation.type,
+          target: operation.objectTypeApiName,
+        });
+        break;
+      case "createInterfaceObject":
+      case "modifyInterfaceObject":
+      case "deleteInterfaceObject":
+        result.push({
+          type: operation.type,
+          target: operation.interfaceTypeApiName,
+        });
+        break;
+      case "createLink":
+      case "deleteLink":
+        result.push(
+          {
+            type: operation.type,
+            target:
+              `${operation.aSideObjectTypeApiName}.${operation.linkTypeApiNameAtoB}`,
+          },
+          {
+            type: operation.type,
+            target:
+              `${operation.bSideObjectTypeApiName}.${operation.linkTypeApiNameBtoA}`,
+          },
+        );
+        break;
+      case "applyScenario":
+        for (const target of operation.objectTypeApiNames) {
+          result.push({ type: operation.type, target });
+        }
+        for (const linkGroup of operation.linkTypes) {
+          for (const linkType of linkGroup.linkTypes) {
+            result.push({
+              type: operation.type,
+              target: `${linkGroup.objectTypeApiName}.${linkType}`,
+            });
+          }
+        }
+        break;
+      case "createInterfaceLink":
+      case "deleteInterfaceLink":
+        result.push({
+          type: operation.type,
+          target:
+            `${operation.interfaceTypeApiName}.${operation.interfaceLinkTypeApiName}`,
+        });
+        break;
+    }
   }
-  return [];
+  return result.sort(compareOperation);
+}
+
+function usableFieldType(
+  fieldType: Ontologies.ValueTypeFieldType,
+): "string" | "boolean" | undefined {
+  if (fieldType.type === "string" || fieldType.type === "boolean") {
+    return fieldType.type;
+  }
+  if (fieldType.type === "array" && fieldType.subType != null) {
+    return usableFieldType(fieldType.subType);
+  }
+  return undefined;
+}
+
+function isNarrowed(valueType: Ontologies.OntologyValueType): boolean {
+  const usableType = usableFieldType(valueType.fieldType);
+  if (usableType == null || valueType.constraints.length !== 1) {
+    return false;
+  }
+
+  let constraint = valueType.constraints[0];
+  if (constraint.type === "array" && constraint.valueConstraint) {
+    constraint = constraint.valueConstraint;
+  }
+  if (constraint.type !== "enum" || constraint.options.length === 0) {
+    return false;
+  }
+
+  if (usableType === "string") {
+    return constraint.options.length > 0;
+  }
+
+  return constraint.options.some((value) => value === true || value === false);
 }
 
 export function buildSemanticManifest(
   metadata: Ontologies.OntologyFullMetadata,
   options: {
-    packageName?: string;
+    packageName: string;
     packageVersion: string;
     ontologyIdentity: "portable" | "installationSpecific";
     imports?: ReadonlyArray<ImportedEntityMapping>;
   },
 ): SemanticManifest {
-  const imports = options.imports ?? [];
+  const imports = [...(options.imports ?? [])].sort((left, right) => {
+    const kindComparison = compareText(left.kind, right.kind);
+    if (kindComparison !== 0) {
+      return kindComparison;
+    }
+    const apiNameComparison = compareText(left.apiName, right.apiName);
+    return apiNameComparison !== 0
+      ? apiNameComparison
+      : compareText(left.package, right.package);
+  });
+  const externalPackages = Object.fromEntries(
+    imports.map((entry) => [
+      `${entry.kind}:${entry.apiName}`,
+      entry.package,
+    ]),
+  );
+  const importedInterfaces = new Set(
+    imports.filter((entry) => entry.kind === "interface").map((entry) =>
+      entry.apiName
+    ),
+  );
+
   return {
     version: 1,
-    ...(options.packageName ? { packageName: options.packageName } : {}),
+    packageName: options.packageName,
     packageVersion: options.packageVersion,
     ontologyIdentity: options.ontologyIdentity,
     interfaces: Object.values(metadata.interfaceTypes)
+      .filter((interfaceType) => !importedInterfaces.has(interfaceType.apiName))
       .map((interfaceType) => {
         const properties = interfaceType.allPropertiesV2
             && Object.keys(interfaceType.allPropertiesV2).length > 0
@@ -136,10 +264,7 @@ export function buildSemanticManifest(
         }));
         return {
           apiName: interfaceType.apiName,
-          extends: [...interfaceType.extendsInterfaces].sort((a, b) =>
-            a.localeCompare(b)
-          ),
-          implementerCompleteness: implementerCompletenessOf(interfaceType),
+          extends: [...interfaceType.extendsInterfaces].sort(compareText),
           properties: properties.sort(compareApiName),
           links: links.sort(compareApiName),
         };
@@ -149,25 +274,18 @@ export function buildSemanticManifest(
       .map((valueType) => ({
         apiName: valueType.apiName,
         version: valueType.version,
+        narrowed: isNarrowed(valueType),
       }))
       .sort(compareApiName),
     actions: Object.values(metadata.actionTypes)
-      .map((action) => {
-        return {
-          apiName: action.apiName,
-          parameters: Object.keys(action.parameters).sort((a, b) =>
-            a.localeCompare(b)
-          ),
-          operations: actionOperationsOf(action),
-        };
-      })
+      .map((action) => ({
+        apiName: action.apiName,
+        parameters: Object.keys(action.parameters).sort(compareText),
+        operations: semanticOperations(action),
+      }))
       .sort(compareApiName),
-    imports: [...imports].sort((left, right) => {
-      const kindOrder = left.kind.localeCompare(right.kind);
-      if (kindOrder !== 0) {
-        return kindOrder;
-      }
-      return left.apiName.localeCompare(right.apiName);
-    }),
+    imports,
+    externalPackages,
+    exclusions: [],
   };
 }

--- a/packages/generator/src/GenerateContext/GenerateContext.ts
+++ b/packages/generator/src/GenerateContext/GenerateContext.ts
@@ -28,4 +28,5 @@ export interface GenerateContext {
   ontologyApiNamespace?: string | undefined;
   apiNamespacePackageMap?: Map<string, string>;
   forInternalUse?: boolean;
+  omitOntologyRid?: boolean;
 }

--- a/packages/generator/src/v2.0/generateClientSdkVersionTwoPointZero.test.ts
+++ b/packages/generator/src/v2.0/generateClientSdkVersionTwoPointZero.test.ts
@@ -1985,6 +1985,34 @@ describe("generator", () => {
         "$ontologyRid",
       );
     });
+
+    it("omits the ontology and branch identities for portable SDKs", async () => {
+      const BASE_PATH = "/foo";
+
+      await generateClientSdkVersionTwoPointZero(
+        TodoWireOntology,
+        "",
+        helper.minimalFiles,
+        BASE_PATH,
+        "module",
+        new Map(),
+        new Map(),
+        new Map(),
+        false,
+        [],
+        false,
+        true,
+      );
+
+      expect(helper.getFiles()["/foo/index.ts"]).not.toContain("$ontologyRid");
+      expect(helper.getFiles()["/foo/index.ts"]).not.toContain("$branch");
+      expect(helper.getFiles()["/foo/OntologyMetadata.ts"]).not.toContain(
+        "$ontologyRid",
+      );
+      expect(helper.getFiles()["/foo/OntologyMetadata.ts"]).not.toContain(
+        "$branch",
+      );
+    });
   });
 
   describe("exportOntologyMetadata", () => {

--- a/packages/generator/src/v2.0/generateClientSdkVersionTwoPointZero.ts
+++ b/packages/generator/src/v2.0/generateClientSdkVersionTwoPointZero.ts
@@ -41,6 +41,7 @@ export async function generateClientSdkVersionTwoPointZero(
   forInternalUse: boolean = false,
   fixedVersionQueryTypes: string[] = [],
   exportOntologyMetadata: boolean = false,
+  omitOntologyRid: boolean = false,
 ): Promise<void> {
   const importExt = ".js"; // turns out you can always use the extension
 
@@ -65,6 +66,7 @@ export async function generateClientSdkVersionTwoPointZero(
     outDir,
     forInternalUse,
     fixedVersionQueryTypes,
+    omitOntologyRid,
   };
 
   await generateRootIndexTsFile(ctx);

--- a/packages/generator/src/v2.0/generateMetadata.ts
+++ b/packages/generator/src/v2.0/generateMetadata.ts
@@ -24,7 +24,13 @@ const ExpectedOsdkVersion = "2.57.0";
 // END: THIS IS GENERATED CODE. DO NOT EDIT.
 
 export async function generateOntologyMetadataTypeFile(
-  { fs, outDir, ontology, ontologyApiNamespace }: GenerateContext,
+  {
+    fs,
+    outDir,
+    ontology,
+    ontologyApiNamespace,
+    omitOntologyRid,
+  }: GenerateContext,
   userAgent: string,
 ): Promise<void> {
   await fs.writeFile(
@@ -34,7 +40,7 @@ export async function generateOntologyMetadataTypeFile(
       export type $ExpectedClientVersion = "${ExpectedOsdkVersion}";
       export const $osdkMetadata = { extraUserAgent: "${userAgent}" };
       ${
-        ontologyApiNamespace == null
+        ontologyApiNamespace == null && !omitOntologyRid
           ? `
         export const $ontologyRid = "${ontology.ontology.rid}";
         /**

--- a/packages/generator/src/v2.0/generateRootIndexTsFile.ts
+++ b/packages/generator/src/v2.0/generateRootIndexTsFile.ts
@@ -20,7 +20,14 @@ import type { GenerateContext } from "../GenerateContext/GenerateContext.js";
 import { formatTs } from "../util/test/formatTs.js";
 
 export async function generateRootIndexTsFile(
-  { fs, outDir, importExt, ontologyApiNamespace, ontology }: GenerateContext,
+  {
+    fs,
+    outDir,
+    importExt,
+    ontologyApiNamespace,
+    ontology,
+    omitOntologyRid,
+  }: GenerateContext,
 ): Promise<void> {
   await fs.writeFile(
     path.join(outDir, "index.ts"),
@@ -43,7 +50,7 @@ export async function generateRootIndexTsFile(
         export * as $Queries from "./ontology/queries${importExt}";
         export { $osdkMetadata } from "./OntologyMetadata${importExt}";
         ${
-        ontologyApiNamespace == null
+        ontologyApiNamespace == null && !omitOntologyRid
           ? `export { $branch, $ontologyRid } from "./OntologyMetadata${importExt}";`
           : ``
       }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -310,13 +310,13 @@ importers:
     dependencies:
       '@docusaurus/core':
         specifier: 3.4.0
-        version: 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
+        version: 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
       '@docusaurus/plugin-content-docs':
         specifier: 3.4.0
-        version: 3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
+        version: 3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
       '@docusaurus/preset-classic':
         specifier: 3.4.0
-        version: 3.4.0(@algolia/client-search@5.46.0)(@rspack/core@1.6.7)(@swc/core@1.7.39)(@types/react@18.3.24)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.3)(typescript@5.8.3)
+        version: 3.4.0(@algolia/client-search@5.46.0)(@rspack/core@1.6.7)(@swc/core@1.7.39)(@types/react@18.3.24)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.3)(typescript@5.5.4)
       '@mdx-js/react':
         specifier: ^3.0.0
         version: 3.1.1(@types/react@18.3.24)(react@18.3.1)
@@ -1970,12 +1970,18 @@ importers:
       '@osdk/cli.common':
         specifier: workspace:~
         version: link:../cli.common
+      '@osdk/client.unstable':
+        specifier: workspace:~
+        version: link:../client.unstable
       '@osdk/foundry.ontologies':
         specifier: catalog:foundry-platform-typescript
         version: 2.73.0
       '@osdk/generator':
         specifier: workspace:~
         version: link:../generator
+      '@osdk/generator-converters.ontologyir':
+        specifier: workspace:~
+        version: link:../generator-converters.ontologyir
       '@osdk/shared.client.impl':
         specifier: workspace:~
         version: link:../shared.client.impl
@@ -8507,7 +8513,7 @@ packages:
 
   '@expo/bunyan@4.0.1':
     resolution: {integrity: sha512-+Lla7nYSiHZirgK+U/uYzsLv/X+HaJienbD5AKX1UQZHYfWaP+9uuQluRB4GrEVWF0GZ7vEVp/jzaOT9k/SQlg==}
-    engines: {'0': node >=0.10.0}
+    engines: {node: '>=0.10.0'}
 
   '@expo/cli@0.22.26':
     resolution: {integrity: sha512-I689wc8Fn/AX7aUGiwrh3HnssiORMJtR2fpksX+JIe8Cj/EDleblYMSwRPd0025wrwOV9UN1KM/RuEt/QjCS3Q==}
@@ -24177,7 +24183,7 @@ snapshots:
     transitivePeerDependencies:
       - '@algolia/client-search'
 
-  '@docusaurus/core@3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)':
+  '@docusaurus/core@3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)':
     dependencies:
       '@babel/core': 7.28.4
       '@babel/generator': 7.28.3
@@ -24191,10 +24197,10 @@ snapshots:
       '@babel/traverse': 7.28.4
       '@docusaurus/cssnano-preset': 3.4.0
       '@docusaurus/logger': 3.4.0
-      '@docusaurus/mdx-loader': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
-      '@docusaurus/utils': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(typescript@5.8.3)
+      '@docusaurus/mdx-loader': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
+      '@docusaurus/utils': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(typescript@5.5.4)
       '@docusaurus/utils-common': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
-      '@docusaurus/utils-validation': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(typescript@5.8.3)
+      '@docusaurus/utils-validation': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(typescript@5.5.4)
       autoprefixer: 10.4.22(postcss@8.5.6)
       babel-loader: 9.2.1(@babel/core@7.28.4)(webpack@5.106.1(@swc/core@1.7.39)(esbuild@0.27.3))
       babel-plugin-dynamic-import-node: 2.3.3
@@ -24225,10 +24231,10 @@ snapshots:
       mini-css-extract-plugin: 2.9.4(webpack@5.106.1(@swc/core@1.7.39)(esbuild@0.27.3))
       p-map: 4.0.0
       postcss: 8.5.6
-      postcss-loader: 7.3.4(postcss@8.5.6)(typescript@5.8.3)(webpack@5.106.1(@swc/core@1.7.39)(esbuild@0.27.3))
+      postcss-loader: 7.3.4(postcss@8.5.6)(typescript@5.5.4)(webpack@5.106.1(@swc/core@1.7.39)(esbuild@0.27.3))
       prompts: 2.4.2
       react: 18.3.1
-      react-dev-utils: 12.0.1(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3)(webpack@5.106.1(@swc/core@1.7.39)(esbuild@0.27.3))
+      react-dev-utils: 12.0.1(eslint@9.35.0(jiti@2.5.1))(typescript@5.5.4)(webpack@5.106.1(@swc/core@1.7.39)(esbuild@0.27.3))
       react-dom: 18.3.1(react@18.3.1)
       react-helmet-async: 1.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-loadable: '@docusaurus/react-loadable@6.0.0(react@18.3.1)'
@@ -24280,11 +24286,11 @@ snapshots:
       chalk: 4.1.2
       tslib: 2.8.1
 
-  '@docusaurus/mdx-loader@3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)':
+  '@docusaurus/mdx-loader@3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)':
     dependencies:
       '@docusaurus/logger': 3.4.0
-      '@docusaurus/utils': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(typescript@5.8.3)
-      '@docusaurus/utils-validation': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(typescript@5.8.3)
+      '@docusaurus/utils': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(typescript@5.5.4)
+      '@docusaurus/utils-validation': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(typescript@5.5.4)
       '@mdx-js/mdx': 3.1.1
       '@slorber/remark-comment': 1.0.0
       escape-html: 1.0.3
@@ -24335,15 +24341,15 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/plugin-content-blog@3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)':
+  '@docusaurus/plugin-content-blog@3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)':
     dependencies:
-      '@docusaurus/core': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
+      '@docusaurus/core': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
       '@docusaurus/logger': 3.4.0
-      '@docusaurus/mdx-loader': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
+      '@docusaurus/mdx-loader': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
       '@docusaurus/types': 3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/utils': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(typescript@5.8.3)
+      '@docusaurus/utils': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(typescript@5.5.4)
       '@docusaurus/utils-common': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
-      '@docusaurus/utils-validation': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(typescript@5.8.3)
+      '@docusaurus/utils-validation': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(typescript@5.5.4)
       cheerio: 1.0.0-rc.12
       feed: 4.2.2
       fs-extra: 11.3.1
@@ -24374,16 +24380,16 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-content-docs@3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)':
+  '@docusaurus/plugin-content-docs@3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)':
     dependencies:
-      '@docusaurus/core': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
+      '@docusaurus/core': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
       '@docusaurus/logger': 3.4.0
-      '@docusaurus/mdx-loader': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
+      '@docusaurus/mdx-loader': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
       '@docusaurus/module-type-aliases': 3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/types': 3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/utils': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(typescript@5.8.3)
+      '@docusaurus/utils': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(typescript@5.5.4)
       '@docusaurus/utils-common': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
-      '@docusaurus/utils-validation': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(typescript@5.8.3)
+      '@docusaurus/utils-validation': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(typescript@5.5.4)
       '@types/react-router-config': 5.0.11
       combine-promises: 1.2.0
       fs-extra: 11.3.1
@@ -24412,13 +24418,13 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-content-pages@3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)':
+  '@docusaurus/plugin-content-pages@3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)':
     dependencies:
-      '@docusaurus/core': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
-      '@docusaurus/mdx-loader': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
+      '@docusaurus/core': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
+      '@docusaurus/mdx-loader': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
       '@docusaurus/types': 3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/utils': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(typescript@5.8.3)
-      '@docusaurus/utils-validation': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(typescript@5.8.3)
+      '@docusaurus/utils': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(typescript@5.5.4)
+      '@docusaurus/utils-validation': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(typescript@5.5.4)
       fs-extra: 11.3.1
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -24442,11 +24448,11 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-debug@3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)':
+  '@docusaurus/plugin-debug@3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)':
     dependencies:
-      '@docusaurus/core': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
+      '@docusaurus/core': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
       '@docusaurus/types': 3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/utils': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(typescript@5.8.3)
+      '@docusaurus/utils': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(typescript@5.5.4)
       fs-extra: 11.3.1
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -24470,11 +24476,11 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-google-analytics@3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)':
+  '@docusaurus/plugin-google-analytics@3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)':
     dependencies:
-      '@docusaurus/core': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
+      '@docusaurus/core': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
       '@docusaurus/types': 3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/utils-validation': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(typescript@5.8.3)
+      '@docusaurus/utils-validation': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(typescript@5.5.4)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       tslib: 2.8.1
@@ -24496,11 +24502,11 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-google-gtag@3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)':
+  '@docusaurus/plugin-google-gtag@3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)':
     dependencies:
-      '@docusaurus/core': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
+      '@docusaurus/core': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
       '@docusaurus/types': 3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/utils-validation': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(typescript@5.8.3)
+      '@docusaurus/utils-validation': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(typescript@5.5.4)
       '@types/gtag.js': 0.0.12
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -24523,11 +24529,11 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-google-tag-manager@3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)':
+  '@docusaurus/plugin-google-tag-manager@3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)':
     dependencies:
-      '@docusaurus/core': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
+      '@docusaurus/core': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
       '@docusaurus/types': 3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/utils-validation': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(typescript@5.8.3)
+      '@docusaurus/utils-validation': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(typescript@5.5.4)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       tslib: 2.8.1
@@ -24549,14 +24555,14 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-sitemap@3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)':
+  '@docusaurus/plugin-sitemap@3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)':
     dependencies:
-      '@docusaurus/core': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
+      '@docusaurus/core': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
       '@docusaurus/logger': 3.4.0
       '@docusaurus/types': 3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/utils': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(typescript@5.8.3)
+      '@docusaurus/utils': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(typescript@5.5.4)
       '@docusaurus/utils-common': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
-      '@docusaurus/utils-validation': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(typescript@5.8.3)
+      '@docusaurus/utils-validation': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(typescript@5.5.4)
       fs-extra: 11.3.1
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -24580,20 +24586,20 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/preset-classic@3.4.0(@algolia/client-search@5.46.0)(@rspack/core@1.6.7)(@swc/core@1.7.39)(@types/react@18.3.24)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.3)(typescript@5.8.3)':
+  '@docusaurus/preset-classic@3.4.0(@algolia/client-search@5.46.0)(@rspack/core@1.6.7)(@swc/core@1.7.39)(@types/react@18.3.24)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.3)(typescript@5.5.4)':
     dependencies:
-      '@docusaurus/core': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
-      '@docusaurus/plugin-content-blog': 3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
-      '@docusaurus/plugin-content-docs': 3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
-      '@docusaurus/plugin-content-pages': 3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
-      '@docusaurus/plugin-debug': 3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
-      '@docusaurus/plugin-google-analytics': 3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
-      '@docusaurus/plugin-google-gtag': 3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
-      '@docusaurus/plugin-google-tag-manager': 3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
-      '@docusaurus/plugin-sitemap': 3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
-      '@docusaurus/theme-classic': 3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(@types/react@18.3.24)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
-      '@docusaurus/theme-common': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
-      '@docusaurus/theme-search-algolia': 3.4.0(@algolia/client-search@5.46.0)(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@rspack/core@1.6.7)(@swc/core@1.7.39)(@types/react@18.3.24)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.3)(typescript@5.8.3)
+      '@docusaurus/core': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
+      '@docusaurus/plugin-content-blog': 3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
+      '@docusaurus/plugin-content-docs': 3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
+      '@docusaurus/plugin-content-pages': 3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
+      '@docusaurus/plugin-debug': 3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
+      '@docusaurus/plugin-google-analytics': 3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
+      '@docusaurus/plugin-google-gtag': 3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
+      '@docusaurus/plugin-google-tag-manager': 3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
+      '@docusaurus/plugin-sitemap': 3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
+      '@docusaurus/theme-classic': 3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(@types/react@18.3.24)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
+      '@docusaurus/theme-common': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
+      '@docusaurus/theme-search-algolia': 3.4.0(@algolia/client-search@5.46.0)(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@rspack/core@1.6.7)(@swc/core@1.7.39)(@types/react@18.3.24)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.3)(typescript@5.5.4)
       '@docusaurus/types': 3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -24623,20 +24629,20 @@ snapshots:
       '@types/react': 18.3.24
       react: 18.3.1
 
-  '@docusaurus/theme-classic@3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(@types/react@18.3.24)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)':
+  '@docusaurus/theme-classic@3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(@types/react@18.3.24)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)':
     dependencies:
-      '@docusaurus/core': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
-      '@docusaurus/mdx-loader': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
+      '@docusaurus/core': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
+      '@docusaurus/mdx-loader': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
       '@docusaurus/module-type-aliases': 3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/plugin-content-blog': 3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
-      '@docusaurus/plugin-content-docs': 3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
-      '@docusaurus/plugin-content-pages': 3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
-      '@docusaurus/theme-common': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
+      '@docusaurus/plugin-content-blog': 3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
+      '@docusaurus/plugin-content-docs': 3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
+      '@docusaurus/plugin-content-pages': 3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
+      '@docusaurus/theme-common': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
       '@docusaurus/theme-translations': 3.4.0
       '@docusaurus/types': 3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/utils': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(typescript@5.8.3)
+      '@docusaurus/utils': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(typescript@5.5.4)
       '@docusaurus/utils-common': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
-      '@docusaurus/utils-validation': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(typescript@5.8.3)
+      '@docusaurus/utils-validation': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(typescript@5.5.4)
       '@mdx-js/react': 3.1.1(@types/react@18.3.24)(react@18.3.1)
       clsx: 2.1.1
       copy-text-to-clipboard: 3.2.2
@@ -24671,14 +24677,14 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/theme-common@3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)':
+  '@docusaurus/theme-common@3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)':
     dependencies:
-      '@docusaurus/mdx-loader': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
+      '@docusaurus/mdx-loader': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
       '@docusaurus/module-type-aliases': 3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/plugin-content-blog': 3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
-      '@docusaurus/plugin-content-docs': 3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
-      '@docusaurus/plugin-content-pages': 3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
-      '@docusaurus/utils': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(typescript@5.8.3)
+      '@docusaurus/plugin-content-blog': 3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
+      '@docusaurus/plugin-content-docs': 3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
+      '@docusaurus/plugin-content-pages': 3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
+      '@docusaurus/utils': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(typescript@5.5.4)
       '@docusaurus/utils-common': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@types/history': 4.7.11
       '@types/react': 18.3.24
@@ -24709,16 +24715,16 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/theme-search-algolia@3.4.0(@algolia/client-search@5.46.0)(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@rspack/core@1.6.7)(@swc/core@1.7.39)(@types/react@18.3.24)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.3)(typescript@5.8.3)':
+  '@docusaurus/theme-search-algolia@3.4.0(@algolia/client-search@5.46.0)(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@rspack/core@1.6.7)(@swc/core@1.7.39)(@types/react@18.3.24)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.3)(typescript@5.5.4)':
     dependencies:
       '@docsearch/react': 3.9.0(@algolia/client-search@5.46.0)(@types/react@18.3.24)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.3)
-      '@docusaurus/core': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
+      '@docusaurus/core': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
       '@docusaurus/logger': 3.4.0
-      '@docusaurus/plugin-content-docs': 3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
-      '@docusaurus/theme-common': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
+      '@docusaurus/plugin-content-docs': 3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
+      '@docusaurus/theme-common': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
       '@docusaurus/theme-translations': 3.4.0
-      '@docusaurus/utils': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(typescript@5.8.3)
-      '@docusaurus/utils-validation': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(typescript@5.8.3)
+      '@docusaurus/utils': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(typescript@5.5.4)
+      '@docusaurus/utils-validation': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(typescript@5.5.4)
       algoliasearch: 4.25.3
       algoliasearch-helper: 3.26.1(algoliasearch@4.25.3)
       clsx: 2.1.1
@@ -24782,10 +24788,10 @@ snapshots:
     optionalDependencies:
       '@docusaurus/types': 3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
 
-  '@docusaurus/utils-validation@3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(typescript@5.8.3)':
+  '@docusaurus/utils-validation@3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(typescript@5.5.4)':
     dependencies:
       '@docusaurus/logger': 3.4.0
-      '@docusaurus/utils': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(typescript@5.8.3)
+      '@docusaurus/utils': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(typescript@5.5.4)
       '@docusaurus/utils-common': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       fs-extra: 11.3.1
       joi: 17.13.3
@@ -24801,11 +24807,11 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/utils@3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(typescript@5.8.3)':
+  '@docusaurus/utils@3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(typescript@5.5.4)':
     dependencies:
       '@docusaurus/logger': 3.4.0
       '@docusaurus/utils-common': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
-      '@svgr/webpack': 8.1.0(typescript@5.8.3)
+      '@svgr/webpack': 8.1.0(typescript@5.5.4)
       escape-string-regexp: 4.0.0
       file-loader: 6.2.0(webpack@5.106.1(@swc/core@1.7.39)(esbuild@0.27.3))
       fs-extra: 11.3.1
@@ -28850,17 +28856,6 @@ snapshots:
       - supports-color
       - typescript
 
-  '@svgr/core@8.1.0(typescript@5.8.3)':
-    dependencies:
-      '@babel/core': 7.28.4
-      '@svgr/babel-preset': 8.1.0(@babel/core@7.28.4)
-      camelcase: 6.3.0
-      cosmiconfig: 8.3.6(typescript@5.8.3)
-      snake-case: 3.0.4
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
-
   '@svgr/hast-util-to-babel-ast@8.0.0':
     dependencies:
       '@babel/types': 7.28.4
@@ -28876,16 +28871,6 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@svgr/plugin-jsx@8.1.0(@svgr/core@8.1.0(typescript@5.8.3))':
-    dependencies:
-      '@babel/core': 7.28.4
-      '@svgr/babel-preset': 8.1.0(@babel/core@7.28.4)
-      '@svgr/core': 8.1.0(typescript@5.8.3)
-      '@svgr/hast-util-to-babel-ast': 8.0.0
-      svg-parser: 2.0.4
-    transitivePeerDependencies:
-      - supports-color
-
   '@svgr/plugin-svgo@8.1.0(@svgr/core@8.1.0(typescript@5.5.4))(typescript@5.5.4)':
     dependencies:
       '@svgr/core': 8.1.0(typescript@5.5.4)
@@ -28895,25 +28880,16 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
-  '@svgr/plugin-svgo@8.1.0(@svgr/core@8.1.0(typescript@5.8.3))(typescript@5.8.3)':
-    dependencies:
-      '@svgr/core': 8.1.0(typescript@5.8.3)
-      cosmiconfig: 8.3.6(typescript@5.8.3)
-      deepmerge: 4.3.1
-      svgo: 3.3.3
-    transitivePeerDependencies:
-      - typescript
-
-  '@svgr/webpack@8.1.0(typescript@5.8.3)':
+  '@svgr/webpack@8.1.0(typescript@5.5.4)':
     dependencies:
       '@babel/core': 7.28.4
       '@babel/plugin-transform-react-constant-elements': 7.27.1(@babel/core@7.28.4)
       '@babel/preset-env': 7.26.0(@babel/core@7.28.4)
       '@babel/preset-react': 7.25.9(@babel/core@7.28.4)
       '@babel/preset-typescript': 7.27.1(@babel/core@7.28.4)
-      '@svgr/core': 8.1.0(typescript@5.8.3)
-      '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0(typescript@5.8.3))
-      '@svgr/plugin-svgo': 8.1.0(@svgr/core@8.1.0(typescript@5.8.3))(typescript@5.8.3)
+      '@svgr/core': 8.1.0(typescript@5.5.4)
+      '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0(typescript@5.5.4))
+      '@svgr/plugin-svgo': 8.1.0(@svgr/core@8.1.0(typescript@5.5.4))(typescript@5.5.4)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -32050,15 +32026,6 @@ snapshots:
     optionalDependencies:
       typescript: 5.5.4
 
-  cosmiconfig@8.3.6(typescript@5.8.3):
-    dependencies:
-      import-fresh: 3.3.1
-      js-yaml: 4.1.1
-      parse-json: 5.2.0
-      path-type: 4.0.0
-    optionalDependencies:
-      typescript: 5.8.3
-
   crc-32@1.2.2: {}
 
   crc32-stream@6.0.0:
@@ -33984,7 +33951,7 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
-  fork-ts-checker-webpack-plugin@6.5.3(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3)(webpack@5.106.1(@swc/core@1.7.39)(esbuild@0.27.3)):
+  fork-ts-checker-webpack-plugin@6.5.3(eslint@9.35.0(jiti@2.5.1))(typescript@5.5.4)(webpack@5.106.1(@swc/core@1.7.39)(esbuild@0.27.3)):
     dependencies:
       '@babel/code-frame': 7.27.1
       '@types/json-schema': 7.0.15
@@ -33999,7 +33966,7 @@ snapshots:
       schema-utils: 2.7.0
       semver: 7.7.4
       tapable: 1.1.3
-      typescript: 5.8.3
+      typescript: 5.5.4
       webpack: 5.106.1(@swc/core@1.7.39)(esbuild@0.27.3)
     optionalDependencies:
       eslint: 9.35.0(jiti@2.5.1)
@@ -38131,9 +38098,9 @@ snapshots:
       tsx: 4.20.5
       yaml: 2.9.0
 
-  postcss-loader@7.3.4(postcss@8.5.6)(typescript@5.8.3)(webpack@5.106.1(@swc/core@1.7.39)(esbuild@0.27.3)):
+  postcss-loader@7.3.4(postcss@8.5.6)(typescript@5.5.4)(webpack@5.106.1(@swc/core@1.7.39)(esbuild@0.27.3)):
     dependencies:
-      cosmiconfig: 8.3.6(typescript@5.8.3)
+      cosmiconfig: 8.3.6(typescript@5.5.4)
       jiti: 1.21.7
       postcss: 8.5.6
       semver: 7.7.4
@@ -38847,7 +38814,7 @@ snapshots:
       date-fns: 2.30.0
       react: 18.3.1
 
-  react-dev-utils@12.0.1(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3)(webpack@5.106.1(@swc/core@1.7.39)(esbuild@0.27.3)):
+  react-dev-utils@12.0.1(eslint@9.35.0(jiti@2.5.1))(typescript@5.5.4)(webpack@5.106.1(@swc/core@1.7.39)(esbuild@0.27.3)):
     dependencies:
       '@babel/code-frame': 7.27.1
       address: 1.2.2
@@ -38858,7 +38825,7 @@ snapshots:
       escape-string-regexp: 4.0.0
       filesize: 8.0.7
       find-up: 5.0.0
-      fork-ts-checker-webpack-plugin: 6.5.3(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3)(webpack@5.106.1(@swc/core@1.7.39)(esbuild@0.27.3))
+      fork-ts-checker-webpack-plugin: 6.5.3(eslint@9.35.0(jiti@2.5.1))(typescript@5.5.4)(webpack@5.106.1(@swc/core@1.7.39)(esbuild@0.27.3))
       global-modules: 2.0.0
       globby: 11.1.0
       gzip-size: 6.0.0
@@ -38875,7 +38842,7 @@ snapshots:
       text-table: 0.2.0
       webpack: 5.106.1(@swc/core@1.7.39)(esbuild@0.27.3)
     optionalDependencies:
-      typescript: 5.8.3
+      typescript: 5.5.4
     transitivePeerDependencies:
       - eslint
       - supports-color
@@ -41412,7 +41379,8 @@ snapshots:
 
   typescript@5.8.2: {}
 
-  typescript@5.8.3: {}
+  typescript@5.8.3:
+    optional: true
 
   typewise-core@1.2.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1997,6 +1997,9 @@ importers:
       tslib:
         specifier: ^2.8.1
         version: 2.8.1
+      yaml:
+        specifier: ^2.8.1
+        version: 2.8.3
       yargs:
         specifier: ^17.7.2
         version: 17.7.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -310,13 +310,13 @@ importers:
     dependencies:
       '@docusaurus/core':
         specifier: 3.4.0
-        version: 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
+        version: 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
       '@docusaurus/plugin-content-docs':
         specifier: 3.4.0
-        version: 3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
+        version: 3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
       '@docusaurus/preset-classic':
         specifier: 3.4.0
-        version: 3.4.0(@algolia/client-search@5.46.0)(@rspack/core@1.6.7)(@swc/core@1.7.39)(@types/react@18.3.24)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.3)(typescript@5.5.4)
+        version: 3.4.0(@algolia/client-search@5.46.0)(@rspack/core@1.6.7)(@swc/core@1.7.39)(@types/react@18.3.24)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.3)(typescript@5.8.3)
       '@mdx-js/react':
         specifier: ^3.0.0
         version: 3.1.1(@types/react@18.3.24)(react@18.3.1)
@@ -8516,7 +8516,7 @@ packages:
 
   '@expo/bunyan@4.0.1':
     resolution: {integrity: sha512-+Lla7nYSiHZirgK+U/uYzsLv/X+HaJienbD5AKX1UQZHYfWaP+9uuQluRB4GrEVWF0GZ7vEVp/jzaOT9k/SQlg==}
-    engines: {node: '>=0.10.0'}
+    engines: {'0': node >=0.10.0}
 
   '@expo/cli@0.22.26':
     resolution: {integrity: sha512-I689wc8Fn/AX7aUGiwrh3HnssiORMJtR2fpksX+JIe8Cj/EDleblYMSwRPd0025wrwOV9UN1KM/RuEt/QjCS3Q==}
@@ -24186,7 +24186,7 @@ snapshots:
     transitivePeerDependencies:
       - '@algolia/client-search'
 
-  '@docusaurus/core@3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)':
+  '@docusaurus/core@3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)':
     dependencies:
       '@babel/core': 7.28.4
       '@babel/generator': 7.28.3
@@ -24200,10 +24200,10 @@ snapshots:
       '@babel/traverse': 7.28.4
       '@docusaurus/cssnano-preset': 3.4.0
       '@docusaurus/logger': 3.4.0
-      '@docusaurus/mdx-loader': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
-      '@docusaurus/utils': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(typescript@5.5.4)
+      '@docusaurus/mdx-loader': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
+      '@docusaurus/utils': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(typescript@5.8.3)
       '@docusaurus/utils-common': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
-      '@docusaurus/utils-validation': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(typescript@5.5.4)
+      '@docusaurus/utils-validation': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(typescript@5.8.3)
       autoprefixer: 10.4.22(postcss@8.5.6)
       babel-loader: 9.2.1(@babel/core@7.28.4)(webpack@5.106.1(@swc/core@1.7.39)(esbuild@0.27.3))
       babel-plugin-dynamic-import-node: 2.3.3
@@ -24234,10 +24234,10 @@ snapshots:
       mini-css-extract-plugin: 2.9.4(webpack@5.106.1(@swc/core@1.7.39)(esbuild@0.27.3))
       p-map: 4.0.0
       postcss: 8.5.6
-      postcss-loader: 7.3.4(postcss@8.5.6)(typescript@5.5.4)(webpack@5.106.1(@swc/core@1.7.39)(esbuild@0.27.3))
+      postcss-loader: 7.3.4(postcss@8.5.6)(typescript@5.8.3)(webpack@5.106.1(@swc/core@1.7.39)(esbuild@0.27.3))
       prompts: 2.4.2
       react: 18.3.1
-      react-dev-utils: 12.0.1(eslint@9.35.0(jiti@2.5.1))(typescript@5.5.4)(webpack@5.106.1(@swc/core@1.7.39)(esbuild@0.27.3))
+      react-dev-utils: 12.0.1(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3)(webpack@5.106.1(@swc/core@1.7.39)(esbuild@0.27.3))
       react-dom: 18.3.1(react@18.3.1)
       react-helmet-async: 1.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-loadable: '@docusaurus/react-loadable@6.0.0(react@18.3.1)'
@@ -24289,11 +24289,11 @@ snapshots:
       chalk: 4.1.2
       tslib: 2.8.1
 
-  '@docusaurus/mdx-loader@3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)':
+  '@docusaurus/mdx-loader@3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)':
     dependencies:
       '@docusaurus/logger': 3.4.0
-      '@docusaurus/utils': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(typescript@5.5.4)
-      '@docusaurus/utils-validation': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(typescript@5.5.4)
+      '@docusaurus/utils': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(typescript@5.8.3)
+      '@docusaurus/utils-validation': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(typescript@5.8.3)
       '@mdx-js/mdx': 3.1.1
       '@slorber/remark-comment': 1.0.0
       escape-html: 1.0.3
@@ -24344,15 +24344,15 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/plugin-content-blog@3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)':
+  '@docusaurus/plugin-content-blog@3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)':
     dependencies:
-      '@docusaurus/core': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
+      '@docusaurus/core': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
       '@docusaurus/logger': 3.4.0
-      '@docusaurus/mdx-loader': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
+      '@docusaurus/mdx-loader': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
       '@docusaurus/types': 3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/utils': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(typescript@5.5.4)
+      '@docusaurus/utils': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(typescript@5.8.3)
       '@docusaurus/utils-common': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
-      '@docusaurus/utils-validation': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(typescript@5.5.4)
+      '@docusaurus/utils-validation': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(typescript@5.8.3)
       cheerio: 1.0.0-rc.12
       feed: 4.2.2
       fs-extra: 11.3.1
@@ -24383,16 +24383,16 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-content-docs@3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)':
+  '@docusaurus/plugin-content-docs@3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)':
     dependencies:
-      '@docusaurus/core': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
+      '@docusaurus/core': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
       '@docusaurus/logger': 3.4.0
-      '@docusaurus/mdx-loader': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
+      '@docusaurus/mdx-loader': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
       '@docusaurus/module-type-aliases': 3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/types': 3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/utils': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(typescript@5.5.4)
+      '@docusaurus/utils': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(typescript@5.8.3)
       '@docusaurus/utils-common': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
-      '@docusaurus/utils-validation': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(typescript@5.5.4)
+      '@docusaurus/utils-validation': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(typescript@5.8.3)
       '@types/react-router-config': 5.0.11
       combine-promises: 1.2.0
       fs-extra: 11.3.1
@@ -24421,13 +24421,13 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-content-pages@3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)':
+  '@docusaurus/plugin-content-pages@3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)':
     dependencies:
-      '@docusaurus/core': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
-      '@docusaurus/mdx-loader': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
+      '@docusaurus/core': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
+      '@docusaurus/mdx-loader': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
       '@docusaurus/types': 3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/utils': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(typescript@5.5.4)
-      '@docusaurus/utils-validation': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(typescript@5.5.4)
+      '@docusaurus/utils': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(typescript@5.8.3)
+      '@docusaurus/utils-validation': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(typescript@5.8.3)
       fs-extra: 11.3.1
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -24451,11 +24451,11 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-debug@3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)':
+  '@docusaurus/plugin-debug@3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)':
     dependencies:
-      '@docusaurus/core': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
+      '@docusaurus/core': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
       '@docusaurus/types': 3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/utils': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(typescript@5.5.4)
+      '@docusaurus/utils': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(typescript@5.8.3)
       fs-extra: 11.3.1
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -24479,11 +24479,11 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-google-analytics@3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)':
+  '@docusaurus/plugin-google-analytics@3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)':
     dependencies:
-      '@docusaurus/core': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
+      '@docusaurus/core': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
       '@docusaurus/types': 3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/utils-validation': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(typescript@5.5.4)
+      '@docusaurus/utils-validation': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(typescript@5.8.3)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       tslib: 2.8.1
@@ -24505,11 +24505,11 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-google-gtag@3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)':
+  '@docusaurus/plugin-google-gtag@3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)':
     dependencies:
-      '@docusaurus/core': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
+      '@docusaurus/core': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
       '@docusaurus/types': 3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/utils-validation': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(typescript@5.5.4)
+      '@docusaurus/utils-validation': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(typescript@5.8.3)
       '@types/gtag.js': 0.0.12
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -24532,11 +24532,11 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-google-tag-manager@3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)':
+  '@docusaurus/plugin-google-tag-manager@3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)':
     dependencies:
-      '@docusaurus/core': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
+      '@docusaurus/core': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
       '@docusaurus/types': 3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/utils-validation': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(typescript@5.5.4)
+      '@docusaurus/utils-validation': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(typescript@5.8.3)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
       tslib: 2.8.1
@@ -24558,14 +24558,14 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/plugin-sitemap@3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)':
+  '@docusaurus/plugin-sitemap@3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)':
     dependencies:
-      '@docusaurus/core': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
+      '@docusaurus/core': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
       '@docusaurus/logger': 3.4.0
       '@docusaurus/types': 3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/utils': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(typescript@5.5.4)
+      '@docusaurus/utils': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(typescript@5.8.3)
       '@docusaurus/utils-common': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
-      '@docusaurus/utils-validation': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(typescript@5.5.4)
+      '@docusaurus/utils-validation': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(typescript@5.8.3)
       fs-extra: 11.3.1
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -24589,20 +24589,20 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/preset-classic@3.4.0(@algolia/client-search@5.46.0)(@rspack/core@1.6.7)(@swc/core@1.7.39)(@types/react@18.3.24)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.3)(typescript@5.5.4)':
+  '@docusaurus/preset-classic@3.4.0(@algolia/client-search@5.46.0)(@rspack/core@1.6.7)(@swc/core@1.7.39)(@types/react@18.3.24)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.3)(typescript@5.8.3)':
     dependencies:
-      '@docusaurus/core': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
-      '@docusaurus/plugin-content-blog': 3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
-      '@docusaurus/plugin-content-docs': 3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
-      '@docusaurus/plugin-content-pages': 3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
-      '@docusaurus/plugin-debug': 3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
-      '@docusaurus/plugin-google-analytics': 3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
-      '@docusaurus/plugin-google-gtag': 3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
-      '@docusaurus/plugin-google-tag-manager': 3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
-      '@docusaurus/plugin-sitemap': 3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
-      '@docusaurus/theme-classic': 3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(@types/react@18.3.24)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
-      '@docusaurus/theme-common': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
-      '@docusaurus/theme-search-algolia': 3.4.0(@algolia/client-search@5.46.0)(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@rspack/core@1.6.7)(@swc/core@1.7.39)(@types/react@18.3.24)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.3)(typescript@5.5.4)
+      '@docusaurus/core': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
+      '@docusaurus/plugin-content-blog': 3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
+      '@docusaurus/plugin-content-docs': 3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
+      '@docusaurus/plugin-content-pages': 3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
+      '@docusaurus/plugin-debug': 3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
+      '@docusaurus/plugin-google-analytics': 3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
+      '@docusaurus/plugin-google-gtag': 3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
+      '@docusaurus/plugin-google-tag-manager': 3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
+      '@docusaurus/plugin-sitemap': 3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
+      '@docusaurus/theme-classic': 3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(@types/react@18.3.24)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
+      '@docusaurus/theme-common': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
+      '@docusaurus/theme-search-algolia': 3.4.0(@algolia/client-search@5.46.0)(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@rspack/core@1.6.7)(@swc/core@1.7.39)(@types/react@18.3.24)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.3)(typescript@5.8.3)
       '@docusaurus/types': 3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
@@ -24632,20 +24632,20 @@ snapshots:
       '@types/react': 18.3.24
       react: 18.3.1
 
-  '@docusaurus/theme-classic@3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(@types/react@18.3.24)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)':
+  '@docusaurus/theme-classic@3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(@types/react@18.3.24)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)':
     dependencies:
-      '@docusaurus/core': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
-      '@docusaurus/mdx-loader': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
+      '@docusaurus/core': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
+      '@docusaurus/mdx-loader': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
       '@docusaurus/module-type-aliases': 3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/plugin-content-blog': 3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
-      '@docusaurus/plugin-content-docs': 3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
-      '@docusaurus/plugin-content-pages': 3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
-      '@docusaurus/theme-common': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
+      '@docusaurus/plugin-content-blog': 3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
+      '@docusaurus/plugin-content-docs': 3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
+      '@docusaurus/plugin-content-pages': 3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
+      '@docusaurus/theme-common': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
       '@docusaurus/theme-translations': 3.4.0
       '@docusaurus/types': 3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/utils': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(typescript@5.5.4)
+      '@docusaurus/utils': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(typescript@5.8.3)
       '@docusaurus/utils-common': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
-      '@docusaurus/utils-validation': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(typescript@5.5.4)
+      '@docusaurus/utils-validation': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(typescript@5.8.3)
       '@mdx-js/react': 3.1.1(@types/react@18.3.24)(react@18.3.1)
       clsx: 2.1.1
       copy-text-to-clipboard: 3.2.2
@@ -24680,14 +24680,14 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/theme-common@3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)':
+  '@docusaurus/theme-common@3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)':
     dependencies:
-      '@docusaurus/mdx-loader': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
+      '@docusaurus/mdx-loader': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
       '@docusaurus/module-type-aliases': 3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
-      '@docusaurus/plugin-content-blog': 3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
-      '@docusaurus/plugin-content-docs': 3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
-      '@docusaurus/plugin-content-pages': 3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
-      '@docusaurus/utils': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(typescript@5.5.4)
+      '@docusaurus/plugin-content-blog': 3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
+      '@docusaurus/plugin-content-docs': 3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
+      '@docusaurus/plugin-content-pages': 3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
+      '@docusaurus/utils': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(typescript@5.8.3)
       '@docusaurus/utils-common': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       '@types/history': 4.7.11
       '@types/react': 18.3.24
@@ -24718,16 +24718,16 @@ snapshots:
       - vue-template-compiler
       - webpack-cli
 
-  '@docusaurus/theme-search-algolia@3.4.0(@algolia/client-search@5.46.0)(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@rspack/core@1.6.7)(@swc/core@1.7.39)(@types/react@18.3.24)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.3)(typescript@5.5.4)':
+  '@docusaurus/theme-search-algolia@3.4.0(@algolia/client-search@5.46.0)(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@rspack/core@1.6.7)(@swc/core@1.7.39)(@types/react@18.3.24)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.3)(typescript@5.8.3)':
     dependencies:
       '@docsearch/react': 3.9.0(@algolia/client-search@5.46.0)(@types/react@18.3.24)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.17.3)
-      '@docusaurus/core': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
+      '@docusaurus/core': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
       '@docusaurus/logger': 3.4.0
-      '@docusaurus/plugin-content-docs': 3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
-      '@docusaurus/theme-common': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.5.4)
+      '@docusaurus/plugin-content-docs': 3.4.0(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
+      '@docusaurus/theme-common': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@rspack/core@1.6.7)(@swc/core@1.7.39)(esbuild@0.27.3)(eslint@9.35.0(jiti@2.5.1))(lightningcss@1.32.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.8.3)
       '@docusaurus/theme-translations': 3.4.0
-      '@docusaurus/utils': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(typescript@5.5.4)
-      '@docusaurus/utils-validation': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(typescript@5.5.4)
+      '@docusaurus/utils': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(typescript@5.8.3)
+      '@docusaurus/utils-validation': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(typescript@5.8.3)
       algoliasearch: 4.25.3
       algoliasearch-helper: 3.26.1(algoliasearch@4.25.3)
       clsx: 2.1.1
@@ -24791,10 +24791,10 @@ snapshots:
     optionalDependencies:
       '@docusaurus/types': 3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
 
-  '@docusaurus/utils-validation@3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(typescript@5.5.4)':
+  '@docusaurus/utils-validation@3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(typescript@5.8.3)':
     dependencies:
       '@docusaurus/logger': 3.4.0
-      '@docusaurus/utils': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(typescript@5.5.4)
+      '@docusaurus/utils': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(typescript@5.8.3)
       '@docusaurus/utils-common': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
       fs-extra: 11.3.1
       joi: 17.13.3
@@ -24810,11 +24810,11 @@ snapshots:
       - uglify-js
       - webpack-cli
 
-  '@docusaurus/utils@3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(typescript@5.5.4)':
+  '@docusaurus/utils@3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(@swc/core@1.7.39)(esbuild@0.27.3)(typescript@5.8.3)':
     dependencies:
       '@docusaurus/logger': 3.4.0
       '@docusaurus/utils-common': 3.4.0(@docusaurus/types@3.4.0(@swc/core@1.7.39)(esbuild@0.27.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))
-      '@svgr/webpack': 8.1.0(typescript@5.5.4)
+      '@svgr/webpack': 8.1.0(typescript@5.8.3)
       escape-string-regexp: 4.0.0
       file-loader: 6.2.0(webpack@5.106.1(@swc/core@1.7.39)(esbuild@0.27.3))
       fs-extra: 11.3.1
@@ -28859,6 +28859,17 @@ snapshots:
       - supports-color
       - typescript
 
+  '@svgr/core@8.1.0(typescript@5.8.3)':
+    dependencies:
+      '@babel/core': 7.28.4
+      '@svgr/babel-preset': 8.1.0(@babel/core@7.28.4)
+      camelcase: 6.3.0
+      cosmiconfig: 8.3.6(typescript@5.8.3)
+      snake-case: 3.0.4
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
+
   '@svgr/hast-util-to-babel-ast@8.0.0':
     dependencies:
       '@babel/types': 7.28.4
@@ -28874,6 +28885,16 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@svgr/plugin-jsx@8.1.0(@svgr/core@8.1.0(typescript@5.8.3))':
+    dependencies:
+      '@babel/core': 7.28.4
+      '@svgr/babel-preset': 8.1.0(@babel/core@7.28.4)
+      '@svgr/core': 8.1.0(typescript@5.8.3)
+      '@svgr/hast-util-to-babel-ast': 8.0.0
+      svg-parser: 2.0.4
+    transitivePeerDependencies:
+      - supports-color
+
   '@svgr/plugin-svgo@8.1.0(@svgr/core@8.1.0(typescript@5.5.4))(typescript@5.5.4)':
     dependencies:
       '@svgr/core': 8.1.0(typescript@5.5.4)
@@ -28883,16 +28904,25 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
-  '@svgr/webpack@8.1.0(typescript@5.5.4)':
+  '@svgr/plugin-svgo@8.1.0(@svgr/core@8.1.0(typescript@5.8.3))(typescript@5.8.3)':
+    dependencies:
+      '@svgr/core': 8.1.0(typescript@5.8.3)
+      cosmiconfig: 8.3.6(typescript@5.8.3)
+      deepmerge: 4.3.1
+      svgo: 3.3.3
+    transitivePeerDependencies:
+      - typescript
+
+  '@svgr/webpack@8.1.0(typescript@5.8.3)':
     dependencies:
       '@babel/core': 7.28.4
       '@babel/plugin-transform-react-constant-elements': 7.27.1(@babel/core@7.28.4)
       '@babel/preset-env': 7.26.0(@babel/core@7.28.4)
       '@babel/preset-react': 7.25.9(@babel/core@7.28.4)
       '@babel/preset-typescript': 7.27.1(@babel/core@7.28.4)
-      '@svgr/core': 8.1.0(typescript@5.5.4)
-      '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0(typescript@5.5.4))
-      '@svgr/plugin-svgo': 8.1.0(@svgr/core@8.1.0(typescript@5.5.4))(typescript@5.5.4)
+      '@svgr/core': 8.1.0(typescript@5.8.3)
+      '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0(typescript@5.8.3))
+      '@svgr/plugin-svgo': 8.1.0(@svgr/core@8.1.0(typescript@5.8.3))(typescript@5.8.3)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -32029,6 +32059,15 @@ snapshots:
     optionalDependencies:
       typescript: 5.5.4
 
+  cosmiconfig@8.3.6(typescript@5.8.3):
+    dependencies:
+      import-fresh: 3.3.1
+      js-yaml: 4.1.1
+      parse-json: 5.2.0
+      path-type: 4.0.0
+    optionalDependencies:
+      typescript: 5.8.3
+
   crc-32@1.2.2: {}
 
   crc32-stream@6.0.0:
@@ -33954,7 +33993,7 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
-  fork-ts-checker-webpack-plugin@6.5.3(eslint@9.35.0(jiti@2.5.1))(typescript@5.5.4)(webpack@5.106.1(@swc/core@1.7.39)(esbuild@0.27.3)):
+  fork-ts-checker-webpack-plugin@6.5.3(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3)(webpack@5.106.1(@swc/core@1.7.39)(esbuild@0.27.3)):
     dependencies:
       '@babel/code-frame': 7.27.1
       '@types/json-schema': 7.0.15
@@ -33969,7 +34008,7 @@ snapshots:
       schema-utils: 2.7.0
       semver: 7.7.4
       tapable: 1.1.3
-      typescript: 5.5.4
+      typescript: 5.8.3
       webpack: 5.106.1(@swc/core@1.7.39)(esbuild@0.27.3)
     optionalDependencies:
       eslint: 9.35.0(jiti@2.5.1)
@@ -38101,9 +38140,9 @@ snapshots:
       tsx: 4.20.5
       yaml: 2.9.0
 
-  postcss-loader@7.3.4(postcss@8.5.6)(typescript@5.5.4)(webpack@5.106.1(@swc/core@1.7.39)(esbuild@0.27.3)):
+  postcss-loader@7.3.4(postcss@8.5.6)(typescript@5.8.3)(webpack@5.106.1(@swc/core@1.7.39)(esbuild@0.27.3)):
     dependencies:
-      cosmiconfig: 8.3.6(typescript@5.5.4)
+      cosmiconfig: 8.3.6(typescript@5.8.3)
       jiti: 1.21.7
       postcss: 8.5.6
       semver: 7.7.4
@@ -38817,7 +38856,7 @@ snapshots:
       date-fns: 2.30.0
       react: 18.3.1
 
-  react-dev-utils@12.0.1(eslint@9.35.0(jiti@2.5.1))(typescript@5.5.4)(webpack@5.106.1(@swc/core@1.7.39)(esbuild@0.27.3)):
+  react-dev-utils@12.0.1(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3)(webpack@5.106.1(@swc/core@1.7.39)(esbuild@0.27.3)):
     dependencies:
       '@babel/code-frame': 7.27.1
       address: 1.2.2
@@ -38828,7 +38867,7 @@ snapshots:
       escape-string-regexp: 4.0.0
       filesize: 8.0.7
       find-up: 5.0.0
-      fork-ts-checker-webpack-plugin: 6.5.3(eslint@9.35.0(jiti@2.5.1))(typescript@5.5.4)(webpack@5.106.1(@swc/core@1.7.39)(esbuild@0.27.3))
+      fork-ts-checker-webpack-plugin: 6.5.3(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3)(webpack@5.106.1(@swc/core@1.7.39)(esbuild@0.27.3))
       global-modules: 2.0.0
       globby: 11.1.0
       gzip-size: 6.0.0
@@ -38845,7 +38884,7 @@ snapshots:
       text-table: 0.2.0
       webpack: 5.106.1(@swc/core@1.7.39)(esbuild@0.27.3)
     optionalDependencies:
-      typescript: 5.5.4
+      typescript: 5.8.3
     transitivePeerDependencies:
       - eslint
       - supports-color
@@ -41382,8 +41421,7 @@ snapshots:
 
   typescript@5.8.2: {}
 
-  typescript@5.8.3:
-    optional: true
+  typescript@5.8.3: {}
 
   typewise-core@1.2.0: {}
 


### PR DESCRIPTION
generate a typescript sdk from a complete maker envelope

• add osdk oac generate with required packageName and yaml import maps
• write a deterministic semantic manifest from official action operations
• reject malformed yaml, duplicate imports, and incomplete ir documents