### PR TITLE
Fix: allow filtering by pk and title on interfaces w/ no properties

### DIFF
--- a/.changeset/sweet-apples-care.md
+++ b/.changeset/sweet-apples-care.md
@@ -1,0 +1,6 @@
+---
+"@osdk/client": patch
+"@osdk/api": patch
+---
+
+Allow interfaces w/ no properties to filter on pk+title

--- a/etc/api.report.api.md
+++ b/etc/api.report.api.md
@@ -2457,13 +2457,15 @@ export interface VideoSpecification {
     durationSeconds: number;
 }
 
-// Warning: (ae-forgotten-export) The symbol "MergedPropertyWhereClause" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "SpecialPropertyWhereClause" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "PropertyWhereClause" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "DerivedObjectOrInterfaceDefinition" needs to be exported by the entry point index.d.ts
 //
 // @public (undocumented)
 export type WhereClause<
 	T extends ObjectOrInterfaceDefinition,
 	RDPs extends Record<string, SimplePropertyDef> = {}
-> = OrWhereClause<T, RDPs> | AndWhereClause<T, RDPs> | NotWhereClause<T, RDPs> | (IsNever<keyof CompileTimeMetadata<T>["properties"]> extends true ? Record<string, never> : MergedPropertyWhereClause<T, RDPs>);
+> = OrWhereClause<T, RDPs> | AndWhereClause<T, RDPs> | NotWhereClause<T, RDPs> | SpecialPropertyWhereClause<T> | (IsNever<keyof CompileTimeMetadata<T>["properties"]> extends true ? Record<string, never> : PropertyWhereClause<DerivedObjectOrInterfaceDefinition.WithDerivedProperties<T, RDPs>>);
 
 // @public (undocumented)
 export type WirePropertyTypes = BaseWirePropertyTypes | Record<string, BaseWirePropertyTypes>;

--- a/packages/api/src/__quickinfo_snapshot__/__snapshots__/objectSet.snap
+++ b/packages/api/src/__quickinfo_snapshot__/__snapshots__/objectSet.snap
@@ -338,15 +338,13 @@ type objectSet_where_clause_param =
   | OrWhereClause<EmployeeApiTest, {}>
   | AndWhereClause<EmployeeApiTest, {}>
   | NotWhereClause<EmployeeApiTest, {}>
-  | (
-    | PropertyWhereClause<
-      DerivedObjectOrInterfaceDefinition.WithDerivedProperties<
-        EmployeeApiTest,
-        {}
-      >
+  | SpecialPropertyWhereClause<EmployeeApiTest>
+  | PropertyWhereClause<
+    DerivedObjectOrInterfaceDefinition.WithDerivedProperties<
+      EmployeeApiTest,
+      {}
     >
-    | SpecialPropertyWhereClause<EmployeeApiTest>
-  );
+  >;
 
 /** The result of objectSet.withProperties({ mom: ..., dad: ... }). */
 type objectSet_withProperties_result = ObjectSet<
@@ -380,20 +378,18 @@ type objectSet_with_rdp_where_clause_param =
     >,
     {}
   >
-  | (
-    | PropertyWhereClause<
-      DerivedObjectOrInterfaceDefinition.WithDerivedProperties<
-        DerivedObjectOrInterfaceDefinition.WithDerivedProperties<
-          EmployeeApiTest,
-          { mom: "integer" }
-        >,
-        {}
-      >
+  | SpecialPropertyWhereClause<
+    DerivedObjectOrInterfaceDefinition.WithDerivedProperties<
+      EmployeeApiTest,
+      { mom: "integer" }
     >
-    | SpecialPropertyWhereClause<
+  >
+  | PropertyWhereClause<
+    DerivedObjectOrInterfaceDefinition.WithDerivedProperties<
       DerivedObjectOrInterfaceDefinition.WithDerivedProperties<
         EmployeeApiTest,
         { mom: "integer" }
-      >
+      >,
+      {}
     >
-  );
+  >;

--- a/packages/api/src/aggregate/WhereClause.ts
+++ b/packages/api/src/aggregate/WhereClause.ts
@@ -226,15 +226,6 @@ export type PropertyWhereClause<T extends ObjectOrInterfaceDefinition> = {
   >;
 };
 
-type MergedPropertyWhereClause<
-  T extends ObjectOrInterfaceDefinition,
-  RDPs extends Record<string, SimplePropertyDef> = {},
-> =
-  | PropertyWhereClause<
-      DerivedObjectOrInterfaceDefinition.WithDerivedProperties<T, RDPs>
-    >
-  | SpecialPropertyWhereClause<T>;
-
 export type WhereClause<
   T extends ObjectOrInterfaceDefinition,
   RDPs extends Record<string, SimplePropertyDef> = {},
@@ -242,6 +233,9 @@ export type WhereClause<
   | OrWhereClause<T, RDPs>
   | AndWhereClause<T, RDPs>
   | NotWhereClause<T, RDPs>
+  | SpecialPropertyWhereClause<T>
   | (IsNever<keyof CompileTimeMetadata<T>["properties"]> extends true
       ? Record<string, never>
-      : MergedPropertyWhereClause<T, RDPs>);
+      : PropertyWhereClause<
+          DerivedObjectOrInterfaceDefinition.WithDerivedProperties<T, RDPs>
+        >);

--- a/packages/client/src/objectSet/ObjectSet.test.ts
+++ b/packages/client/src/objectSet/ObjectSet.test.ts
@@ -487,6 +487,11 @@ describe("ObjectSet", () => {
     });
   });
 
+  it("allows filtering by $primaryKey and $title on interfaces with no properties", () => {
+    client(BarInterface).where({ $primaryKey: { $eq: "abc" } });
+    client(BarInterface).where({ $title: { $eq: "abc" } });
+  });
+
   it("type checking containsallterm and containsanyterm", () => {
     const ids: ReadonlyArray<number> = [50030, 50031];
     client(Employee).where({


### PR DESCRIPTION
On interfaces with no properties, there was an issue where it wasn't allowing filtering on primary key or title, which should be allowed. Fixed that issue so now you are able to filter on PK and title.

Tested in local ts environment and made sure that `primaryKey` and title in a `where` clause with an no property interface (WhTempInterface) compiled correctly.