### PR TITLE
Moved aip-core to direct dependency

### DIFF
--- a/.changeset/aip-core-direct-dependency.md
+++ b/.changeset/aip-core-direct-dependency.md
@@ -1,0 +1,7 @@
+---
+"@osdk/react-components": patch
+"@osdk/aip-core": patch
+"@osdk/react": patch
+---
+
+`@osdk/aip-core` is now a direct dependency of `@osdk/react` and `@osdk/react-components` instead of an optional peer dependency, so consumers of `AipAgentChat` and `useChat` no longer have to install it themselves. For the same reason, `@osdk/aip-core` now depends on `@osdk/language-models` directly rather than declaring it as a peer.

--- a/packages/aip-core/package.json
+++ b/packages/aip-core/package.json
@@ -51,7 +51,7 @@
     "typecheck": "tsc --noEmit --emitDeclarationOnly false"
   },
   "dependencies": {
-    "@osdk/language-models": "workspace:~"
+    "@osdk/language-models": "workspace:*"
   },
   "peerDependencies": {
     "@ai-sdk/provider": "^3.0.0",

--- a/packages/aip-core/package.json
+++ b/packages/aip-core/package.json
@@ -50,10 +50,12 @@
     "transpileTypes": "monorepo.tool.transpile -f esm -m types -t node",
     "typecheck": "tsc --noEmit --emitDeclarationOnly false"
   },
+  "dependencies": {
+    "@osdk/language-models": "workspace:~"
+  },
   "peerDependencies": {
     "@ai-sdk/provider": "^3.0.0",
-    "@osdk/client": "workspace:^",
-    "@osdk/language-models": ">=0.6.0 <1.0.0"
+    "@osdk/client": "workspace:^"
   },
   "peerDependenciesMeta": {
     "@ai-sdk/provider": {

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -202,6 +202,7 @@
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
+    "@osdk/aip-core": "workspace:~",
     "@tanstack/react-table": "^8.21.3",
     "@tanstack/react-virtual": "^3.13.13",
     "date-fns": "^2.28.0",
@@ -218,7 +219,6 @@
     "xlsx-republish": "0.20.3"
   },
   "peerDependencies": {
-    "@osdk/aip-core": ">=0.5.0 <1.0.0",
     "@osdk/api": "^2.8.0",
     "@osdk/client": "^2.8.0",
     "@osdk/react": "^2.8.0",
@@ -227,13 +227,7 @@
     "react": "^17 || ^18 || ^19",
     "react-dom": "^17 || ^18 || ^19"
   },
-  "peerDependenciesMeta": {
-    "@osdk/aip-core": {
-      "optional": true
-    }
-  },
   "devDependencies": {
-    "@osdk/aip-core": "workspace:*",
     "@osdk/api": "workspace:*",
     "@osdk/client": "workspace:*",
     "@osdk/monorepo.api-extractor": "workspace:~",

--- a/packages/react-components/package.json
+++ b/packages/react-components/package.json
@@ -202,7 +202,7 @@
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
-    "@osdk/aip-core": "workspace:~",
+    "@osdk/aip-core": "workspace:*",
     "@tanstack/react-table": "^8.21.3",
     "@tanstack/react-virtual": "^3.13.13",
     "date-fns": "^2.28.0",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -96,10 +96,10 @@
     "typecheck": "tsc --noEmit --emitDeclarationOnly false"
   },
   "dependencies": {
+    "@osdk/aip-core": "workspace:~",
     "fast-deep-equal": "^3.1.3"
   },
   "peerDependencies": {
-    "@osdk/aip-core": ">=0.5.0 <1.0.0",
     "@osdk/api": "^2.15.0",
     "@osdk/client": "^2.15.0",
     "@osdk/foundry.admin": "*",
@@ -109,9 +109,6 @@
     "react-dom": "^17 || ^18 || ^19"
   },
   "peerDependenciesMeta": {
-    "@osdk/aip-core": {
-      "optional": true
-    },
     "@osdk/foundry.admin": {
       "optional": true
     },
@@ -120,7 +117,6 @@
     }
   },
   "devDependencies": {
-    "@osdk/aip-core": "workspace:*",
     "@osdk/api": "workspace:*",
     "@osdk/client": "workspace:*",
     "@osdk/client.test.ontology": "workspace:*",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -96,7 +96,7 @@
     "typecheck": "tsc --noEmit --emitDeclarationOnly false"
   },
   "dependencies": {
-    "@osdk/aip-core": "workspace:~",
+    "@osdk/aip-core": "workspace:*",
     "fast-deep-equal": "^3.1.3"
   },
   "peerDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1778,8 +1778,8 @@ importers:
         specifier: workspace:^
         version: link:../client
       '@osdk/language-models':
-        specifier: '>=0.6.0 <1.0.0'
-        version: 0.6.0(@osdk/client@packages+client)
+        specifier: workspace:~
+        version: link:../language-models
     devDependencies:
       '@ai-sdk/provider':
         specifier: ^3.0.8
@@ -4873,6 +4873,9 @@ importers:
 
   packages/react:
     dependencies:
+      '@osdk/aip-core':
+        specifier: workspace:~
+        version: link:../aip-core
       fast-deep-equal:
         specifier: ^3.1.3
         version: 3.1.3
@@ -4880,9 +4883,6 @@ importers:
         specifier: ^17 || ^18 || ^19
         version: 18.3.1(react@18.3.1)
     devDependencies:
-      '@osdk/aip-core':
-        specifier: workspace:*
-        version: link:../aip-core
       '@osdk/api':
         specifier: workspace:*
         version: link:../api
@@ -4961,6 +4961,9 @@ importers:
       '@dnd-kit/utilities':
         specifier: ^3.2.2
         version: 3.2.2(react@18.3.1)
+      '@osdk/aip-core':
+        specifier: workspace:~
+        version: link:../aip-core
       '@tanstack/react-table':
         specifier: ^8.21.3
         version: 8.21.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -5007,9 +5010,6 @@ importers:
         specifier: 0.20.3
         version: 0.20.3
     devDependencies:
-      '@osdk/aip-core':
-        specifier: workspace:*
-        version: link:../aip-core
       '@osdk/api':
         specifier: workspace:*
         version: link:../api
@@ -9280,11 +9280,6 @@ packages:
 
   '@osdk/internal.foundry.ontologies@2.73.0':
     resolution: {integrity: sha512-6A5rQDjTEoW/GfiQq85g5yY0PWuh9Cx+pbzBMnXmrX+Kxbj7PglxzusL5xj34CG5FkVxKp+Bj+ewMmdORDxqBA==}
-
-  '@osdk/language-models@0.6.0':
-    resolution: {integrity: sha512-cPyJA4YG6BeIKu1TtjKdqRfSCA85SOLoN+o8PCkJHx35Gn7YCUbHe0gWiSqznak0XzA7HjzWcSouPjWYjmdogw==}
-    peerDependencies:
-      '@osdk/client': ^2.16.0
 
   '@osdk/legacy-client@2.5.6':
     resolution: {integrity: sha512-QPeCcuqCv+s6toIxWMRArKJx35bzvcpoKAqsQ6YYiFEiGn43vLoQQGbeMlnqcGYfdbljyzeOoDxZtgVIn6a8HA==}
@@ -26790,10 +26785,6 @@ snapshots:
       '@osdk/shared.client': 1.0.1
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.7.0
-
-  '@osdk/language-models@0.6.0(@osdk/client@packages+client)':
-    dependencies:
-      '@osdk/client': link:packages/client
 
   '@osdk/legacy-client@2.5.6':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1778,7 +1778,7 @@ importers:
         specifier: workspace:^
         version: link:../client
       '@osdk/language-models':
-        specifier: workspace:~
+        specifier: workspace:*
         version: link:../language-models
     devDependencies:
       '@ai-sdk/provider':
@@ -4874,7 +4874,7 @@ importers:
   packages/react:
     dependencies:
       '@osdk/aip-core':
-        specifier: workspace:~
+        specifier: workspace:*
         version: link:../aip-core
       fast-deep-equal:
         specifier: ^3.1.3
@@ -4962,7 +4962,7 @@ importers:
         specifier: ^3.2.2
         version: 3.2.2(react@18.3.1)
       '@osdk/aip-core':
-        specifier: workspace:~
+        specifier: workspace:*
         version: link:../aip-core
       '@tanstack/react-table':
         specifier: ^8.21.3


### PR DESCRIPTION
`@osdk/aip-core` is now a direct dependency of `@osdk/react` and `@osdk/react-components` instead of an optional peer dependency, so consumers of `AipAgentChat` and `useChat` no longer have to install it themselves. 

AipAgentChat component and useChat hook are experimental and the dependencies will likely change. Making `@osdk/aip-core` a direct dependency so it is not surfaced to users now. 