### PR TITLE
Add widget Vite plugin user agent

### DIFF
--- a/.changeset/widget-vite-plugin-user-agent.md
+++ b/.changeset/widget-vite-plugin-user-agent.md
@@ -1,0 +1,5 @@
+---
+"@osdk/widget.vite-plugin": patch
+---
+
+Include the widget Vite plugin version in dev mode request user agents.

--- a/packages/widget.vite-plugin/src/dev-plugin/__tests__/network.test.ts
+++ b/packages/widget.vite-plugin/src/dev-plugin/__tests__/network.test.ts
@@ -36,6 +36,10 @@ function getFetchedUrl(fetchMock: ReturnType<typeof vi.fn>): string {
   return arg instanceof URL ? arg.toString() : String(arg);
 }
 
+function getFetchedHeaders(fetchMock: ReturnType<typeof vi.fn>): Headers {
+  return new Headers(fetchMock.mock.calls[0][1]?.headers);
+}
+
 describe("network", () => {
   let fetchMock: ReturnType<typeof vi.fn>;
 
@@ -63,6 +67,9 @@ describe("network", () => {
       expect(getFetchedUrl(fetchMock)).toBe(
         "https://example.palantirfoundry.com/api/v2/widgets/devModeSettingsV2/setWidgetSetManifest?preview=true",
       );
+      expect(getFetchedHeaders(fetchMock).get("Fetch-User-Agent")).toBe(
+        `osdk-widget.vite-plugin/${process.env.PACKAGE_VERSION}`,
+      );
     });
   });
 
@@ -74,6 +81,9 @@ describe("network", () => {
       await enableDevMode(foundryUrl, undefined);
       expect(getFetchedUrl(fetchMock)).toBe(
         "https://example.palantirfoundry.com/api/v2/widgets/devModeSettingsV2/enable?preview=true",
+      );
+      expect(getFetchedHeaders(fetchMock).get("Fetch-User-Agent")).toBe(
+        `osdk-widget.vite-plugin/${process.env.PACKAGE_VERSION}`,
       );
     });
   });

--- a/packages/widget.vite-plugin/src/dev-plugin/network.ts
+++ b/packages/widget.vite-plugin/src/dev-plugin/network.ts
@@ -17,6 +17,8 @@
 import type { DevModeManifest } from "./buildDevModeManifest.js";
 import { getFoundryToken } from "./getFoundryToken.js";
 
+const USER_AGENT = `osdk-widget.vite-plugin/${process.env.PACKAGE_VERSION}`;
+
 export function setWidgetSetManifest(
   foundryUrl: string,
   widgetSetRid: string,
@@ -38,6 +40,7 @@ export function setWidgetSetManifest(
       authorization: `Bearer ${getFoundryToken(viteMode)}`,
       accept: "application/json",
       "content-type": "application/json",
+      "Fetch-User-Agent": USER_AGENT,
     },
   });
 }
@@ -53,6 +56,7 @@ export function enableDevMode(
     headers: {
       authorization: `Bearer ${getFoundryToken(viteMode)}`,
       accept: "application/json",
+      "Fetch-User-Agent": USER_AGENT,
     },
   });
 }


### PR DESCRIPTION
## Summary
- include the @osdk/widget.vite-plugin version in the Fetch-User-Agent header for dev mode requests
- cover both dev mode endpoints with regression tests
- add a patch changeset

## Testing
- pnpm --filter @osdk/widget.vite-plugin test
- pnpm --filter @osdk/widget.vite-plugin typecheck
- pnpm --filter @osdk/widget.vite-plugin lint
- pnpm --filter @osdk/widget.vite-plugin transpileEsm