### PR TITLE
preserve value types through sdk generation

### DIFF
--- a/.changeset/oac-preserve-semantics.md
+++ b/.changeset/oac-preserve-semantics.md
@@ -5,4 +5,4 @@
 "@osdk/maker-experimental": minor
 ---
 
-preserve value types, interface properties, and interface-link action rules through current ontology block data conversion
+preserve value types, interface properties, and interface-link action rules through current ontology block data and SDK generation conversion

--- a/packages/generator-converters.preview/src/cli/convertSdkGenerationInput.ts
+++ b/packages/generator-converters.preview/src/cli/convertSdkGenerationInput.ts
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { OntologyBlockDataV2, OntologyIrV2 } from "@osdk/client.unstable";
+import type * as Ontologies from "@osdk/foundry.ontologies";
+import { OntologyIrToFullMetadataConverter } from "@osdk/generator-converters.ontologyir";
+import {
+  type PreviewOntologyFullMetadata,
+  PreviewOntologyIrConverter,
+} from "../PreviewOntologyIrConverter.js";
+
+export type SdkGenerationInput = OntologyBlockDataV2 | OntologyIrV2;
+
+export function unwrapSdkGenerationInput(value: unknown): unknown {
+  if (
+    typeof value === "object"
+    && value != null
+    && "ontology" in value
+    && !("transitiveImportedOntology" in value)
+  ) {
+    return value.ontology;
+  }
+  return value;
+}
+
+export function isSdkGenerationInput(
+  value: unknown,
+): value is SdkGenerationInput {
+  if (typeof value !== "object" || value == null) {
+    return false;
+  }
+
+  if ("transitiveImportedOntology" in value) {
+    return "ontology" in value
+      && "importedOntology" in value
+      && "valueTypes" in value
+      && "importedValueTypes" in value;
+  }
+
+  return "objectTypes" in value && "actionTypes" in value;
+}
+
+export function convertSdkGenerationInput(
+  input: SdkGenerationInput,
+  importedTypes?: Ontologies.OntologyFullMetadata,
+): PreviewOntologyFullMetadata | Ontologies.OntologyFullMetadata {
+  if ("transitiveImportedOntology" in input) {
+    return OntologyIrToFullMetadataConverter.getFullMetadataFromEnvelope(input);
+  }
+
+  return PreviewOntologyIrConverter.getPreviewFullMetadataFromBlockData(
+    input,
+    importedTypes,
+  );
+}

--- a/packages/generator-converters.preview/src/cli/convertSdkGenerationInput.ts
+++ b/packages/generator-converters.preview/src/cli/convertSdkGenerationInput.ts
@@ -24,6 +24,21 @@ import {
 
 export type SdkGenerationInput = OntologyBlockDataV2 | OntologyIrV2;
 
+type SdkGenerationActionType =
+  | Ontologies.ActionTypeV2
+  | Ontologies.ActionTypeFullMetadata;
+
+export function normalizeSdkGenerationActionTypes(
+  actionTypes: Record<string, SdkGenerationActionType>,
+): Record<string, Ontologies.ActionTypeV2> {
+  return Object.fromEntries(
+    Object.entries(actionTypes).map(([apiName, action]) => [
+      apiName,
+      "actionType" in action ? action.actionType : action,
+    ]),
+  );
+}
+
 export function unwrapSdkGenerationInput(value: unknown): unknown {
   if (
     typeof value === "object"

--- a/packages/generator-converters.preview/src/cli/generate-sdk.test.ts
+++ b/packages/generator-converters.preview/src/cli/generate-sdk.test.ts
@@ -14,12 +14,27 @@
  * limitations under the License.
  */
 
-import type { OntologyIrV2 } from "@osdk/client.unstable";
+import type {
+  OntologyIrV2,
+  ValueTypeDataConstraint,
+} from "@osdk/client.unstable";
+import type * as Ontologies from "@osdk/foundry.ontologies";
+import {
+  generateClientSdkVersionTwoPointZero,
+  type MinimalFs,
+} from "@osdk/generator";
+import { createHash } from "node:crypto";
 import { describe, expect, it } from "vitest";
 import {
   convertSdkGenerationInput,
+  normalizeSdkGenerationActionTypes,
   unwrapSdkGenerationInput,
 } from "./convertSdkGenerationInput.js";
+
+type StringValueTypeConstraint = Extract<
+  ValueTypeDataConstraint["constraint"]["constraint"],
+  { type: "string" }
+>;
 
 function emptyBlock(): OntologyIrV2["ontology"] {
   return {
@@ -63,19 +78,180 @@ function emptyBlock(): OntologyIrV2["ontology"] {
   };
 }
 
+function createInMemoryFiles(): {
+  fs: MinimalFs;
+  files: Map<string, string>;
+} {
+  const files = new Map<string, string>();
+  return {
+    files,
+    fs: {
+      mkdir: () => Promise.resolve(),
+      readdir: () => Promise.resolve([]),
+      writeFile: (path, contents) => {
+        files.set(path, contents);
+        return Promise.resolve();
+      },
+    },
+  };
+}
+
+function valueTypeVersionId(version: string): string {
+  const hash = createHash("md5").update(version, "utf8").digest("hex");
+  return `${hash.slice(0, 8)}-${hash.slice(8, 12)}-${hash.slice(12, 16)}-${
+    hash.slice(16, 20)
+  }-${hash.slice(20)}`;
+}
+
 describe("convertSdkGenerationInput", () => {
+  it("preserves envelope ActionTypeV2 metadata during SDK generation", () => {
+    const actionRid = "ri.ontology.main.action-type.noop";
+    const ontology = emptyBlock();
+    const envelope: OntologyIrV2 = {
+      importedOntology: emptyBlock(),
+      importedValueTypes: [],
+      ontology: {
+        ...ontology,
+        actionTypes: {
+          [actionRid]: {
+            actionType: {
+              actionTypeLogic: {
+                logic: { rules: [] },
+                notifications: [],
+                validation: {
+                  actionTypeLevelValidation: { ordering: [], rules: {} },
+                  parameterValidations: {},
+                  sectionValidations: {},
+                },
+              },
+              metadata: {
+                apiName: "noop",
+                displayMetadata: {
+                  applyingMessage: [],
+                  description: "",
+                  displayName: "No-op",
+                  successMessage: [],
+                  typeClasses: [],
+                },
+                formContentOrdering: [],
+                parameterOrdering: [],
+                parameters: {},
+                rid: actionRid,
+                sections: {},
+                status: { type: "active", active: {} },
+                version: "1.0.0",
+              },
+            },
+            parameterIds: {},
+          },
+        },
+        knownIdentifiers: {
+          ...ontology.knownIdentifiers,
+          actionTypes: { [actionRid]: "action-type-noop" },
+        },
+      },
+      randomnessKey: "00000000-0000-0000-0000-000000000000",
+      transitiveImportedOntology: emptyBlock(),
+      valueTypes: [],
+    };
+
+    const metadata = convertSdkGenerationInput(envelope);
+    const actionTypes = normalizeSdkGenerationActionTypes(metadata.actionTypes);
+    expect(actionTypes).toEqual({ noop: actionTypes.noop });
+    expect(actionTypes.noop).toMatchObject({
+      apiName: "noop",
+      operations: [],
+      parameters: {},
+    });
+  });
+
+  it("unwraps block-only ActionTypeFullMetadata during SDK generation", () => {
+    const action: Ontologies.ActionTypeV2 = {
+      apiName: "createMobile",
+      displayName: "Create Mobile",
+      operations: [],
+      parameters: {},
+      rid: "ri.actions.main.action-type.create-mobile",
+      status: "ACTIVE",
+    };
+
+    expect(
+      normalizeSdkGenerationActionTypes({
+        createMobile: { actionType: action, fullLogicRules: [] },
+      }),
+    ).toEqual({ createMobile: action });
+  });
+
   it("keeps wrapped block-only inputs backwards compatible", () => {
     const block = emptyBlock();
 
     expect(unwrapSdkGenerationInput({ ontology: block })).toBe(block);
   });
 
-  it("preserves Value Types from a complete Maker V2 envelope", () => {
+  it("preserves Value Types and generates their literal unions from the SDK input", async () => {
+    const randomnessKey = "00000000-0000-0000-0000-000000000000";
+    const valueTypeRid = `ri.ontology-metadata.temp.value-type.${
+      createHash("sha256")
+        .update(`mobility-${randomnessKey}`, "utf8")
+        .digest("hex")
+    }`;
+    const versionId = valueTypeVersionId("1.0.0");
+    const ontology = emptyBlock();
     const envelope: OntologyIrV2 = {
       importedOntology: emptyBlock(),
       importedValueTypes: [],
-      ontology: emptyBlock(),
-      randomnessKey: "00000000-0000-0000-0000-000000000000",
+      ontology: {
+        ...ontology,
+        interfaceTypes: {
+          "ri.interface.Mobile": {
+            interfaceType: {
+              actionTypeConstraints: [],
+              apiName: "Mobile",
+              displayMetadata: { displayName: "Mobile" },
+              extendsInterfaces: [],
+              links: [],
+              properties: [],
+              propertiesV2: {},
+              propertiesV3: {
+                mobility: {
+                  type: "sharedPropertyBasedPropertyType",
+                  sharedPropertyBasedPropertyType: {
+                    requireImplementation: true,
+                    sharedPropertyType: {
+                      aliases: [],
+                      apiName: "mobility",
+                      displayMetadata: {
+                        displayName: "Mobility",
+                        visibility: "NORMAL",
+                      },
+                      indexedForSearch: true,
+                      rid: "ri.shared-property.mobility",
+                      type: {
+                        type: "string",
+                        string: {
+                          isLongText: false,
+                          supportsExactMatching: true,
+                        },
+                      },
+                      typeClasses: [],
+                      valueType: { rid: valueTypeRid, versionId },
+                    },
+                  },
+                },
+              },
+              rid: "ri.interface.Mobile",
+              status: { type: "active", active: {} },
+            },
+          },
+        },
+        knownIdentifiers: {
+          ...ontology.knownIdentifiers,
+          valueTypes: {
+            [valueTypeRid]: { [versionId]: "mobility-value-type" },
+          },
+        },
+      },
+      randomnessKey,
       transitiveImportedOntology: emptyBlock(),
       valueTypes: [
         {
@@ -102,7 +278,7 @@ describe("convertSdkGenerationInput", () => {
                           useIgnoreCase: false,
                           values: ["Moving", "Stationary"],
                         },
-                      },
+                      } satisfies StringValueTypeConstraint["string"],
                     },
                   },
                 },
@@ -124,5 +300,22 @@ describe("convertSdkGenerationInput", () => {
       ],
       version: "1.0.0",
     });
+
+    const generated = createInMemoryFiles();
+    const generationMetadata = {
+      ...metadata,
+      actionTypes: normalizeSdkGenerationActionTypes(metadata.actionTypes),
+    };
+    await generateClientSdkVersionTwoPointZero(
+      generationMetadata,
+      "generate-sdk/test",
+      generated.fs,
+      "generated",
+      "module",
+    );
+
+    expect(
+      generated.files.get("generated/ontology/interfaces/Mobile.ts"),
+    ).toContain("readonly mobility: 'Moving' | 'Stationary' | undefined;");
   });
 });

--- a/packages/generator-converters.preview/src/cli/generate-sdk.test.ts
+++ b/packages/generator-converters.preview/src/cli/generate-sdk.test.ts
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { OntologyIrV2 } from "@osdk/client.unstable";
+import { describe, expect, it } from "vitest";
+import {
+  convertSdkGenerationInput,
+  unwrapSdkGenerationInput,
+} from "./convertSdkGenerationInput.js";
+
+function emptyBlock(): OntologyIrV2["ontology"] {
+  return {
+    actionTypes: {},
+    blockOutputCompassLocations: {},
+    interfaceTypes: {},
+    knownIdentifiers: {
+      actionParameterIds: {},
+      actionParameters: {},
+      actionTypes: {},
+      datasourceColumns: {},
+      datasources: {},
+      filesDatasources: {},
+      functions: {},
+      geotimeSeriesSyncs: {},
+      groupIds: {},
+      interfaceActionTypeConstraints: {},
+      interfaceLinkTypes: {},
+      interfaceParameterConstraints: {},
+      interfacePropertyTypes: {},
+      interfaceTypes: {},
+      linkTypeIds: {},
+      linkTypes: {},
+      markings: {},
+      objectPropertyTypeIdsToRids: {},
+      objectTypeIds: {},
+      objectTypes: {},
+      propertyTypeIds: {},
+      propertyTypes: {},
+      sharedPropertyTypes: {},
+      structFieldRidsToApiNames: {},
+      timeSeriesSyncs: {},
+      valueTypes: {},
+      webhooks: {},
+      workshopModules: {},
+    },
+    linkTypes: {},
+    objectTypes: {},
+    ruleSets: {},
+    sharedPropertyTypes: {},
+  };
+}
+
+describe("convertSdkGenerationInput", () => {
+  it("keeps wrapped block-only inputs backwards compatible", () => {
+    const block = emptyBlock();
+
+    expect(unwrapSdkGenerationInput({ ontology: block })).toBe(block);
+  });
+
+  it("preserves Value Types from a complete Maker V2 envelope", () => {
+    const envelope: OntologyIrV2 = {
+      importedOntology: emptyBlock(),
+      importedValueTypes: [],
+      ontology: emptyBlock(),
+      randomnessKey: "00000000-0000-0000-0000-000000000000",
+      transitiveImportedOntology: emptyBlock(),
+      valueTypes: [
+        {
+          metadata: {
+            apiName: "mobility",
+            baseType: { type: "string", string: {} },
+            displayMetadata: {
+              description: "Movement state",
+              displayName: "Mobility",
+            },
+            status: { type: "active", active: {} },
+          },
+          versions: [
+            {
+              baseType: { type: "string", string: {} },
+              constraints: [
+                {
+                  constraint: {
+                    constraint: {
+                      type: "string",
+                      string: {
+                        type: "oneOf",
+                        oneOf: {
+                          useIgnoreCase: false,
+                          values: ["Moving", "Stationary"],
+                        },
+                      },
+                    },
+                  },
+                },
+              ],
+              exampleValues: [],
+              version: "1.0.0",
+            },
+          ],
+        },
+      ],
+    };
+
+    const metadata = convertSdkGenerationInput(envelope);
+
+    expect(metadata.valueTypes.mobility).toMatchObject({
+      apiName: "mobility",
+      constraints: [
+        { type: "enum", options: ["Moving", "Stationary"] },
+      ],
+      version: "1.0.0",
+    });
+  });
+});

--- a/packages/generator-converters.preview/src/cli/generate-sdk.ts
+++ b/packages/generator-converters.preview/src/cli/generate-sdk.ts
@@ -33,7 +33,11 @@ import { consola } from "consola";
 import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
 
-import { PreviewOntologyIrConverter } from "../PreviewOntologyIrConverter.js";
+import {
+  convertSdkGenerationInput,
+  isSdkGenerationInput,
+  unwrapSdkGenerationInput,
+} from "./convertSdkGenerationInput.js";
 
 const PYTHON_SDK_PACKAGE_NAME = "ontology_sdk";
 
@@ -42,9 +46,7 @@ const PYTHON_SDK_PACKAGE_NAME = "ontology_sdk";
  * so that Python function discovery can resolve ontology type imports.
  */
 function generatePythonSdk(
-  previewMetadata: ReturnType<
-    typeof PreviewOntologyIrConverter.getPreviewFullMetadataFromBlockData
-  >,
+  previewMetadata: ReturnType<typeof convertSdkGenerationInput>,
   pythonBinary: string,
 ): void {
   // Build the Python-compatible metadata: unwrap actionTypes and add globalFunctions
@@ -238,26 +240,17 @@ async function main(): Promise<void> {
   consola.info(`Converting ${inputFile}...`);
 
   const fileContent = await fs.readFile(inputFile, "utf-8");
-  let blockDataJson: unknown;
+  let sdkGenerationInput: unknown;
   try {
-    const parsed = JSON.parse(fileContent);
-    // Handle both wrapped (ontology.objectTypes) and unwrapped (objectTypes) formats
-    blockDataJson = parsed.ontology ?? parsed;
+    sdkGenerationInput = unwrapSdkGenerationInput(JSON.parse(fileContent));
   } catch {
     consola.error(`Failed to parse JSON from ${inputFile}`);
     process.exit(1);
   }
 
-  // Basic structural validation before passing to converter
-  const blockData = blockDataJson as Record<string, unknown>;
-  if (
-    !blockData
-    || typeof blockData !== "object"
-    || !("objectTypes" in blockData)
-    || !("actionTypes" in blockData)
-  ) {
+  if (!isSdkGenerationInput(sdkGenerationInput)) {
     consola.error(
-      `Invalid Ontology structure in ${inputFile}. Expected objectTypes and actionTypes fields.`,
+      `Invalid Ontology structure in ${inputFile}. Expected complete OntologyIrV2 envelope or objectTypes and actionTypes fields.`,
     );
     process.exit(1);
   }
@@ -266,13 +259,10 @@ async function main(): Promise<void> {
     ? JSON.parse(await fs.readFile(argv.importJson, "utf-8"))
     : undefined;
 
-  const previewMetadata = PreviewOntologyIrConverter
-    .getPreviewFullMetadataFromBlockData(
-      blockDataJson as Parameters<
-        typeof PreviewOntologyIrConverter.getPreviewFullMetadataFromBlockData
-      >[0],
-      importJson,
-    );
+  const previewMetadata = convertSdkGenerationInput(
+    sdkGenerationInput,
+    importJson,
+  );
 
   // Generate the Python SDK before function discovery so that Python functions
   // that import ontology types (e.g. `from ontology_sdk.ontology.objects import X`)

--- a/packages/generator-converters.preview/src/cli/generate-sdk.ts
+++ b/packages/generator-converters.preview/src/cli/generate-sdk.ts
@@ -36,6 +36,7 @@ import { hideBin } from "yargs/helpers";
 import {
   convertSdkGenerationInput,
   isSdkGenerationInput,
+  normalizeSdkGenerationActionTypes,
   unwrapSdkGenerationInput,
 } from "./convertSdkGenerationInput.js";
 
@@ -49,14 +50,10 @@ function generatePythonSdk(
   previewMetadata: ReturnType<typeof convertSdkGenerationInput>,
   pythonBinary: string,
 ): void {
-  // Build the Python-compatible metadata: unwrap actionTypes and add globalFunctions
   const pythonMetadata = {
     ...previewMetadata,
-    actionTypes: Object.fromEntries(
-      Object.entries(previewMetadata.actionTypes).map(([key, fullMeta]) => [
-        key,
-        fullMeta.actionType,
-      ]),
+    actionTypes: normalizeSdkGenerationActionTypes(
+      previewMetadata.actionTypes,
     ),
     globalFunctions: { queryTypes: {}, valueTypes: {} },
   };
@@ -311,14 +308,10 @@ async function main(): Promise<void> {
     }
   }
 
-  // Convert ActionTypeFullMetadata to ActionTypeV2 for generator compatibility
   const metadata = {
     ...previewMetadata,
-    actionTypes: Object.fromEntries(
-      Object.entries(previewMetadata.actionTypes).map(([key, fullMeta]) => [
-        key,
-        fullMeta.actionType,
-      ]),
+    actionTypes: normalizeSdkGenerationActionTypes(
+      previewMetadata.actionTypes,
     ),
   };
 

--- a/packages/maker-experimental/src/cli/main.test.ts
+++ b/packages/maker-experimental/src/cli/main.test.ts
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import type { OntologyIrV2 } from "@osdk/client.unstable";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { writeOntologyArtifacts } from "./main.js";
+
+function emptyBlock(): OntologyIrV2["ontology"] {
+  return {
+    actionTypes: {},
+    blockOutputCompassLocations: {},
+    interfaceTypes: {},
+    knownIdentifiers: {
+      actionParameterIds: {},
+      actionParameters: {},
+      actionTypes: {},
+      datasourceColumns: {},
+      datasources: {},
+      filesDatasources: {},
+      functions: {},
+      geotimeSeriesSyncs: {},
+      groupIds: {},
+      interfaceActionTypeConstraints: {},
+      interfaceLinkTypes: {},
+      interfaceParameterConstraints: {},
+      interfacePropertyTypes: {},
+      interfaceTypes: {},
+      linkTypeIds: {},
+      linkTypes: {},
+      markings: {},
+      objectPropertyTypeIdsToRids: {},
+      objectTypeIds: {},
+      objectTypes: {},
+      propertyTypeIds: {},
+      propertyTypes: {},
+      sharedPropertyTypes: {},
+      structFieldRidsToApiNames: {},
+      timeSeriesSyncs: {},
+      valueTypes: {},
+      webhooks: {},
+      workshopModules: {},
+    },
+    linkTypes: {},
+    objectTypes: {},
+    ruleSets: {},
+    sharedPropertyTypes: {},
+  };
+}
+
+describe("writeOntologyArtifacts", () => {
+  let buildDir: string;
+
+  beforeEach(() => {
+    buildDir = fs.mkdtempSync(path.join(os.tmpdir(), "maker-artifacts-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(buildDir, { recursive: true, force: true });
+  });
+
+  it("rejects an SDK output inside the Marketplace block data directory", async () => {
+    const ontologyIr: OntologyIrV2 = {
+      importedOntology: emptyBlock(),
+      importedValueTypes: [],
+      ontology: emptyBlock(),
+      randomnessKey: "00000000-0000-0000-0000-000000000000",
+      transitiveImportedOntology: emptyBlock(),
+      valueTypes: [],
+    };
+
+    await expect(
+      writeOntologyArtifacts(
+        ontologyIr,
+        buildDir,
+        path.join(buildDir, "temp_block_data", "ontology.json"),
+      ),
+    ).rejects.toThrow(
+      "sdkOutput must be outside the Marketplace block data directory",
+    );
+  });
+
+  it("separates Marketplace block data from the SDK generation envelope", async () => {
+    const ontology = emptyBlock();
+    const ontologyIr: OntologyIrV2 = {
+      importedOntology: emptyBlock(),
+      importedValueTypes: [],
+      ontology,
+      randomnessKey: "00000000-0000-0000-0000-000000000000",
+      transitiveImportedOntology: emptyBlock(),
+      valueTypes: [],
+    };
+    const sdkOutput = path.join(buildDir, "sdk_input", "ontology.json");
+
+    await writeOntologyArtifacts(ontologyIr, buildDir, sdkOutput);
+
+    const marketplaceFile = JSON.parse(
+      fs.readFileSync(
+        path.join(buildDir, "temp_block_data", "ontology.json"),
+        "utf-8",
+      ),
+    );
+    expect(marketplaceFile).toEqual(ontology);
+    expect(marketplaceFile).toHaveProperty("objectTypes");
+    expect(marketplaceFile).toHaveProperty("actionTypes");
+    expect(marketplaceFile).not.toHaveProperty("ontology");
+    expect(marketplaceFile).not.toHaveProperty("valueTypes");
+    expect(marketplaceFile).not.toHaveProperty("transitiveImportedOntology");
+
+    const sdkInputFile = JSON.parse(fs.readFileSync(sdkOutput, "utf-8"));
+    expect(sdkInputFile).toEqual(ontologyIr);
+    expect(sdkInputFile).toHaveProperty("ontology");
+    expect(sdkInputFile).toHaveProperty("valueTypes", []);
+    expect(sdkInputFile).toHaveProperty("importedValueTypes", []);
+    expect(sdkInputFile).toHaveProperty("transitiveImportedOntology");
+  });
+});

--- a/packages/maker-experimental/src/cli/main.ts
+++ b/packages/maker-experimental/src/cli/main.ts
@@ -256,7 +256,7 @@ export default async function main(
 
   // Write ontology.json to the block data directory
   const ontologyJsonPath = path.join(blockDataDir, "ontology.json");
-  const ontologyJson = JSON.stringify(ontologyIr.ontology, null, 2);
+  const ontologyJson = JSON.stringify(ontologyIr, null, 2);
   await fs.promises.writeFile(ontologyJsonPath, ontologyJson);
   consola.info(`Wrote ontology.json to ${ontologyJsonPath}`);
 

--- a/packages/maker-experimental/src/cli/main.ts
+++ b/packages/maker-experimental/src/cli/main.ts
@@ -21,6 +21,7 @@ import { pathToFileURL } from "node:url";
 import type {
   LinkTypeBlockDataV2,
   ObjectTypeBlockDataV2,
+  OntologyIrV2,
 } from "@osdk/client.unstable";
 import type { OntologyFullMetadata } from "@osdk/foundry.ontologies";
 import {
@@ -63,6 +64,7 @@ export default async function main(
     input: string;
     output: string;
     valueTypesOutput: string;
+    sdkOutput: string;
     apiNamespace: string;
     buildDir: string;
     codegenDir?: string;
@@ -96,6 +98,12 @@ export default async function main(
         describe: "Output file for value types BlockGeneratorResult JSON",
         type: "string",
         default: "build/value_types_block_generator_result.json",
+        coerce: path.resolve,
+      },
+      sdkOutput: {
+        describe: "Output file for the complete SDK generation input",
+        type: "string",
+        default: "build/sdk_input/ontology.json",
         coerce: path.resolve,
       },
       apiNamespace: {
@@ -248,17 +256,11 @@ export default async function main(
     importedLinkTypeIdsByApiName,
   );
 
-  // Create temp directory for block data
-  const blockDataDir = path.join(commandLineOpts.buildDir, "temp_block_data");
-  if (!fs.existsSync(blockDataDir)) {
-    await fs.promises.mkdir(blockDataDir, { recursive: true });
-  }
-
-  // Write ontology.json to the block data directory
-  const ontologyJsonPath = path.join(blockDataDir, "ontology.json");
-  const ontologyJson = JSON.stringify(ontologyIr, null, 2);
-  await fs.promises.writeFile(ontologyJsonPath, ontologyJson);
-  consola.info(`Wrote ontology.json to ${ontologyJsonPath}`);
+  const blockDataDir = await writeOntologyArtifacts(
+    ontologyIr,
+    commandLineOpts.buildDir,
+    commandLineOpts.sdkOutput,
+  );
 
   const importedMetadata =
     OntologyBlockDataToFullMetadataConverter.getFullMetadataFromBlockData(
@@ -478,6 +480,37 @@ export default async function main(
       `Value type BlockGeneratorResult written to ${commandLineOpts.valueTypesOutput}`,
     );
   }
+}
+
+export async function writeOntologyArtifacts(
+  ontologyIr: OntologyIrV2,
+  buildDir: string,
+  sdkOutput: string,
+): Promise<string> {
+  const blockDataDir = path.resolve(buildDir, "temp_block_data");
+  const resolvedSdkOutput = path.resolve(sdkOutput);
+  invariant(
+    resolvedSdkOutput !== blockDataDir &&
+      !resolvedSdkOutput.startsWith(`${blockDataDir}${path.sep}`),
+    "sdkOutput must be outside the Marketplace block data directory",
+  );
+  await fs.promises.mkdir(blockDataDir, { recursive: true });
+
+  const ontologyJsonPath = path.join(blockDataDir, "ontology.json");
+  await fs.promises.writeFile(
+    ontologyJsonPath,
+    JSON.stringify(ontologyIr.ontology, null, 2),
+  );
+  consola.info(`Wrote ontology.json to ${ontologyJsonPath}`);
+
+  await fs.promises.mkdir(path.dirname(resolvedSdkOutput), { recursive: true });
+  await fs.promises.writeFile(
+    resolvedSdkOutput,
+    JSON.stringify(ontologyIr, null, 2),
+  );
+  consola.info(`Wrote SDK generation input to ${resolvedSdkOutput}`);
+
+  return blockDataDir;
 }
 
 async function loadOntology(


### PR DESCRIPTION
the current maker-to-sdk handoff passed ontology block data without its value type registries

• write a complete maker v2 envelope for sdk generation
• convert the complete envelope before invoking the existing generator
• preserve block-only input compatibility for existing callers