### PR TITLE
support portable generated sdks

### DIFF
--- a/.changeset/portable-sdk-ontology-rid.md
+++ b/.changeset/portable-sdk-ontology-rid.md
@@ -1,0 +1,5 @@
+---
+"@osdk/generator": minor
+---
+
+Allow generated SDKs to omit the installed ontology RID and branch identity.

--- a/packages/generator/src/GenerateContext/GenerateContext.ts
+++ b/packages/generator/src/GenerateContext/GenerateContext.ts
@@ -28,4 +28,5 @@ export interface GenerateContext {
   ontologyApiNamespace?: string | undefined;
   apiNamespacePackageMap?: Map<string, string>;
   forInternalUse?: boolean;
+  omitOntologyRid?: boolean;
 }

--- a/packages/generator/src/v2.0/generateClientSdkVersionTwoPointZero.test.ts
+++ b/packages/generator/src/v2.0/generateClientSdkVersionTwoPointZero.test.ts
@@ -1976,6 +1976,34 @@ describe("generator", () => {
 
       expect(helper.getFiles()["/foo/index.ts"]).toContain("$ontologyRid");
     });
+
+    it("omits the ontology and branch identities for portable SDKs", async () => {
+      const BASE_PATH = "/foo";
+
+      await generateClientSdkVersionTwoPointZero(
+        TodoWireOntology,
+        "",
+        helper.minimalFiles,
+        BASE_PATH,
+        "module",
+        new Map(),
+        new Map(),
+        new Map(),
+        false,
+        [],
+        false,
+        true,
+      );
+
+      expect(helper.getFiles()["/foo/index.ts"]).not.toContain("$ontologyRid");
+      expect(helper.getFiles()["/foo/index.ts"]).not.toContain("$branch");
+      expect(helper.getFiles()["/foo/OntologyMetadata.ts"]).not.toContain(
+        "$ontologyRid",
+      );
+      expect(helper.getFiles()["/foo/OntologyMetadata.ts"]).not.toContain(
+        "$branch",
+      );
+    });
   });
 
   describe("exportOntologyMetadata", () => {

--- a/packages/generator/src/v2.0/generateClientSdkVersionTwoPointZero.ts
+++ b/packages/generator/src/v2.0/generateClientSdkVersionTwoPointZero.ts
@@ -41,6 +41,7 @@ export async function generateClientSdkVersionTwoPointZero(
   forInternalUse: boolean = false,
   fixedVersionQueryTypes: string[] = [],
   exportOntologyMetadata: boolean = false,
+  omitOntologyRid: boolean = false,
 ): Promise<void> {
   const importExt = ".js"; // turns out you can always use the extension
 
@@ -65,6 +66,7 @@ export async function generateClientSdkVersionTwoPointZero(
     outDir,
     forInternalUse,
     fixedVersionQueryTypes,
+    omitOntologyRid,
   };
 
   await generateRootIndexTsFile(ctx);

--- a/packages/generator/src/v2.0/generateMetadata.ts
+++ b/packages/generator/src/v2.0/generateMetadata.ts
@@ -24,7 +24,13 @@ const ExpectedOsdkVersion = "2.59.0";
 // END: THIS IS GENERATED CODE. DO NOT EDIT.
 
 export async function generateOntologyMetadataTypeFile(
-  { fs, outDir, ontology, ontologyApiNamespace }: GenerateContext,
+  {
+    fs,
+    outDir,
+    ontology,
+    ontologyApiNamespace,
+    omitOntologyRid,
+  }: GenerateContext,
   userAgent: string,
 ): Promise<void> {
   await fs.writeFile(
@@ -34,7 +40,7 @@ export async function generateOntologyMetadataTypeFile(
       export type $ExpectedClientVersion = "${ExpectedOsdkVersion}";
       export const $osdkMetadata = { extraUserAgent: "${userAgent}" };
       ${
-        ontologyApiNamespace == null
+        ontologyApiNamespace == null && !omitOntologyRid
           ? `
         export const $ontologyRid = "${ontology.ontology.rid}";
         /**

--- a/packages/generator/src/v2.0/generateRootIndexTsFile.ts
+++ b/packages/generator/src/v2.0/generateRootIndexTsFile.ts
@@ -20,7 +20,14 @@ import type { GenerateContext } from "../GenerateContext/GenerateContext.js";
 import { formatTs } from "../util/test/formatTs.js";
 
 export async function generateRootIndexTsFile(
-  { fs, outDir, importExt, ontologyApiNamespace, ontology }: GenerateContext,
+  {
+    fs,
+    outDir,
+    importExt,
+    ontologyApiNamespace,
+    ontology,
+    omitOntologyRid,
+  }: GenerateContext,
 ): Promise<void> {
   await fs.writeFile(
     path.join(outDir, "index.ts"),
@@ -43,7 +50,7 @@ export async function generateRootIndexTsFile(
         export * as $Queries from "./ontology/queries${importExt}";
         export { $osdkMetadata } from "./OntologyMetadata${importExt}";
         ${
-        ontologyApiNamespace == null
+        ontologyApiNamespace == null && !omitOntologyRid
           ? `export { $branch, $ontologyRid } from "./OntologyMetadata${importExt}";`
           : ``
       }


### PR DESCRIPTION
generated SDKs can now omit installed ontology and branch identities

• add an opt-in generator setting for portable SDK output
• omit ontology and branch identity exports when enabled
• keep existing generated SDK output unchanged by default