### PR TITLE
preserve interface link actions in oac conversion

### DIFF
--- a/.changeset/preserve-interface-link-actions.md
+++ b/.changeset/preserve-interface-link-actions.md
@@ -1,0 +1,6 @@
+---
+"@osdk/generator-converters.ontologyir": patch
+"@osdk/generator-converters.preview": patch
+---
+
+Preserve supported create and delete interface link operations in converted Action metadata.

--- a/packages/generator-converters.ontologyir/src/OntologyBlockDataToFullMetadataConverter.ts
+++ b/packages/generator-converters.ontologyir/src/OntologyBlockDataToFullMetadataConverter.ts
@@ -19,6 +19,7 @@ import type {
   ActionTypeStatus,
   InterfacePropertyTypeType,
   InterfaceTypeBlockDataV2,
+  LinkedObjectReference,
   LinkTypeBlockDataV2,
   LinkTypeStatus,
   MarketplaceInterfaceLinkType,
@@ -67,10 +68,14 @@ export class OntologyBlockDataToFullMetadataConverter {
       blockData.linkTypes,
       objectTypeLookup,
     );
+    const interfaceLinkLookup = buildBlockDataInterfaceLinkTypeLookup(
+      blockData,
+    );
     const actionTypes = this.getOsdkActionTypesFromBlockData(
       blockData,
       objectTypeLookup,
       interfaceTypeLookup,
+      interfaceLinkLookup,
     );
 
     return {
@@ -365,6 +370,7 @@ export class OntologyBlockDataToFullMetadataConverter {
     blockData: OntologyBlockDataV2,
     objectTypeLookup: BlockDataApiNameLookup | undefined,
     interfaceTypeLookup: BlockDataApiNameLookup | undefined,
+    interfaceLinkLookup?: BlockDataApiNameLookup,
   ): Record<ApiName, Ontologies.ActionTypeV2> {
     const result: Record<ApiName, Ontologies.ActionTypeV2> = {};
 
@@ -384,7 +390,8 @@ export class OntologyBlockDataToFullMetadataConverter {
           action,
           objectTypeLookup,
           interfaceTypeLookup,
-        ),
+          interfaceLinkLookup,
+        ) as Ontologies.LogicRule[],
         status: this.convertActionTypeStatusFromBlockData(metadata.status),
       };
 
@@ -398,7 +405,14 @@ export class OntologyBlockDataToFullMetadataConverter {
     action: ActionTypeBlockDataV2,
     objectTypeLookup: BlockDataApiNameLookup | undefined,
     interfaceTypeLookup: BlockDataApiNameLookup | undefined,
-  ): Ontologies.LogicRule[] {
+    interfaceLinkLookup?: BlockDataApiNameLookup,
+  ): Array<
+    | Ontologies.LogicRule
+    | Extract<
+      Ontologies.ActionLogicRule,
+      { type: "createInterfaceLink" | "deleteInterfaceLink" }
+    >
+  > {
     return action.actionType.actionTypeLogic.logic.rules.flatMap(irLogic => {
       switch (irLogic.type) {
         case "addInterfaceRule": {
@@ -523,9 +537,45 @@ export class OntologyBlockDataToFullMetadataConverter {
           }
         }
         case "functionRule":
-        case "addInterfaceLinkRuleV2":
-        case "deleteInterfaceLinkRule":
           return [];
+        case "addInterfaceLinkRuleV2": {
+          const rule = irLogic.addInterfaceLinkRuleV2;
+          return {
+            type: "createInterfaceLink",
+            interfaceTypeApiName: resolveBlockDataApiName(
+              rule.interfaceTypeRid,
+              interfaceTypeLookup,
+            ),
+            interfaceLinkTypeApiName: resolveBlockDataApiName(
+              rule.interfaceLinkTypeRid,
+              interfaceLinkLookup,
+            ),
+            sourceObject: firstExistingObjectParameterId(
+              rule.sourceObjects,
+              "sourceObjects",
+            ),
+            targetObject: firstExistingObjectParameterId(
+              rule.targetObjects,
+              "targetObjects",
+            ),
+          };
+        }
+        case "deleteInterfaceLinkRule": {
+          const rule = irLogic.deleteInterfaceLinkRule;
+          return {
+            type: "deleteInterfaceLink",
+            interfaceTypeApiName: resolveBlockDataApiName(
+              rule.interfaceTypeRid,
+              interfaceTypeLookup,
+            ),
+            interfaceLinkTypeApiName: resolveBlockDataApiName(
+              rule.interfaceLinkTypeRid,
+              interfaceLinkLookup,
+            ),
+            sourceObject: rule.sourceObject,
+            targetObject: rule.targetObject,
+          };
+        }
         default:
           throw new Error("Unknown logic rule type");
       }
@@ -1372,4 +1422,17 @@ export function resolveBlockDataApiName(
     return id;
   }
   return lookup.byRid.get(id) ?? lookup.byHyphenated.get(id) ?? id;
+}
+
+function firstExistingObjectParameterId(
+  references: ReadonlyArray<LinkedObjectReference>,
+  field: string,
+): string {
+  const first = references[0];
+  if (references.length !== 1 || first?.type !== "existingObject") {
+    throw new Error(
+      `Interface-link rule ${field} must reference exactly one existing object`,
+    );
+  }
+  return first.existingObject;
 }

--- a/packages/generator-converters.ontologyir/src/OntologyIrToFullMetadaConvert.test.ts
+++ b/packages/generator-converters.ontologyir/src/OntologyIrToFullMetadaConvert.test.ts
@@ -17,6 +17,7 @@
 import { fileURLToPath } from "node:url";
 import { describe, expect, it, vi } from "vitest";
 import { isInjectedRuntimeInput } from "./convertDataType.js";
+import { OntologyBlockDataToFullMetadataConverter } from "./OntologyBlockDataToFullMetadataConverter.js";
 import {
   type IDiscoveredFunction,
   OntologyIrToFullMetadataConverter,
@@ -3637,5 +3638,294 @@ describe(OntologyIrToFullMetadataConverter, () => {
     } finally {
       createProgramSpy.mockRestore();
     }
+  });
+  describe("interface link action operations", () => {
+    type BlockDataAction = Parameters<
+      typeof OntologyBlockDataToFullMetadataConverter.getOsdkActionOperationsFromBlockData
+    >[0];
+    type CurrentIrAction = Parameters<
+      typeof OntologyIrToFullMetadataConverter.getOsdkActionOperations
+    >[0];
+    type BlockDataRule =
+      BlockDataAction["actionType"]["actionTypeLogic"]["logic"]["rules"][
+        number
+      ];
+    type BlockDataCreateRule = Extract<
+      BlockDataRule,
+      { type: "addInterfaceLinkRuleV2" }
+    >;
+    type BlockDataDeleteRule = Extract<
+      BlockDataRule,
+      { type: "deleteInterfaceLinkRule" }
+    >;
+
+    const createRule: BlockDataCreateRule = {
+      type: "addInterfaceLinkRuleV2",
+      addInterfaceLinkRuleV2: {
+        interfaceTypeRid: "ri.interface.item",
+        interfaceLinkTypeRid: "ri.interface-link.observations",
+        sourceObjects: [{
+          type: "existingObject",
+          existingObject: "source",
+        }],
+        targetObjects: [{
+          type: "existingObject",
+          existingObject: "target",
+        }],
+      },
+    };
+    const deleteRule: BlockDataDeleteRule = {
+      type: "deleteInterfaceLinkRule",
+      deleteInterfaceLinkRule: {
+        interfaceTypeRid: "ri.interface.item",
+        interfaceLinkTypeRid: "ri.interface-link.observations",
+        sourceObject: "source",
+        targetObject: "target",
+      },
+    };
+
+    function interfaceParameters() {
+      return {
+        source: {
+          displayMetadata: {
+            description: "",
+            displayName: "Source",
+            structFields: {},
+            structFieldsV2: [],
+            typeClasses: [],
+          },
+          id: "source",
+          rid: "ri.parameter.source",
+          type: {
+            type: "interfaceReference" as const,
+            interfaceReference: { interfaceTypeRid: "ri.interface.item" },
+          },
+        },
+        target: {
+          displayMetadata: {
+            description: "",
+            displayName: "Target",
+            structFields: {},
+            structFieldsV2: [],
+            typeClasses: [],
+          },
+          id: "target",
+          rid: "ri.parameter.target",
+          type: {
+            type: "interfaceReference" as const,
+            interfaceReference: { interfaceTypeRid: "ri.interface.item" },
+          },
+        },
+      };
+    }
+
+    function requiredInterfaceParameterValidation() {
+      return {
+        conditionalOverrides: [],
+        defaultValidation: {
+          display: {
+            renderHint: { type: "dropdown" as const, dropdown: {} },
+            visibility: { type: "editable" as const, editable: {} },
+          },
+          validation: {
+            allowedValues: {
+              type: "interfaceObjectQuery" as const,
+              interfaceObjectQuery: {
+                type: "interfaceObjectQuery" as const,
+                interfaceObjectQuery: {},
+              },
+            },
+            required: { type: "required" as const, required: {} },
+          },
+        },
+        structFieldValidations: {},
+      };
+    }
+
+    function blockDataAction(
+      rules: BlockDataAction["actionType"]["actionTypeLogic"]["logic"]["rules"],
+    ): BlockDataAction {
+      return {
+        actionType: {
+          actionTypeLogic: {
+            logic: { rules },
+            notifications: [],
+            validation: {
+              actionTypeLevelValidation: { ordering: [], rules: {} },
+              parameterValidations: {
+                source: requiredInterfaceParameterValidation(),
+                target: requiredInterfaceParameterValidation(),
+              },
+              sectionValidations: {},
+            },
+          },
+          metadata: {
+            apiName: "linkItems",
+            displayMetadata: {
+              applyingMessage: [],
+              description: "",
+              displayName: "Link items",
+              successMessage: [],
+              typeClasses: [],
+            },
+            formContentOrdering: [],
+            parameterOrdering: ["source", "target"],
+            parameters: interfaceParameters(),
+            rid: "ri.action.link-items",
+            sections: {},
+            status: { type: "active", active: {} },
+            version: "1.0.0",
+          },
+        },
+        parameterIds: {},
+      };
+    }
+
+    function currentIrAction(
+      rules: CurrentIrAction["actionType"]["actionTypeLogic"]["logic"]["rules"],
+    ): CurrentIrAction {
+      return {
+        actionType: {
+          actionTypeLogic: {
+            logic: { rules },
+            validation: {
+              actionTypeLevelValidation: { rules: {} },
+              parameterValidations: {
+                source: requiredInterfaceParameterValidation(),
+                target: requiredInterfaceParameterValidation(),
+              },
+              sectionValidations: {},
+            },
+          },
+          metadata: {
+            apiName: "linkItems",
+            displayMetadata: {
+              applyingMessage: [],
+              description: "",
+              displayName: "Link items",
+              successMessage: [],
+              typeClasses: [],
+            },
+            formContentOrdering: [],
+            parameterOrdering: ["source", "target"],
+            parameters: interfaceParameters(),
+            sections: {},
+            status: { type: "active", active: {} },
+          },
+        },
+      };
+    }
+
+    const interfaceTypeLookup = {
+      byRid: new Map([["ri.interface.item", "local.Item"]]),
+      byHyphenated: new Map<string, string>(),
+    };
+    const interfaceLinkLookup = {
+      byRid: new Map([[
+        "ri.interface-link.observations",
+        "observations",
+      ]]),
+      byHyphenated: new Map<string, string>(),
+    };
+
+    it("converts block-data create and delete interface link rules", () => {
+      expect(
+        OntologyBlockDataToFullMetadataConverter
+          .getOsdkActionOperationsFromBlockData(
+            blockDataAction([createRule, deleteRule]),
+            undefined,
+            interfaceTypeLookup,
+            interfaceLinkLookup,
+          ),
+      ).toEqual([{
+        type: "createInterfaceLink",
+        interfaceTypeApiName: "local.Item",
+        interfaceLinkTypeApiName: "observations",
+        sourceObject: "source",
+        targetObject: "target",
+      }, {
+        type: "deleteInterfaceLink",
+        interfaceTypeApiName: "local.Item",
+        interfaceLinkTypeApiName: "observations",
+        sourceObject: "source",
+        targetObject: "target",
+      }]);
+    });
+
+    it.each(["sourceObjects", "targetObjects"] as const)(
+      "rejects invalid block-data %s references",
+      field => {
+        for (
+          const references of [
+            [],
+            [
+              createRule.addInterfaceLinkRuleV2[field][0],
+              createRule.addInterfaceLinkRuleV2[field][0],
+            ],
+            [{
+              type: "createdObjectReference" as const,
+              createdObjectReference: "createObjectRule",
+            }],
+          ]
+        ) {
+          const rule = {
+            ...createRule,
+            addInterfaceLinkRuleV2: {
+              ...createRule.addInterfaceLinkRuleV2,
+              [field]: references,
+            },
+          };
+
+          expect(() =>
+            OntologyBlockDataToFullMetadataConverter
+              .getOsdkActionOperationsFromBlockData(
+                blockDataAction([rule]),
+                undefined,
+                interfaceTypeLookup,
+                interfaceLinkLookup,
+              )
+          ).toThrow(
+            `Interface-link rule ${field} must reference exactly one existing object`,
+          );
+        }
+      },
+    );
+
+    it("converts current IR create and delete interface link rules", () => {
+      const currentCreateRule = {
+        ...createRule,
+        addInterfaceLinkRuleV2: {
+          ...createRule.addInterfaceLinkRuleV2,
+          interfaceTypeRid: "local.Item",
+          interfaceLinkTypeRid: "observations",
+        },
+      };
+      const currentDeleteRule = {
+        ...deleteRule,
+        deleteInterfaceLinkRule: {
+          ...deleteRule.deleteInterfaceLinkRule,
+          interfaceTypeRid: "local.Item",
+          interfaceLinkTypeRid: "observations",
+        },
+      };
+
+      expect(
+        OntologyIrToFullMetadataConverter.getOsdkActionOperations(
+          currentIrAction([currentCreateRule, currentDeleteRule]),
+        ),
+      ).toEqual([{
+        type: "createInterfaceLink",
+        interfaceTypeApiName: "local.Item",
+        interfaceLinkTypeApiName: "observations",
+        sourceObject: "source",
+        targetObject: "target",
+      }, {
+        type: "deleteInterfaceLink",
+        interfaceTypeApiName: "local.Item",
+        interfaceLinkTypeApiName: "observations",
+        sourceObject: "source",
+        targetObject: "target",
+      }]);
+    });
   });
 });

--- a/packages/generator-converters.ontologyir/src/OntologyIrToFullMetadataConverter.ts
+++ b/packages/generator-converters.ontologyir/src/OntologyIrToFullMetadataConverter.ts
@@ -15,6 +15,7 @@
  */
 
 import type {
+  LinkedObjectReference,
   OntologyIrActionTypeBlockDataV2,
   OntologyIrActionTypeStatus,
   OntologyIrInterfaceTypeBlockDataV2,
@@ -952,7 +953,9 @@ export class OntologyIrToFullMetadataConverter {
         displayName: metadata.displayMetadata.displayName,
         description: metadata.displayMetadata.description,
         parameters: this.getOsdkActionParameters(action),
-        operations: this.getOsdkActionOperations(action),
+        operations: this.getOsdkActionOperations(
+          action,
+        ) as Ontologies.LogicRule[],
         status: this.convertActionTypeStatus(metadata.status),
       };
 
@@ -967,7 +970,13 @@ export class OntologyIrToFullMetadataConverter {
    */
   static getOsdkActionOperations(
     action: OntologyIrActionTypeBlockDataV2,
-  ): Ontologies.LogicRule[] {
+  ): Array<
+    | Ontologies.LogicRule
+    | Extract<
+      Ontologies.ActionLogicRule,
+      { type: "createInterfaceLink" | "deleteInterfaceLink" }
+    >
+  > {
     return action.actionType.actionTypeLogic.logic.rules.flatMap(irLogic => {
       switch (irLogic.type) {
         case "addInterfaceRule": {
@@ -1074,9 +1083,32 @@ export class OntologyIrToFullMetadataConverter {
             );
           }
         }
-        case "addInterfaceLinkRuleV2":
-        case "deleteInterfaceLinkRule":
-          return [];
+        case "addInterfaceLinkRuleV2": {
+          const rule = irLogic.addInterfaceLinkRuleV2;
+          return {
+            type: "createInterfaceLink",
+            interfaceTypeApiName: rule.interfaceTypeRid,
+            interfaceLinkTypeApiName: rule.interfaceLinkTypeRid,
+            sourceObject: firstExistingObjectParameterId(
+              rule.sourceObjects,
+              "sourceObjects",
+            ),
+            targetObject: firstExistingObjectParameterId(
+              rule.targetObjects,
+              "targetObjects",
+            ),
+          };
+        }
+        case "deleteInterfaceLinkRule": {
+          const rule = irLogic.deleteInterfaceLinkRule;
+          return {
+            type: "deleteInterfaceLink",
+            interfaceTypeApiName: rule.interfaceTypeRid,
+            interfaceLinkTypeApiName: rule.interfaceLinkTypeRid,
+            sourceObject: rule.sourceObject,
+            targetObject: rule.targetObject,
+          };
+        }
         default:
           throw new Error("Unknown logic rule type");
       }
@@ -1593,4 +1625,17 @@ function isParameterRequired(
   return action.actionType.actionTypeLogic.validation
     .parameterValidations[paramKey].defaultValidation.validation.required.type
     === "required";
+}
+
+function firstExistingObjectParameterId(
+  references: ReadonlyArray<LinkedObjectReference>,
+  field: string,
+): string {
+  const first = references[0];
+  if (references.length !== 1 || first?.type !== "existingObject") {
+    throw new Error(
+      `Interface-link rule ${field} must reference exactly one existing object`,
+    );
+  }
+  return first.existingObject;
 }

--- a/packages/generator-converters.preview/src/PreviewOntologyIrConverter.test.ts
+++ b/packages/generator-converters.preview/src/PreviewOntologyIrConverter.test.ts
@@ -1,0 +1,281 @@
+/*
+ * Copyright 2025 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { OntologyBlockDataV2 } from "@osdk/client.unstable";
+import { describe, expect, it } from "vitest";
+import { PreviewOntologyIrConverter } from "./PreviewOntologyIrConverter.js";
+
+function interfaceActionBlockData(): OntologyBlockDataV2 {
+  const interfaceParameters = {
+    source: {
+      displayMetadata: {
+        description: "",
+        displayName: "Source",
+        structFields: {},
+        structFieldsV2: [],
+        typeClasses: [],
+      },
+      id: "source",
+      rid: "ri.parameter.source",
+      type: {
+        type: "interfaceReference" as const,
+        interfaceReference: { interfaceTypeRid: "ri.interface.item" },
+      },
+    },
+    target: {
+      displayMetadata: {
+        description: "",
+        displayName: "Target",
+        structFields: {},
+        structFieldsV2: [],
+        typeClasses: [],
+      },
+      id: "target",
+      rid: "ri.parameter.target",
+      type: {
+        type: "interfaceReference" as const,
+        interfaceReference: { interfaceTypeRid: "ri.interface.observation" },
+      },
+    },
+  };
+  const actionMetadata = {
+    displayMetadata: {
+      applyingMessage: [],
+      description: "",
+      successMessage: [],
+      typeClasses: [],
+    },
+    formContentOrdering: [],
+    parameterOrdering: ["source", "target"],
+    parameters: interfaceParameters,
+    sections: {},
+    status: { type: "active", active: {} } as const,
+    version: "1.0.0",
+  };
+  const parameterValidation = {
+    conditionalOverrides: [],
+    defaultValidation: {
+      display: {
+        renderHint: { type: "dropdown" as const, dropdown: {} },
+        visibility: { type: "editable" as const, editable: {} },
+      },
+      validation: {
+        allowedValues: {
+          type: "interfaceObjectQuery" as const,
+          interfaceObjectQuery: {
+            type: "interfaceObjectQuery" as const,
+            interfaceObjectQuery: {},
+          },
+        },
+        required: { type: "required" as const, required: {} },
+      },
+    },
+    structFieldValidations: {},
+  };
+  const actionValidation = {
+    actionTypeLevelValidation: { ordering: [], rules: {} },
+    parameterValidations: {
+      source: parameterValidation,
+      target: parameterValidation,
+    },
+    sectionValidations: {},
+  };
+
+  return {
+    actionTypes: {
+      "ri.action.create-item-link": {
+        actionType: {
+          actionTypeLogic: {
+            logic: {
+              rules: [{
+                type: "addInterfaceLinkRuleV2",
+                addInterfaceLinkRuleV2: {
+                  interfaceTypeRid: "ri.interface.item",
+                  interfaceLinkTypeRid: "ri.interface-link.observations",
+                  sourceObjects: [{
+                    type: "existingObject",
+                    existingObject: "source",
+                  }],
+                  targetObjects: [{
+                    type: "existingObject",
+                    existingObject: "target",
+                  }],
+                },
+              }],
+            },
+            notifications: [],
+            validation: actionValidation,
+          },
+          metadata: {
+            ...actionMetadata,
+            apiName: "createItemLink",
+            displayMetadata: {
+              ...actionMetadata.displayMetadata,
+              displayName: "Create item link",
+            },
+            rid: "ri.action.create-item-link",
+          },
+        },
+        parameterIds: {},
+      },
+      "ri.action.delete-item-link": {
+        actionType: {
+          actionTypeLogic: {
+            logic: {
+              rules: [{
+                type: "deleteInterfaceLinkRule",
+                deleteInterfaceLinkRule: {
+                  interfaceTypeRid: "ri.interface.item",
+                  interfaceLinkTypeRid: "ri.interface-link.observations",
+                  sourceObject: "source",
+                  targetObject: "target",
+                },
+              }],
+            },
+            notifications: [],
+            validation: actionValidation,
+          },
+          metadata: {
+            ...actionMetadata,
+            apiName: "deleteItemLink",
+            displayMetadata: {
+              ...actionMetadata.displayMetadata,
+              displayName: "Delete item link",
+            },
+            rid: "ri.action.delete-item-link",
+          },
+        },
+        parameterIds: {},
+      },
+    },
+    blockOutputCompassLocations: {},
+    interfaceTypes: {
+      "ri.interface.item": {
+        interfaceType: {
+          actionTypeConstraints: [],
+          apiName: "local.Item",
+          displayMetadata: { displayName: "Item" },
+          extendsInterfaces: [],
+          links: [{
+            cardinality: "MANY",
+            linkedEntityTypeId: {
+              type: "interfaceType",
+              interfaceType: "ri.interface.observation",
+            },
+            metadata: {
+              apiName: "observations",
+              description: "",
+              displayName: "Observations",
+            },
+            required: false,
+            rid: "ri.interface-link.observations",
+          }],
+          properties: [],
+          propertiesV2: {},
+          propertiesV3: {},
+          rid: "ri.interface.item",
+          status: { type: "active", active: {} },
+        },
+      },
+      "ri.interface.observation": {
+        interfaceType: {
+          actionTypeConstraints: [],
+          apiName: "local.Observation",
+          displayMetadata: { displayName: "Observation" },
+          extendsInterfaces: [],
+          links: [],
+          properties: [],
+          propertiesV2: {},
+          propertiesV3: {},
+          rid: "ri.interface.observation",
+          status: { type: "active", active: {} },
+        },
+      },
+    },
+    knownIdentifiers: {
+      actionParameterIds: {},
+      actionParameters: {},
+      actionTypes: {},
+      datasourceColumns: {},
+      datasources: {},
+      filesDatasources: {},
+      functions: {},
+      geotimeSeriesSyncs: {},
+      groupIds: {},
+      interfaceActionTypeConstraints: {},
+      interfaceLinkTypes: {},
+      interfaceParameterConstraints: {},
+      interfacePropertyTypes: {},
+      interfaceTypes: {},
+      linkTypeIds: {},
+      linkTypes: {},
+      markings: {},
+      objectPropertyTypeIdsToRids: {},
+      objectTypeIds: {},
+      objectTypes: {},
+      propertyTypeIds: {},
+      propertyTypes: {},
+      sharedPropertyTypes: {},
+      structFieldRidsToApiNames: {},
+      timeSeriesSyncs: {},
+      valueTypes: {},
+      webhooks: {},
+      workshopModules: {},
+    },
+    linkTypes: {},
+    objectTypes: {},
+    ruleSets: {},
+    sharedPropertyTypes: {},
+  };
+}
+
+describe(PreviewOntologyIrConverter, () => {
+  it("keeps interface link operations and full rules", () => {
+    const metadata = PreviewOntologyIrConverter
+      .getPreviewFullMetadataFromBlockData(interfaceActionBlockData());
+
+    expect(metadata.actionTypes.createItemLink.actionType.operations)
+      .toContainEqual({
+        type: "createInterfaceLink",
+        interfaceTypeApiName: "local.Item",
+        interfaceLinkTypeApiName: "observations",
+        sourceObject: "source",
+        targetObject: "target",
+      });
+    expect(metadata.actionTypes.createItemLink.fullLogicRules).toContainEqual({
+      type: "createInterfaceLink",
+      interfaceTypeApiName: "local.Item",
+      interfaceLinkTypeApiName: "observations",
+      sourceObject: "source",
+      targetObject: "target",
+    });
+    expect(metadata.actionTypes.deleteItemLink.actionType.operations)
+      .toContainEqual({
+        type: "deleteInterfaceLink",
+        interfaceTypeApiName: "local.Item",
+        interfaceLinkTypeApiName: "observations",
+        sourceObject: "source",
+        targetObject: "target",
+      });
+    expect(metadata.actionTypes.deleteItemLink.fullLogicRules).toContainEqual({
+      type: "deleteInterfaceLink",
+      interfaceTypeApiName: "local.Item",
+      interfaceLinkTypeApiName: "observations",
+      sourceObject: "source",
+      targetObject: "target",
+    });
+  });
+});

--- a/packages/generator-converters.preview/src/PreviewOntologyIrConverter.ts
+++ b/packages/generator-converters.preview/src/PreviewOntologyIrConverter.ts
@@ -20,6 +20,7 @@ import type {
 } from "@osdk/client.unstable";
 import type * as Ontologies from "@osdk/foundry.ontologies";
 import {
+  buildBlockDataInterfaceLinkTypeLookup,
   buildBlockDataInterfaceTypeLookup,
   buildBlockDataObjectTypeLookup,
   OntologyBlockDataToFullMetadataConverter,
@@ -125,11 +126,15 @@ export class PreviewOntologyIrConverter {
   ): Record<string, Ontologies.ActionTypeFullMetadata> {
     const objectTypeLookup = buildBlockDataObjectTypeLookup(blockdata);
     const interfaceTypeLookup = buildBlockDataInterfaceTypeLookup(blockdata);
+    const interfaceLinkLookup = buildBlockDataInterfaceLinkTypeLookup(
+      blockdata,
+    );
     const baseActionTypes = OntologyBlockDataToFullMetadataConverter
       .getOsdkActionTypesFromBlockData(
         blockdata,
         objectTypeLookup,
         interfaceTypeLookup,
+        interfaceLinkLookup,
       );
 
     // Build a lookup from apiName to the original IR action for logic rules


### PR DESCRIPTION
interface link actions were omitted from converted sdk action metadata

• convert supported create and delete interface link operations
• resolve interface and interface link api names from block data
• keep preview action operations alongside full logic rules