### PR TITLE
preserve imported interfaces in sdk metadata

### DIFF
--- a/.changeset/preserve-imported-maker-definitions.md
+++ b/.changeset/preserve-imported-maker-definitions.md
@@ -1,0 +1,5 @@
+---
+"@osdk/generator-converters.ontologyir": patch
+---
+
+Preserve directly and transitively imported interfaces in SDK metadata.

--- a/packages/generator-converters.ontologyir/package.json
+++ b/packages/generator-converters.ontologyir/package.json
@@ -49,6 +49,7 @@
     "tiny-invariant": "^1.3.3"
   },
   "devDependencies": {
+    "@osdk/generator": "workspace:~",
     "@osdk/monorepo.api-extractor": "workspace:~",
     "@osdk/monorepo.tsconfig": "workspace:~",
     "@types/node": "^24.3.1",

--- a/packages/generator-converters.ontologyir/src/OntologyIrToFullMetadaConvert.test.ts
+++ b/packages/generator-converters.ontologyir/src/OntologyIrToFullMetadaConvert.test.ts
@@ -14,6 +14,11 @@
  * limitations under the License.
  */
 
+import type { OntologyIrV2 } from "@osdk/client.unstable";
+import {
+  generateClientSdkVersionTwoPointZero,
+  type MinimalFs,
+} from "@osdk/generator";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it, vi } from "vitest";
 import { isInjectedRuntimeInput } from "./convertDataType.js";
@@ -23,6 +28,224 @@ import {
 } from "./OntologyIrToFullMetadataConverter.js";
 
 const discoveredFunctions = vi.hoisted<IDiscoveredFunction[]>(() => []);
+
+type OntologyBlock = OntologyIrV2["ontology"];
+type ActionBlock = OntologyBlock["actionTypes"][string];
+type InterfaceBlock = OntologyBlock["interfaceTypes"][string];
+
+function emptyOntologyBlock(): OntologyBlock {
+  return {
+    actionTypes: {},
+    blockOutputCompassLocations: {},
+    interfaceTypes: {},
+    knownIdentifiers: {
+      actionParameterIds: {},
+      actionParameters: {},
+      actionTypes: {},
+      datasourceColumns: {},
+      datasources: {},
+      filesDatasources: {},
+      functions: {},
+      geotimeSeriesSyncs: {},
+      groupIds: {},
+      interfaceActionTypeConstraints: {},
+      interfaceLinkTypes: {},
+      interfaceParameterConstraints: {},
+      interfacePropertyTypes: {},
+      interfaceTypes: {},
+      linkTypeIds: {},
+      linkTypes: {},
+      markings: {},
+      objectPropertyTypeIdsToRids: {},
+      objectTypeIds: {},
+      objectTypes: {},
+      propertyTypeIds: {},
+      propertyTypes: {},
+      sharedPropertyTypes: {},
+      structFieldRidsToApiNames: {},
+      timeSeriesSyncs: {},
+      valueTypes: {},
+      webhooks: {},
+      workshopModules: {},
+    },
+    linkTypes: {},
+    objectTypes: {},
+    ruleSets: {},
+    sharedPropertyTypes: {},
+  };
+}
+
+function interfaceType(
+  apiName: string,
+  extendsInterfaces: string[],
+  propertyApiName?: string,
+  linkedInterfaceRid?: string,
+): InterfaceBlock {
+  return {
+    interfaceType: {
+      actionTypeConstraints: [],
+      apiName,
+      displayMetadata: { displayName: apiName },
+      extendsInterfaces,
+      links: linkedInterfaceRid === undefined
+        ? []
+        : [{
+          cardinality: "SINGLE",
+          linkedEntityTypeId: {
+            interfaceType: linkedInterfaceRid,
+            type: "interfaceType",
+          },
+          metadata: {
+            apiName: "related",
+            description: "",
+            displayName: "Related",
+          },
+          required: false,
+          rid:
+            "ri.ontology.main.interface-link.830df50e-1bad-4dab-b352-dd55b01191ec",
+        }],
+      properties: [],
+      propertiesV2: {},
+      propertiesV3: propertyApiName === undefined
+        ? {}
+        : {
+          [propertyApiName]: {
+            type: "interfaceDefinedPropertyType",
+            interfaceDefinedPropertyType: {
+              apiName: propertyApiName,
+              constraints: {
+                indexedForSearch: true,
+                primaryKeyConstraint: "NO_RESTRICTION",
+                requireImplementation: true,
+                typeClasses: [],
+              },
+              displayMetadata: {
+                displayName: propertyApiName,
+                visibility: "NORMAL",
+              },
+              rid: `ri.interface-property.${propertyApiName}`,
+              type: {
+                type: "string",
+                string: {
+                  isLongText: false,
+                  supportsExactMatching: true,
+                },
+              },
+            },
+          },
+        },
+      rid: `ri.interface.${apiName}`,
+      status: { type: "active", active: {} },
+    },
+  };
+}
+
+function unsupportedImportedAction(): ActionBlock {
+  return {
+    actionType: {
+      actionTypeLogic: {
+        logic: {
+          rules: [{
+            type: "addLinkRule",
+            addLinkRule: {
+              linkTypeId: "unsupported-link",
+              sourceObject: "source",
+              targetObject: "target",
+            },
+          }],
+        },
+        notifications: [],
+        validation: {
+          actionTypeLevelValidation: {
+            ordering: [],
+            rules: {},
+          },
+          parameterValidations: {},
+          sectionValidations: {},
+        },
+      },
+      metadata: {
+        apiName: "importedUnsupported",
+        displayMetadata: {
+          applyingMessage: [],
+          description: "",
+          displayName: "Imported Unsupported",
+          successMessage: [],
+          typeClasses: [],
+        },
+        formContentOrdering: [],
+        parameterOrdering: [],
+        parameters: {},
+        rid: "ri.ontology.main.action-type.imported-unsupported",
+        sections: {},
+        status: {
+          type: "active",
+          active: {},
+        },
+        version: "",
+      },
+    },
+    parameterIds: {},
+  };
+}
+
+function importedDefinitionsEnvelope(): OntologyIrV2 {
+  const ancestor = interfaceType(
+    "TransitiveAncestor",
+    [],
+    "ancestorProperty",
+  );
+  const parent = interfaceType(
+    "ImportedParent",
+    [ancestor.interfaceType.rid],
+    "parentProperty",
+    ancestor.interfaceType.rid,
+  );
+  const child = interfaceType(
+    "LocalItem",
+    [parent.interfaceType.rid],
+    "localProperty",
+  );
+
+  return {
+    importedOntology: {
+      ...emptyOntologyBlock(),
+      actionTypes: {
+        "ri.ontology.main.action-type.imported-unsupported":
+          unsupportedImportedAction(),
+      },
+      interfaceTypes: { [parent.interfaceType.rid]: parent },
+    },
+    importedValueTypes: [],
+    ontology: {
+      ...emptyOntologyBlock(),
+      interfaceTypes: { [child.interfaceType.rid]: child },
+    },
+    transitiveImportedOntology: {
+      ...emptyOntologyBlock(),
+      interfaceTypes: { [ancestor.interfaceType.rid]: ancestor },
+    },
+    valueTypes: [],
+  };
+}
+
+function createInMemoryFiles(): {
+  fs: MinimalFs;
+  files: Map<string, string>;
+} {
+  const files = new Map<string, string>();
+  return {
+    files,
+    fs: {
+      mkdir: () => Promise.resolve(),
+      readdir: () => Promise.resolve([]),
+      writeFile: (path, contents) => {
+        files.set(path, contents);
+        return Promise.resolve();
+      },
+    },
+  };
+}
 
 vi.mock("@foundry/functions-typescript-osdk-discovery", () => ({
   FunctionDiscoverer: class {
@@ -3637,5 +3860,130 @@ describe(OntologyIrToFullMetadataConverter, () => {
     } finally {
       createProgramSpy.mockRestore();
     }
+  });
+
+  describe("full ontology V2 imports", () => {
+    it("preserves owned, direct, and transitive interface metadata", () => {
+      const metadata = OntologyIrToFullMetadataConverter
+        .getFullMetadataFromEnvelope(importedDefinitionsEnvelope());
+      const child = metadata.interfaceTypes.LocalItem;
+      const parent = metadata.interfaceTypes.ImportedParent;
+
+      expect(metadata.actionTypes).toEqual({});
+      expect(Object.keys(metadata.interfaceTypes)).toEqual([
+        "TransitiveAncestor",
+        "ImportedParent",
+        "LocalItem",
+      ]);
+      expect(child.extendsInterfaces).toEqual(["ImportedParent"]);
+      expect(child.allExtendsInterfaces).toEqual([
+        "ImportedParent",
+        "TransitiveAncestor",
+      ]);
+      expect(Object.keys(child.allPropertiesV2)).toEqual([
+        "ancestorProperty",
+        "parentProperty",
+        "localProperty",
+      ]);
+      expect(parent.links.related).toMatchObject({
+        linkedEntityApiName: {
+          apiName: "TransitiveAncestor",
+          type: "interfaceTypeApiName",
+        },
+      });
+    });
+
+    it.each(
+      [
+        ["transitiveImportedOntology", "importedOntology"],
+        ["transitiveImportedOntology", "ontology"],
+        ["importedOntology", "ontology"],
+      ] as const,
+    )(
+      "rejects duplicate interface api names across %s and %s",
+      (firstScope, secondScope) => {
+        const ir = importedDefinitionsEnvelope();
+        const first = interfaceType("DuplicateInterface", []);
+        const second = interfaceType("DuplicateInterface", []);
+        first.interfaceType.rid = `ri.interface.${firstScope}`;
+        second.interfaceType.rid = `ri.interface.${secondScope}`;
+        ir[firstScope].interfaceTypes[first.interfaceType.rid] = first;
+        ir[secondScope].interfaceTypes[second.interfaceType.rid] = second;
+
+        expect(() =>
+          OntologyIrToFullMetadataConverter.getFullMetadataFromEnvelope(ir)
+        ).toThrow(
+          `Duplicate interface API name "DuplicateInterface" is associated with multiple RIDs: "ri.interface.${firstScope}", "ri.interface.${secondScope}"`,
+        );
+      },
+    );
+
+    it("uses the owned interface when the same rid is repeated", () => {
+      const ir = importedDefinitionsEnvelope();
+      const imported = interfaceType("RepeatedInterface", [], "importedOnly");
+      const owned = interfaceType("RepeatedInterface", [], "ownedOnly");
+      imported.interfaceType.rid = "ri.interface.repeated";
+      owned.interfaceType.rid = "ri.interface.repeated";
+      ir.importedOntology.interfaceTypes[imported.interfaceType.rid] = imported;
+      ir.ontology.interfaceTypes[owned.interfaceType.rid] = owned;
+
+      const metadata = OntologyIrToFullMetadataConverter
+        .getFullMetadataFromEnvelope(ir);
+
+      expect(
+        Object.keys(metadata.interfaceTypes.RepeatedInterface.propertiesV2),
+      )
+        .toEqual(["ownedOnly"]);
+    });
+
+    it("rejects different interface api names under the same rid", () => {
+      const ir = importedDefinitionsEnvelope();
+      const imported = interfaceType("ImportedName", []);
+      const owned = interfaceType("OwnedName", []);
+      imported.interfaceType.rid = "ri.interface.repeated";
+      owned.interfaceType.rid = "ri.interface.repeated";
+      ir.importedOntology.interfaceTypes[imported.interfaceType.rid] = imported;
+      ir.ontology.interfaceTypes[owned.interfaceType.rid] = owned;
+
+      expect(() =>
+        OntologyIrToFullMetadataConverter.getFullMetadataFromEnvelope(ir)
+      ).toThrow(
+        "Interface RID \"ri.interface.repeated\" is associated with multiple API names: \"ImportedName\", \"OwnedName\"",
+      );
+    });
+
+    it("generates imported interfaces as local package exports", async () => {
+      const metadata = OntologyIrToFullMetadataConverter
+        .getFullMetadataFromEnvelope(importedDefinitionsEnvelope());
+      const generated = createInMemoryFiles();
+
+      await generateClientSdkVersionTwoPointZero(
+        metadata,
+        "osdk-oac/test",
+        generated.fs,
+        "generated",
+        "module",
+      );
+
+      expect(
+        generated.files.get("generated/ontology/interfaces/ImportedParent.ts"),
+      ).toContain("apiName: 'ImportedParent'");
+      expect(
+        generated.files.get(
+          "generated/ontology/interfaces/TransitiveAncestor.ts",
+        ),
+      ).toContain("apiName: 'TransitiveAncestor'");
+      expect(generated.files.get("generated/ontology/interfaces.ts"))
+        .toContain(
+          "export { ImportedParent } from './interfaces/ImportedParent.js';",
+        );
+      expect(generated.files.get("generated/ontology/interfaces.ts"))
+        .toContain(
+          "export { TransitiveAncestor } from './interfaces/TransitiveAncestor.js';",
+        );
+      expect(generated.files.get("generated/index.ts")).toContain(
+        "export * as $Interfaces from './ontology/interfaces.js';",
+      );
+    });
   });
 });

--- a/packages/generator-converters.ontologyir/src/OntologyIrToFullMetadataConverter.ts
+++ b/packages/generator-converters.ontologyir/src/OntologyIrToFullMetadataConverter.ts
@@ -26,6 +26,7 @@ import type {
   OntologyIrOntologyBlockDataV2,
   OntologyIrSharedPropertyTypeBlockDataV2,
   OntologyIrType,
+  OntologyIrV2,
 } from "@osdk/client.unstable";
 import type * as Ontologies from "@osdk/foundry.ontologies";
 
@@ -40,6 +41,7 @@ import invariant from "tiny-invariant";
 import * as ts from "typescript";
 import type { ApiName } from "./ApiName.js";
 import { convertDataType, isInjectedRuntimeInput } from "./convertDataType.js";
+import { OntologyBlockDataToFullMetadataConverter } from "./OntologyBlockDataToFullMetadataConverter.js";
 import { toStructFieldRid } from "./ridUtils.js";
 
 // Type definitions for optional function discovery dependencies
@@ -249,6 +251,24 @@ export class OntologyIrToFullMetadataConverter {
   /**
    * Main entry point - converts IR to full metadata
    */
+  static getFullMetadataFromEnvelope(
+    ir: OntologyIrV2,
+  ): Ontologies.OntologyFullMetadata {
+    assertUniqueInterfaceApiNames(
+      ir.transitiveImportedOntology.interfaceTypes,
+      ir.importedOntology.interfaceTypes,
+      ir.ontology.interfaceTypes,
+    );
+    return OntologyBlockDataToFullMetadataConverter
+      .getFullMetadataFromBlockData(
+        mergeOntologyBlocks(
+          ir.transitiveImportedOntology,
+          ir.importedOntology,
+          ir.ontology,
+        ),
+      );
+  }
+
   static getFullMetadataFromIr(
     ir: OntologyIrOntologyBlockDataV2,
   ): Ontologies.OntologyFullMetadata {
@@ -1561,6 +1581,55 @@ export class OntologyIrToFullMetadataConverter {
         throw new Error(`Unknown link type status: ${status}`);
     }
   }
+}
+
+function assertUniqueInterfaceApiNames(
+  ...interfaceMaps: OntologyIrV2["ontology"]["interfaceTypes"][]
+): void {
+  const ridByApiName = new Map<string, string>();
+  const apiNameByRid = new Map<string, string>();
+  for (const interfaces of interfaceMaps) {
+    for (const [rid, { interfaceType }] of Object.entries(interfaces)) {
+      const existingRid = ridByApiName.get(interfaceType.apiName);
+      if (existingRid !== undefined && existingRid !== rid) {
+        throw new Error(
+          `Duplicate interface API name "${interfaceType.apiName}" is associated with multiple RIDs: "${existingRid}", "${rid}"`,
+        );
+      }
+      const existingApiName = apiNameByRid.get(rid);
+      if (
+        existingApiName !== undefined
+        && existingApiName !== interfaceType.apiName
+      ) {
+        throw new Error(
+          `Interface RID "${rid}" is associated with multiple API names: "${existingApiName}", "${interfaceType.apiName}"`,
+        );
+      }
+      ridByApiName.set(interfaceType.apiName, rid);
+      apiNameByRid.set(rid, interfaceType.apiName);
+    }
+  }
+}
+
+function mergeOntologyBlocks(
+  transitiveImported: OntologyIrV2["transitiveImportedOntology"],
+  imported: OntologyIrV2["importedOntology"],
+  owned: OntologyIrV2["ontology"],
+): OntologyIrV2["ontology"] {
+  return {
+    actionTypes: owned.actionTypes,
+    blockOutputCompassLocations: owned.blockOutputCompassLocations,
+    interfaceTypes: {
+      ...transitiveImported.interfaceTypes,
+      ...imported.interfaceTypes,
+      ...owned.interfaceTypes,
+    },
+    knownIdentifiers: owned.knownIdentifiers,
+    linkTypes: owned.linkTypes,
+    objectTypes: owned.objectTypes,
+    ruleSets: owned.ruleSets,
+    sharedPropertyTypes: owned.sharedPropertyTypes,
+  };
 }
 
 function discoverComponentRoot(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4166,6 +4166,9 @@ importers:
         specifier: ^1.3.3
         version: 1.3.3
     devDependencies:
+      '@osdk/generator':
+        specifier: workspace:~
+        version: link:../generator
       '@osdk/monorepo.api-extractor':
         specifier: workspace:~
         version: link:../monorepo.api-extractor


### PR DESCRIPTION
Maker's complete ontology input dropped directly and transitively imported interfaces before SDK generation.

• merge imported interface definitions while keeping owned actions, objects, links, and shared properties unchanged
• preserve inherited interface properties and links across direct and transitive imports
• reject conflicting interface API names and RIDs before conversion
