### PR TITLE
preserve value type metadata in sdk conversion

### DIFF
--- a/.changeset/preserve-imported-maker-definitions.md
+++ b/.changeset/preserve-imported-maker-definitions.md
@@ -1,0 +1,5 @@
+---
+"@osdk/generator-converters.ontologyir": patch
+---
+
+Preserve directly and transitively imported interfaces in SDK metadata.

--- a/.changeset/preserve-value-type-metadata.md
+++ b/.changeset/preserve-value-type-metadata.md
@@ -1,0 +1,5 @@
+---
+"@osdk/generator-converters.ontologyir": patch
+---
+
+Preserve Value Type definitions and property references during complete ontology IR conversion.

--- a/packages/generator-converters.ontologyir/package.json
+++ b/packages/generator-converters.ontologyir/package.json
@@ -46,6 +46,7 @@
     "@osdk/client.unstable": "workspace:~",
     "@osdk/foundry.ontologies": "catalog:foundry-platform-typescript",
     "consola": "^3.4.2",
+    "semver-ts": "^1.0.3",
     "tiny-invariant": "^1.3.3"
   },
   "devDependencies": {

--- a/packages/generator-converters.ontologyir/package.json
+++ b/packages/generator-converters.ontologyir/package.json
@@ -49,6 +49,7 @@
     "tiny-invariant": "^1.3.3"
   },
   "devDependencies": {
+    "@osdk/generator": "workspace:~",
     "@osdk/monorepo.api-extractor": "workspace:~",
     "@osdk/monorepo.tsconfig": "workspace:~",
     "@types/node": "^24.3.1",

--- a/packages/generator-converters.ontologyir/src/OntologyIrToFullMetadaConvert.test.ts
+++ b/packages/generator-converters.ontologyir/src/OntologyIrToFullMetadaConvert.test.ts
@@ -14,6 +14,11 @@
  * limitations under the License.
  */
 
+import type { OntologyIrV2 } from "@osdk/client.unstable";
+import {
+  generateClientSdkVersionTwoPointZero,
+  type MinimalFs,
+} from "@osdk/generator";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it, vi } from "vitest";
 import { isInjectedRuntimeInput } from "./convertDataType.js";
@@ -23,6 +28,224 @@ import {
 } from "./OntologyIrToFullMetadataConverter.js";
 
 const discoveredFunctions = vi.hoisted<IDiscoveredFunction[]>(() => []);
+
+type OntologyBlock = OntologyIrV2["ontology"];
+type ActionBlock = OntologyBlock["actionTypes"][string];
+type InterfaceBlock = OntologyBlock["interfaceTypes"][string];
+
+function emptyOntologyBlock(): OntologyBlock {
+  return {
+    actionTypes: {},
+    blockOutputCompassLocations: {},
+    interfaceTypes: {},
+    knownIdentifiers: {
+      actionParameterIds: {},
+      actionParameters: {},
+      actionTypes: {},
+      datasourceColumns: {},
+      datasources: {},
+      filesDatasources: {},
+      functions: {},
+      geotimeSeriesSyncs: {},
+      groupIds: {},
+      interfaceActionTypeConstraints: {},
+      interfaceLinkTypes: {},
+      interfaceParameterConstraints: {},
+      interfacePropertyTypes: {},
+      interfaceTypes: {},
+      linkTypeIds: {},
+      linkTypes: {},
+      markings: {},
+      objectPropertyTypeIdsToRids: {},
+      objectTypeIds: {},
+      objectTypes: {},
+      propertyTypeIds: {},
+      propertyTypes: {},
+      sharedPropertyTypes: {},
+      structFieldRidsToApiNames: {},
+      timeSeriesSyncs: {},
+      valueTypes: {},
+      webhooks: {},
+      workshopModules: {},
+    },
+    linkTypes: {},
+    objectTypes: {},
+    ruleSets: {},
+    sharedPropertyTypes: {},
+  };
+}
+
+function interfaceType(
+  apiName: string,
+  extendsInterfaces: string[],
+  propertyApiName?: string,
+  linkedInterfaceRid?: string,
+): InterfaceBlock {
+  return {
+    interfaceType: {
+      actionTypeConstraints: [],
+      apiName,
+      displayMetadata: { displayName: apiName },
+      extendsInterfaces,
+      links: linkedInterfaceRid === undefined
+        ? []
+        : [{
+          cardinality: "SINGLE",
+          linkedEntityTypeId: {
+            interfaceType: linkedInterfaceRid,
+            type: "interfaceType",
+          },
+          metadata: {
+            apiName: "related",
+            description: "",
+            displayName: "Related",
+          },
+          required: false,
+          rid:
+            "ri.ontology.main.interface-link.830df50e-1bad-4dab-b352-dd55b01191ec",
+        }],
+      properties: [],
+      propertiesV2: {},
+      propertiesV3: propertyApiName === undefined
+        ? {}
+        : {
+          [propertyApiName]: {
+            type: "interfaceDefinedPropertyType",
+            interfaceDefinedPropertyType: {
+              apiName: propertyApiName,
+              constraints: {
+                indexedForSearch: true,
+                primaryKeyConstraint: "NO_RESTRICTION",
+                requireImplementation: true,
+                typeClasses: [],
+              },
+              displayMetadata: {
+                displayName: propertyApiName,
+                visibility: "NORMAL",
+              },
+              rid: `ri.interface-property.${propertyApiName}`,
+              type: {
+                type: "string",
+                string: {
+                  isLongText: false,
+                  supportsExactMatching: true,
+                },
+              },
+            },
+          },
+        },
+      rid: `ri.interface.${apiName}`,
+      status: { type: "active", active: {} },
+    },
+  };
+}
+
+function unsupportedImportedAction(): ActionBlock {
+  return {
+    actionType: {
+      actionTypeLogic: {
+        logic: {
+          rules: [{
+            type: "addLinkRule",
+            addLinkRule: {
+              linkTypeId: "unsupported-link",
+              sourceObject: "source",
+              targetObject: "target",
+            },
+          }],
+        },
+        notifications: [],
+        validation: {
+          actionTypeLevelValidation: {
+            ordering: [],
+            rules: {},
+          },
+          parameterValidations: {},
+          sectionValidations: {},
+        },
+      },
+      metadata: {
+        apiName: "importedUnsupported",
+        displayMetadata: {
+          applyingMessage: [],
+          description: "",
+          displayName: "Imported Unsupported",
+          successMessage: [],
+          typeClasses: [],
+        },
+        formContentOrdering: [],
+        parameterOrdering: [],
+        parameters: {},
+        rid: "ri.ontology.main.action-type.imported-unsupported",
+        sections: {},
+        status: {
+          type: "active",
+          active: {},
+        },
+        version: "",
+      },
+    },
+    parameterIds: {},
+  };
+}
+
+function importedDefinitionsEnvelope(): OntologyIrV2 {
+  const ancestor = interfaceType(
+    "TransitiveAncestor",
+    [],
+    "ancestorProperty",
+  );
+  const parent = interfaceType(
+    "ImportedParent",
+    [ancestor.interfaceType.rid],
+    "parentProperty",
+    ancestor.interfaceType.rid,
+  );
+  const child = interfaceType(
+    "LocalItem",
+    [parent.interfaceType.rid],
+    "localProperty",
+  );
+
+  return {
+    importedOntology: {
+      ...emptyOntologyBlock(),
+      actionTypes: {
+        "ri.ontology.main.action-type.imported-unsupported":
+          unsupportedImportedAction(),
+      },
+      interfaceTypes: { [parent.interfaceType.rid]: parent },
+    },
+    importedValueTypes: [],
+    ontology: {
+      ...emptyOntologyBlock(),
+      interfaceTypes: { [child.interfaceType.rid]: child },
+    },
+    transitiveImportedOntology: {
+      ...emptyOntologyBlock(),
+      interfaceTypes: { [ancestor.interfaceType.rid]: ancestor },
+    },
+    valueTypes: [],
+  };
+}
+
+function createInMemoryFiles(): {
+  fs: MinimalFs;
+  files: Map<string, string>;
+} {
+  const files = new Map<string, string>();
+  return {
+    files,
+    fs: {
+      mkdir: () => Promise.resolve(),
+      readdir: () => Promise.resolve([]),
+      writeFile: (path, contents) => {
+        files.set(path, contents);
+        return Promise.resolve();
+      },
+    },
+  };
+}
 
 vi.mock("@foundry/functions-typescript-osdk-discovery", () => ({
   FunctionDiscoverer: class {
@@ -3637,5 +3860,130 @@ describe(OntologyIrToFullMetadataConverter, () => {
     } finally {
       createProgramSpy.mockRestore();
     }
+  });
+
+  describe("full ontology V2 imports", () => {
+    it("preserves owned, direct, and transitive interface metadata", () => {
+      const metadata = OntologyIrToFullMetadataConverter
+        .getFullMetadataFromEnvelope(importedDefinitionsEnvelope());
+      const child = metadata.interfaceTypes.LocalItem;
+      const parent = metadata.interfaceTypes.ImportedParent;
+
+      expect(metadata.actionTypes).toEqual({});
+      expect(Object.keys(metadata.interfaceTypes)).toEqual([
+        "TransitiveAncestor",
+        "ImportedParent",
+        "LocalItem",
+      ]);
+      expect(child.extendsInterfaces).toEqual(["ImportedParent"]);
+      expect(child.allExtendsInterfaces).toEqual([
+        "ImportedParent",
+        "TransitiveAncestor",
+      ]);
+      expect(Object.keys(child.allPropertiesV2)).toEqual([
+        "ancestorProperty",
+        "parentProperty",
+        "localProperty",
+      ]);
+      expect(parent.links.related).toMatchObject({
+        linkedEntityApiName: {
+          apiName: "TransitiveAncestor",
+          type: "interfaceTypeApiName",
+        },
+      });
+    });
+
+    it.each(
+      [
+        ["transitiveImportedOntology", "importedOntology"],
+        ["transitiveImportedOntology", "ontology"],
+        ["importedOntology", "ontology"],
+      ] as const,
+    )(
+      "rejects duplicate interface api names across %s and %s",
+      (firstScope, secondScope) => {
+        const ir = importedDefinitionsEnvelope();
+        const first = interfaceType("DuplicateInterface", []);
+        const second = interfaceType("DuplicateInterface", []);
+        first.interfaceType.rid = `ri.interface.${firstScope}`;
+        second.interfaceType.rid = `ri.interface.${secondScope}`;
+        ir[firstScope].interfaceTypes[first.interfaceType.rid] = first;
+        ir[secondScope].interfaceTypes[second.interfaceType.rid] = second;
+
+        expect(() =>
+          OntologyIrToFullMetadataConverter.getFullMetadataFromEnvelope(ir)
+        ).toThrow(
+          `Duplicate interface API name "DuplicateInterface" is associated with multiple RIDs: "ri.interface.${firstScope}", "ri.interface.${secondScope}"`,
+        );
+      },
+    );
+
+    it("uses the owned interface when the same rid is repeated", () => {
+      const ir = importedDefinitionsEnvelope();
+      const imported = interfaceType("RepeatedInterface", [], "importedOnly");
+      const owned = interfaceType("RepeatedInterface", [], "ownedOnly");
+      imported.interfaceType.rid = "ri.interface.repeated";
+      owned.interfaceType.rid = "ri.interface.repeated";
+      ir.importedOntology.interfaceTypes[imported.interfaceType.rid] = imported;
+      ir.ontology.interfaceTypes[owned.interfaceType.rid] = owned;
+
+      const metadata = OntologyIrToFullMetadataConverter
+        .getFullMetadataFromEnvelope(ir);
+
+      expect(
+        Object.keys(metadata.interfaceTypes.RepeatedInterface.propertiesV2),
+      )
+        .toEqual(["ownedOnly"]);
+    });
+
+    it("rejects different interface api names under the same rid", () => {
+      const ir = importedDefinitionsEnvelope();
+      const imported = interfaceType("ImportedName", []);
+      const owned = interfaceType("OwnedName", []);
+      imported.interfaceType.rid = "ri.interface.repeated";
+      owned.interfaceType.rid = "ri.interface.repeated";
+      ir.importedOntology.interfaceTypes[imported.interfaceType.rid] = imported;
+      ir.ontology.interfaceTypes[owned.interfaceType.rid] = owned;
+
+      expect(() =>
+        OntologyIrToFullMetadataConverter.getFullMetadataFromEnvelope(ir)
+      ).toThrow(
+        "Interface RID \"ri.interface.repeated\" is associated with multiple API names: \"ImportedName\", \"OwnedName\"",
+      );
+    });
+
+    it("generates imported interfaces as local package exports", async () => {
+      const metadata = OntologyIrToFullMetadataConverter
+        .getFullMetadataFromEnvelope(importedDefinitionsEnvelope());
+      const generated = createInMemoryFiles();
+
+      await generateClientSdkVersionTwoPointZero(
+        metadata,
+        "osdk-oac/test",
+        generated.fs,
+        "generated",
+        "module",
+      );
+
+      expect(
+        generated.files.get("generated/ontology/interfaces/ImportedParent.ts"),
+      ).toContain("apiName: 'ImportedParent'");
+      expect(
+        generated.files.get(
+          "generated/ontology/interfaces/TransitiveAncestor.ts",
+        ),
+      ).toContain("apiName: 'TransitiveAncestor'");
+      expect(generated.files.get("generated/ontology/interfaces.ts"))
+        .toContain(
+          "export { ImportedParent } from './interfaces/ImportedParent.js';",
+        );
+      expect(generated.files.get("generated/ontology/interfaces.ts"))
+        .toContain(
+          "export { TransitiveAncestor } from './interfaces/TransitiveAncestor.js';",
+        );
+      expect(generated.files.get("generated/index.ts")).toContain(
+        "export * as $Interfaces from './ontology/interfaces.js';",
+      );
+    });
   });
 });

--- a/packages/generator-converters.ontologyir/src/OntologyIrToFullMetadaConvert.test.ts
+++ b/packages/generator-converters.ontologyir/src/OntologyIrToFullMetadaConvert.test.ts
@@ -14,11 +14,17 @@
  * limitations under the License.
  */
 
-import type { OntologyIrV2 } from "@osdk/client.unstable";
+import type {
+  OntologyIrV2,
+  ValueTypeBlockData,
+  ValueTypeDataConstraint,
+  ValueTypeReference,
+} from "@osdk/client.unstable";
 import {
   generateClientSdkVersionTwoPointZero,
   type MinimalFs,
 } from "@osdk/generator";
+import { createHash } from "node:crypto";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it, vi } from "vitest";
 import { isInjectedRuntimeInput } from "./convertDataType.js";
@@ -32,7 +38,31 @@ const discoveredFunctions = vi.hoisted<IDiscoveredFunction[]>(() => []);
 type OntologyBlock = OntologyIrV2["ontology"];
 type ActionBlock = OntologyBlock["actionTypes"][string];
 type InterfaceBlock = OntologyBlock["interfaceTypes"][string];
+type InterfaceType = InterfaceBlock["interfaceType"];
+type InterfaceProperty = InterfaceType["propertiesV3"][string];
+type SharedProperty = Extract<
+  InterfaceProperty,
+  { type: "sharedPropertyBasedPropertyType" }
+>["sharedPropertyBasedPropertyType"]["sharedPropertyType"];
+type InterfaceDefinedProperty = Extract<
+  InterfaceProperty,
+  { type: "interfaceDefinedPropertyType" }
+>["interfaceDefinedPropertyType"];
+type StringValueTypeConstraint = Extract<
+  ValueTypeDataConstraint["constraint"]["constraint"],
+  { type: "string" }
+>;
 
+type ValueTypeLocation = "owned" | "imported";
+
+const RANDOMNESS_KEY = "current-v2-envelope";
+const VALUE_TYPE_API_NAME = "trackQuality";
+const VALUE_TYPE_VERSION = "10.0.0";
+const LEGACY_VALUE_TYPE_REFERENCE = legacyValueTypeReference(
+  VALUE_TYPE_API_NAME,
+  VALUE_TYPE_VERSION,
+  RANDOMNESS_KEY,
+);
 function emptyOntologyBlock(): OntologyBlock {
   return {
     actionTypes: {},
@@ -72,6 +102,130 @@ function emptyOntologyBlock(): OntologyBlock {
     objectTypes: {},
     ruleSets: {},
     sharedPropertyTypes: {},
+  };
+}
+
+function legacyValueTypeReference(
+  apiName: string,
+  version: string,
+  randomnessKey?: string,
+): ValueTypeReference {
+  const ridInput = randomnessKey
+    ? `${apiName}-${randomnessKey}`
+    : apiName;
+  const versionHash = createHash("md5").update(version, "utf8").digest("hex");
+  return {
+    rid: `ri.ontology-metadata.temp.value-type.${
+      createHash("sha256").update(ridInput, "utf8").digest("hex")
+    }`,
+    versionId: `${versionHash.slice(0, 8)}-${
+      versionHash.slice(
+        8,
+        12,
+      )
+    }-${versionHash.slice(12, 16)}-${
+      versionHash.slice(
+        16,
+        20,
+      )
+    }-${versionHash.slice(20)}`,
+  };
+}
+
+function stringOneOfConstraint(
+  values: string[],
+): StringValueTypeConstraint {
+  return {
+    type: "string",
+    string: {
+      type: "oneOf",
+      oneOf: {
+        useIgnoreCase: undefined,
+        values,
+      },
+    },
+  };
+}
+
+function valueType(
+  apiName: string,
+  versions: string[],
+  displayName = `Display ${apiName}`,
+): ValueTypeBlockData {
+  return {
+    metadata: {
+      apiName,
+      baseType: { type: "string", string: {} },
+      displayMetadata: {
+        description: `Description for ${apiName}`,
+        displayName,
+      },
+      status: { type: "active", active: {} },
+    },
+    versions: versions.map((version) => ({
+      baseType: { type: "string", string: {} },
+      constraints: [{
+        constraint: {
+          constraint: stringOneOfConstraint(["HIGH", "MEDIUM", "LOW"]),
+          failureMessage: undefined,
+        },
+      }],
+      exampleValues: [],
+      version,
+    })),
+  };
+}
+
+function sharedProperty(
+  apiName: string,
+  valueTypeReference: ValueTypeReference,
+): SharedProperty {
+  return {
+    aliases: [],
+    apiName,
+    displayMetadata: {
+      displayName: apiName,
+      visibility: "NORMAL",
+    },
+    indexedForSearch: true,
+    rid: `ri.shared-property.${apiName}`,
+    type: {
+      type: "string",
+      string: {
+        isLongText: false,
+        supportsExactMatching: true,
+      },
+    },
+    typeClasses: [],
+    valueType: valueTypeReference,
+  };
+}
+
+function interfaceDefinedProperty(
+  apiName: string,
+  valueTypeReference: ValueTypeReference,
+): InterfaceDefinedProperty {
+  return {
+    apiName,
+    constraints: {
+      indexedForSearch: true,
+      primaryKeyConstraint: "NO_RESTRICTION",
+      requireImplementation: true,
+      typeClasses: [],
+      valueType: valueTypeReference,
+    },
+    displayMetadata: {
+      displayName: apiName,
+      visibility: "NORMAL",
+    },
+    rid: `ri.interface-property.${apiName}`,
+    type: {
+      type: "string",
+      string: {
+        isLongText: false,
+        supportsExactMatching: true,
+      },
+    },
   };
 }
 
@@ -226,6 +380,61 @@ function importedDefinitionsEnvelope(): OntologyIrV2 {
       interfaceTypes: { [ancestor.interfaceType.rid]: ancestor },
     },
     valueTypes: [],
+  };
+}
+
+function valueTypeEnvelope(
+  propertyReference: ValueTypeReference = LEGACY_VALUE_TYPE_REFERENCE,
+  ownedValueTypes: ValueTypeBlockData[] = [
+    valueType(VALUE_TYPE_API_NAME, ["2.0.0", VALUE_TYPE_VERSION, "1.0.0"]),
+  ],
+  importedValueTypes: ValueTypeBlockData[] = [],
+): OntologyIrV2 {
+  const ancestor = interfaceType("transitive.Ancestor", []);
+  ancestor.interfaceType.propertiesV3 = {
+    inheritedQuality: {
+      type: "interfaceDefinedPropertyType",
+      interfaceDefinedPropertyType: interfaceDefinedProperty(
+        "inheritedQuality",
+        propertyReference,
+      ),
+    },
+  };
+  const parent = interfaceType("imported.Parent", [ancestor.interfaceType.rid]);
+  const child = interfaceType("local.Item", [parent.interfaceType.rid]);
+  child.interfaceType.propertiesV3 = {
+    inlineQuality: {
+      type: "interfaceDefinedPropertyType",
+      interfaceDefinedPropertyType: interfaceDefinedProperty(
+        "inlineQuality",
+        propertyReference,
+      ),
+    },
+    trackQuality: {
+      type: "sharedPropertyBasedPropertyType",
+      sharedPropertyBasedPropertyType: {
+        requireImplementation: true,
+        sharedPropertyType: sharedProperty("trackQuality", propertyReference),
+      },
+    },
+  };
+
+  return {
+    importedOntology: {
+      ...emptyOntologyBlock(),
+      interfaceTypes: { [parent.interfaceType.rid]: parent },
+    },
+    importedValueTypes,
+    ontology: {
+      ...emptyOntologyBlock(),
+      interfaceTypes: { [child.interfaceType.rid]: child },
+    },
+    randomnessKey: RANDOMNESS_KEY,
+    transitiveImportedOntology: {
+      ...emptyOntologyBlock(),
+      interfaceTypes: { [ancestor.interfaceType.rid]: ancestor },
+    },
+    valueTypes: ownedValueTypes,
   };
 }
 
@@ -3860,6 +4069,137 @@ describe(OntologyIrToFullMetadataConverter, () => {
     } finally {
       createProgramSpy.mockRestore();
     }
+  });
+
+  describe("full ontology V2 Value Types", () => {
+    it("preserves metadata and property api names", () => {
+      const metadata = OntologyIrToFullMetadataConverter
+        .getFullMetadataFromEnvelope(valueTypeEnvelope());
+      const child = metadata.interfaceTypes["local.Item"];
+
+      expect(metadata.valueTypes.trackQuality).toMatchObject({
+        apiName: VALUE_TYPE_API_NAME,
+        rid: LEGACY_VALUE_TYPE_REFERENCE.rid,
+        version: VALUE_TYPE_VERSION,
+      });
+      expect(child.propertiesV2.trackQuality.valueTypeApiName).toBe(
+        VALUE_TYPE_API_NAME,
+      );
+      expect(child.propertiesV2.inlineQuality.valueTypeApiName).toBe(
+        VALUE_TYPE_API_NAME,
+      );
+      expect(child.allPropertiesV2.inheritedQuality.valueTypeApiName).toBe(
+        VALUE_TYPE_API_NAME,
+      );
+    });
+
+    it.each([RANDOMNESS_KEY, ""])(
+      "resolves legacy property references with randomness key %s",
+      (randomnessKey) => {
+        const propertyReference = legacyValueTypeReference(
+          VALUE_TYPE_API_NAME,
+          VALUE_TYPE_VERSION,
+          randomnessKey,
+        );
+        const input = valueTypeEnvelope(propertyReference);
+        input.randomnessKey = randomnessKey;
+        const metadata = OntologyIrToFullMetadataConverter
+          .getFullMetadataFromEnvelope(input);
+
+        expect(
+          metadata.interfaceTypes["local.Item"].propertiesV2.trackQuality
+            .valueTypeApiName,
+        ).toBe(VALUE_TYPE_API_NAME);
+        expect(metadata.valueTypes.trackQuality.rid).toBe(
+          propertyReference.rid,
+        );
+      },
+    );
+
+    it("selects a stable version over a prerelease", () => {
+      const stableReference = legacyValueTypeReference(
+        VALUE_TYPE_API_NAME,
+        "1.0.0",
+        RANDOMNESS_KEY,
+      );
+      const metadata = OntologyIrToFullMetadataConverter
+        .getFullMetadataFromEnvelope(
+          valueTypeEnvelope(
+            stableReference,
+            [valueType(VALUE_TYPE_API_NAME, ["1.0.0-alpha", "1.0.0"])],
+          ),
+        );
+
+      expect(metadata.valueTypes.trackQuality).toMatchObject({
+        rid: stableReference.rid,
+        version: "1.0.0",
+      });
+    });
+
+    it("orders prerelease identifiers and build metadata consistently", () => {
+      const stableReference = legacyValueTypeReference(
+        "stableCase",
+        "1.0.0",
+        RANDOMNESS_KEY,
+      );
+      const buildFirstReference = legacyValueTypeReference(
+        "buildCase",
+        "1.0.0+first",
+        RANDOMNESS_KEY,
+      );
+
+      const stableMetadata = OntologyIrToFullMetadataConverter
+        .getFullMetadataFromEnvelope(
+          valueTypeEnvelope(
+            stableReference,
+            [
+              valueType("stableCase", [
+                "1.0.0-A",
+                "1.0.0-a",
+                "1.0.0-999999999999999999999999999999",
+                "1.0.0",
+              ]),
+              valueType("buildCase", ["1.0.0+first", "1.0.0+second"]),
+            ],
+          ),
+        );
+
+      expect(stableMetadata.valueTypes.stableCase).toMatchObject({
+        rid: stableReference.rid,
+        version: "1.0.0",
+      });
+      expect(stableMetadata.valueTypes.buildCase).toMatchObject({
+        rid: buildFirstReference.rid,
+        version: "1.0.0+first",
+      });
+    });
+
+    it("uses owned definitions for equal-version duplicates", () => {
+      const reference = legacyValueTypeReference(
+        VALUE_TYPE_API_NAME,
+        VALUE_TYPE_VERSION,
+        RANDOMNESS_KEY,
+      );
+      const metadata = OntologyIrToFullMetadataConverter
+        .getFullMetadataFromEnvelope(
+          valueTypeEnvelope(
+            reference,
+            [valueType(VALUE_TYPE_API_NAME, [VALUE_TYPE_VERSION], "Owned")],
+            [
+              valueType(
+                VALUE_TYPE_API_NAME,
+                [VALUE_TYPE_VERSION],
+                "Imported",
+              ),
+            ],
+          ),
+        );
+
+      expect(metadata.valueTypes.trackQuality).toMatchObject({
+        displayName: "Owned",
+        rid: reference.rid,
+      });
+    });
   });
 
   describe("full ontology V2 imports", () => {

--- a/packages/generator-converters.ontologyir/src/OntologyIrToFullMetadataConverter.ts
+++ b/packages/generator-converters.ontologyir/src/OntologyIrToFullMetadataConverter.ts
@@ -26,6 +26,7 @@ import type {
   OntologyIrOntologyBlockDataV2,
   OntologyIrSharedPropertyTypeBlockDataV2,
   OntologyIrType,
+  OntologyIrV2,
 } from "@osdk/client.unstable";
 import type * as Ontologies from "@osdk/foundry.ontologies";
 
@@ -40,6 +41,7 @@ import invariant from "tiny-invariant";
 import * as ts from "typescript";
 import type { ApiName } from "./ApiName.js";
 import { convertDataType, isInjectedRuntimeInput } from "./convertDataType.js";
+import { OntologyBlockDataToFullMetadataConverter } from "./OntologyBlockDataToFullMetadataConverter.js";
 import { toStructFieldRid } from "./ridUtils.js";
 
 // Type definitions for optional function discovery dependencies
@@ -249,6 +251,24 @@ export class OntologyIrToFullMetadataConverter {
   /**
    * Main entry point - converts IR to full metadata
    */
+  static getFullMetadataFromEnvelope(
+    ir: OntologyIrV2,
+  ): Ontologies.OntologyFullMetadata {
+    assertUniqueInterfaceApiNames(
+      ir.transitiveImportedOntology.interfaceTypes,
+      ir.importedOntology.interfaceTypes,
+      ir.ontology.interfaceTypes,
+    );
+    return OntologyBlockDataToFullMetadataConverter
+      .getFullMetadataFromBlockData(
+        mergeOntologyBlocks(
+          ir.transitiveImportedOntology,
+          ir.importedOntology,
+          ir.ontology,
+        ),
+      );
+  }
+
   static getFullMetadataFromIr(
     ir: OntologyIrOntologyBlockDataV2,
   ): Ontologies.OntologyFullMetadata {
@@ -1561,6 +1581,55 @@ export class OntologyIrToFullMetadataConverter {
         throw new Error(`Unknown link type status: ${status}`);
     }
   }
+}
+
+function assertUniqueInterfaceApiNames(
+  ...interfaceMaps: OntologyIrV2["ontology"]["interfaceTypes"][]
+): void {
+  const ridByApiName = new Map<string, string>();
+  const apiNameByRid = new Map<string, string>();
+  for (const interfaces of interfaceMaps) {
+    for (const [rid, { interfaceType }] of Object.entries(interfaces)) {
+      const existingRid = ridByApiName.get(interfaceType.apiName);
+      if (existingRid !== undefined && existingRid !== rid) {
+        throw new Error(
+          `Duplicate interface API name "${interfaceType.apiName}" is associated with multiple RIDs: "${existingRid}", "${rid}"`,
+        );
+      }
+      const existingApiName = apiNameByRid.get(rid);
+      if (
+        existingApiName !== undefined
+        && existingApiName !== interfaceType.apiName
+      ) {
+        throw new Error(
+          `Interface RID "${rid}" is associated with multiple API names: "${existingApiName}", "${interfaceType.apiName}"`,
+        );
+      }
+      ridByApiName.set(interfaceType.apiName, rid);
+      apiNameByRid.set(rid, interfaceType.apiName);
+    }
+  }
+}
+
+function mergeOntologyBlocks(
+  transitiveImported: OntologyIrV2["transitiveImportedOntology"],
+  imported: OntologyIrV2["importedOntology"],
+  owned: OntologyIrV2["ontology"],
+): OntologyIrV2["ontology"] {
+  return {
+    actionTypes: owned.actionTypes,
+    blockOutputCompassLocations: owned.blockOutputCompassLocations,
+    interfaceTypes: {
+      ...transitiveImported.interfaceTypes,
+      ...imported.interfaceTypes,
+      ...owned.interfaceTypes,
+    },
+    knownIdentifiers: owned.knownIdentifiers,
+    linkTypes: owned.linkTypes,
+    objectTypes: owned.objectTypes,
+    ruleSets: owned.ruleSets,
+    sharedPropertyTypes: owned.sharedPropertyTypes,
+  };
 }
 
 function discoverComponentRoot(

--- a/packages/generator-converters.ontologyir/src/OntologyIrToFullMetadataConverter.ts
+++ b/packages/generator-converters.ontologyir/src/OntologyIrToFullMetadataConverter.ts
@@ -15,6 +15,8 @@
  */
 
 import type {
+  BaseType,
+  DataConstraint,
   OntologyIrActionTypeBlockDataV2,
   OntologyIrActionTypeStatus,
   OntologyIrInterfaceTypeBlockDataV2,
@@ -27,16 +29,21 @@ import type {
   OntologyIrSharedPropertyTypeBlockDataV2,
   OntologyIrType,
   OntologyIrV2,
+  ValueTypeBlockData,
+  ValueTypeDataConstraint,
+  ValueTypeReference,
 } from "@osdk/client.unstable";
 import type * as Ontologies from "@osdk/foundry.ontologies";
 
 import { consola } from "consola";
 import * as fs from "fs";
 import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
 import { accessSync, constants } from "node:fs";
 import { createRequire } from "node:module";
 import * as path from "node:path";
 import { pathToFileURL } from "node:url";
+import { compare as compareSemver, valid as validSemver } from "semver-ts";
 import invariant from "tiny-invariant";
 import * as ts from "typescript";
 import type { ApiName } from "./ApiName.js";
@@ -259,14 +266,14 @@ export class OntologyIrToFullMetadataConverter {
       ir.importedOntology.interfaceTypes,
       ir.ontology.interfaceTypes,
     );
-    return OntologyBlockDataToFullMetadataConverter
-      .getFullMetadataFromBlockData(
-        mergeOntologyBlocks(
-          ir.transitiveImportedOntology,
-          ir.importedOntology,
-          ir.ontology,
-        ),
-      );
+    const blockData = mergeOntologyBlocks(
+      ir.transitiveImportedOntology,
+      ir.importedOntology,
+      ir.ontology,
+    );
+    const metadata = OntologyBlockDataToFullMetadataConverter
+      .getFullMetadataFromBlockData(blockData);
+    return addValueTypeMetadata(metadata, blockData, ir);
   }
 
   static getFullMetadataFromIr(
@@ -1630,6 +1637,449 @@ function mergeOntologyBlocks(
     ruleSets: owned.ruleSets,
     sharedPropertyTypes: owned.sharedPropertyTypes,
   };
+}
+
+function addValueTypeMetadata(
+  metadata: Ontologies.OntologyFullMetadata,
+  blockData: OntologyIrV2["ontology"],
+  ir: OntologyIrV2,
+): Ontologies.OntologyFullMetadata {
+  const apiNameByReference = buildValueTypeApiNameLookup(ir);
+  addPropertyValueTypeApiNames(metadata, blockData, apiNameByReference);
+  return {
+    ...metadata,
+    valueTypes: convertEnvelopeValueTypes(ir),
+  };
+}
+
+function buildValueTypeApiNameLookup(
+  ir: OntologyIrV2,
+): Map<string, ApiName> {
+  const result = new Map<string, ApiName>();
+  for (const valueType of [...ir.importedValueTypes, ...ir.valueTypes]) {
+    const apiName = valueType.metadata.apiName;
+    for (const version of valueType.versions) {
+      result.set(
+        valueTypeReferenceKey(
+          legacyValueTypeReference(apiName, version.version, ir.randomnessKey),
+        ),
+        apiName,
+      );
+    }
+  }
+  return result;
+}
+
+function valueTypeReferenceKey(reference: ValueTypeReference): string {
+  return `${reference.rid}\0${reference.versionId}`;
+}
+
+function legacyValueTypeReference(
+  apiName: string,
+  version: string,
+  randomnessKey: string | undefined,
+): ValueTypeReference {
+  const ridInput = randomnessKey
+    ? `${apiName}-${randomnessKey}`
+    : apiName;
+  const versionHash = createHash("md5").update(version, "utf8").digest("hex");
+  return {
+    rid: `ri.ontology-metadata.temp.value-type.${
+      createHash("sha256").update(ridInput, "utf8").digest("hex")
+    }`,
+    versionId: `${versionHash.slice(0, 8)}-${
+      versionHash.slice(
+        8,
+        12,
+      )
+    }-${versionHash.slice(12, 16)}-${
+      versionHash.slice(
+        16,
+        20,
+      )
+    }-${versionHash.slice(20)}`,
+  };
+}
+
+function resolveValueTypeApiName(
+  reference: ValueTypeReference | null | undefined,
+  apiNameByReference: ReadonlyMap<string, ApiName>,
+): ApiName | undefined {
+  return reference == null
+    ? undefined
+    : apiNameByReference.get(valueTypeReferenceKey(reference));
+}
+
+function addPropertyValueTypeApiNames(
+  metadata: Ontologies.OntologyFullMetadata,
+  blockData: OntologyIrV2["ontology"],
+  apiNameByReference: ReadonlyMap<string, ApiName>,
+): void {
+  for (const objectBlock of Object.values(blockData.objectTypes)) {
+    const objectApiName = objectBlock.objectType.apiName;
+    if (objectApiName == null) {
+      continue;
+    }
+    const output = metadata.objectTypes[objectApiName];
+    if (output === undefined) {
+      continue;
+    }
+    for (
+      const property of Object.values(objectBlock.objectType.propertyTypes)
+    ) {
+      const apiName = resolveValueTypeApiName(
+        property.valueType,
+        apiNameByReference,
+      );
+      const propertyApiName = property.apiName;
+      if (propertyApiName == null) {
+        continue;
+      }
+      const outputProperty = output.objectType.properties[propertyApiName];
+      if (apiName !== undefined && outputProperty !== undefined) {
+        outputProperty.valueTypeApiName = apiName;
+      }
+    }
+  }
+
+  for (
+    const sharedPropertyBlock of Object.values(blockData.sharedPropertyTypes)
+  ) {
+    const property = sharedPropertyBlock.sharedPropertyType;
+    const apiName = resolveValueTypeApiName(
+      property.valueType,
+      apiNameByReference,
+    );
+    const output = metadata.sharedPropertyTypes[property.apiName];
+    if (apiName !== undefined && output !== undefined) {
+      output.valueTypeApiName = apiName;
+    }
+  }
+
+  const referenceByPropertyRid = new Map<string, ValueTypeReference>();
+  for (const interfaceBlock of Object.values(blockData.interfaceTypes)) {
+    const interfaceType = interfaceBlock.interfaceType;
+    for (const property of Object.values(interfaceType.propertiesV2)) {
+      const valueType = property.sharedPropertyType.valueType;
+      if (valueType != null) {
+        referenceByPropertyRid.set(property.sharedPropertyType.rid, valueType);
+      }
+    }
+    for (const property of Object.values(interfaceType.propertiesV3)) {
+      if (property.type === "interfaceDefinedPropertyType") {
+        const valueType = property.interfaceDefinedPropertyType.constraints
+          .valueType;
+        if (valueType != null) {
+          referenceByPropertyRid.set(
+            property.interfaceDefinedPropertyType.rid,
+            valueType,
+          );
+        }
+      } else {
+        const sharedPropertyType = property.sharedPropertyBasedPropertyType
+          .sharedPropertyType;
+        if (sharedPropertyType.valueType != null) {
+          referenceByPropertyRid.set(
+            sharedPropertyType.rid,
+            sharedPropertyType.valueType,
+          );
+        }
+      }
+    }
+  }
+
+  for (const interfaceType of Object.values(metadata.interfaceTypes)) {
+    addInterfacePropertyValueTypeApiNames(
+      interfaceType.properties,
+      referenceByPropertyRid,
+      apiNameByReference,
+    );
+    addInterfacePropertyValueTypeApiNames(
+      interfaceType.propertiesV2,
+      referenceByPropertyRid,
+      apiNameByReference,
+    );
+    addInterfacePropertyValueTypeApiNames(
+      interfaceType.allPropertiesV2,
+      referenceByPropertyRid,
+      apiNameByReference,
+    );
+  }
+}
+
+function addInterfacePropertyValueTypeApiNames(
+  properties: Record<ApiName, { rid: string; valueTypeApiName?: string }>,
+  referenceByPropertyRid: ReadonlyMap<string, ValueTypeReference>,
+  apiNameByReference: ReadonlyMap<string, ApiName>,
+): void {
+  for (const property of Object.values(properties)) {
+    const apiName = resolveValueTypeApiName(
+      referenceByPropertyRid.get(property.rid),
+      apiNameByReference,
+    );
+    if (apiName !== undefined) {
+      property.valueTypeApiName = apiName;
+    }
+  }
+}
+
+function convertEnvelopeValueTypes(
+  ir: OntologyIrV2,
+): Record<ApiName, Ontologies.OntologyValueType> {
+  const result: Record<ApiName, Ontologies.OntologyValueType> = {};
+  for (const valueType of [...ir.importedValueTypes, ...ir.valueTypes]) {
+    const version = latestValueTypeVersion(valueType.versions);
+    if (version === undefined) {
+      continue;
+    }
+    const existing = result[valueType.metadata.apiName];
+    if (
+      existing !== undefined
+      && compareValueTypeVersions(version.version, existing.version) < 0
+    ) {
+      continue;
+    }
+    const reference = legacyValueTypeReference(
+      valueType.metadata.apiName,
+      version.version,
+      ir.randomnessKey,
+    );
+    result[valueType.metadata.apiName] = {
+      apiName: valueType.metadata.apiName,
+      displayName: valueType.metadata.displayMetadata.displayName,
+      description: valueType.metadata.displayMetadata.description ?? undefined,
+      rid: reference.rid,
+      status: convertValueTypeStatus(valueType.metadata.status.type),
+      version: version.version,
+      fieldType: convertValueTypeFieldType(
+        version.baseType ?? valueType.metadata.baseType,
+      ),
+      constraints: version.constraints.map(convertValueTypeConstraint),
+    };
+  }
+  return result;
+}
+
+function latestValueTypeVersion(
+  versions: ValueTypeBlockData["versions"],
+): ValueTypeBlockData["versions"][number] | undefined {
+  let latest: ValueTypeBlockData["versions"][number] | undefined;
+  for (const version of versions) {
+    if (
+      latest === undefined
+      || compareValueTypeVersions(version.version, latest.version) > 0
+    ) {
+      latest = version;
+    }
+  }
+  return latest;
+}
+
+function compareValueTypeVersions(a: string, b: string): number {
+  const validA = validSemver(a);
+  const validB = validSemver(b);
+  if (validA != null && validB != null) {
+    return compareSemver(validA, validB);
+  }
+  if (validA != null) {
+    return 1;
+  }
+  if (validB != null) {
+    return -1;
+  }
+  return a < b ? -1 : a > b ? 1 : 0;
+}
+
+function convertValueTypeStatus(
+  status: string,
+): Ontologies.ValueTypeStatus | undefined {
+  switch (status) {
+    case "active":
+      return "ACTIVE";
+    case "deprecated":
+      return "DEPRECATED";
+    default:
+      return undefined;
+  }
+}
+
+function convertValueTypeFieldType(
+  baseType: BaseType,
+): Ontologies.ValueTypeFieldType {
+  switch (baseType.type) {
+    case "array":
+      return {
+        type: "array",
+        subType: convertValueTypeFieldType(baseType.array.elementType),
+      };
+    case "boolean":
+    case "binary":
+    case "byte":
+    case "date":
+    case "decimal":
+    case "double":
+    case "float":
+    case "integer":
+    case "long":
+    case "short":
+    case "string":
+    case "timestamp":
+      return { type: baseType.type };
+    case "map":
+      return {
+        type: "map",
+        keyType: convertValueTypeFieldType(baseType.map.keyType),
+        valueType: convertValueTypeFieldType(baseType.map.valueType),
+      };
+    case "optional":
+      return {
+        type: "optional",
+        wrappedType: convertValueTypeFieldType(baseType.optional.wrappedType),
+      };
+    case "referenced":
+      return { type: "reference" };
+    case "struct":
+      return {
+        type: "struct",
+        fields: baseType.struct.fields.map((field) => ({
+          name: field.name,
+          fieldType: convertValueTypeFieldType(field.type),
+        })),
+      };
+    case "structV2":
+      return {
+        type: "struct",
+        fields: baseType.structV2.fields.map((field) => ({
+          name: field.identifier,
+          fieldType: convertValueTypeFieldType(field.baseType),
+        })),
+      };
+    case "union":
+      return {
+        type: "union",
+        memberTypes: baseType.union.memberTypes.map(convertValueTypeFieldType),
+      };
+  }
+}
+
+function convertValueTypeConstraint(
+  constraint: ValueTypeDataConstraint,
+): Ontologies.ValueTypeConstraint {
+  return convertValueTypeDataConstraint(constraint.constraint.constraint);
+}
+
+function convertValueTypeDataConstraint(
+  constraint: DataConstraint,
+): Ontologies.ValueTypeConstraint {
+  switch (constraint.type) {
+    case "array":
+      return {
+        type: "array",
+        minimumSize: constraint.array.size?.minSize,
+        maximumSize: constraint.array.size?.maxSize,
+        uniqueValues: constraint.array.elementsUnique ?? false,
+        valueConstraint: constraint.array.elementsConstraint === undefined
+          ? undefined
+          : convertValueTypeDataConstraint(
+            constraint.array.elementsConstraint,
+          ),
+      };
+    case "boolean":
+      return {
+        type: "enum",
+        options: constraint.boolean.allowedValues.map((value) => {
+          switch (value) {
+            case "TRUE_VALUE":
+              return true;
+            case "FALSE_VALUE":
+              return false;
+            case "NULL_VALUE":
+              return undefined;
+          }
+        }),
+      };
+    case "binary":
+      return {
+        type: "length",
+        minimumLength: constraint.binary.size.minSize,
+        maximumLength: constraint.binary.size.maxSize,
+      };
+    case "date":
+      return {
+        type: "range",
+        minimumValue: constraint.date.range.min,
+        maximumValue: constraint.date.range.max,
+      };
+    case "decimal":
+      return convertNumericValueTypeConstraint(constraint.decimal);
+    case "double":
+      return convertNumericValueTypeConstraint(constraint.double);
+    case "float":
+      return convertNumericValueTypeConstraint(constraint.float);
+    case "integer":
+      return convertNumericValueTypeConstraint(constraint.integer);
+    case "long":
+      return convertNumericValueTypeConstraint(constraint.long);
+    case "short":
+      return convertNumericValueTypeConstraint(constraint.short);
+    case "string":
+      switch (constraint.string.type) {
+        case "regex":
+          return {
+            type: "regex",
+            pattern: constraint.string.regex.regexPattern,
+            partialMatch: constraint.string.regex.usePartialMatch ?? false,
+          };
+        case "oneOf":
+          return { type: "enum", options: constraint.string.oneOf.values };
+        case "length":
+          return {
+            type: "length",
+            minimumLength: constraint.string.length.minSize,
+            maximumLength: constraint.string.length.maxSize,
+          };
+        case "isUuid":
+          return { type: "uuid" };
+        case "isRid":
+          return { type: "rid" };
+      }
+    case "timestamp":
+      return {
+        type: "range",
+        minimumValue: constraint.timestamp.range.min,
+        maximumValue: constraint.timestamp.range.max,
+      };
+    case "map":
+    case "nullable":
+    case "struct":
+    case "structV2":
+      return {
+        type: "unsupported",
+        unsupportedType: constraint.type,
+        params: {},
+      };
+  }
+}
+
+function convertNumericValueTypeConstraint(
+  constraint:
+    | Extract<DataConstraint, { type: "decimal" }>["decimal"]
+    | Extract<DataConstraint, { type: "double" }>["double"]
+    | Extract<DataConstraint, { type: "float" }>["float"]
+    | Extract<DataConstraint, { type: "integer" }>["integer"]
+    | Extract<DataConstraint, { type: "long" }>["long"]
+    | Extract<DataConstraint, { type: "short" }>["short"],
+): Ontologies.ValueTypeConstraint {
+  switch (constraint.type) {
+    case "range":
+      return {
+        type: "range",
+        minimumValue: constraint.range.min,
+        maximumValue: constraint.range.max,
+      };
+    case "oneOf":
+      return { type: "enum", options: constraint.oneOf.values };
+  }
 }
 
 function discoverComponentRoot(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4166,6 +4166,9 @@ importers:
         specifier: ^1.3.3
         version: 1.3.3
     devDependencies:
+      '@osdk/generator':
+        specifier: workspace:~
+        version: link:../generator
       '@osdk/monorepo.api-extractor':
         specifier: workspace:~
         version: link:../monorepo.api-extractor

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4162,6 +4162,9 @@ importers:
       consola:
         specifier: ^3.4.2
         version: 3.4.2
+      semver-ts:
+        specifier: ^1.0.3
+        version: 1.0.3
       tiny-invariant:
         specifier: ^1.3.3
         version: 1.3.3
@@ -4429,6 +4432,9 @@ importers:
       jiti:
         specifier: ^2.5.1
         version: 2.5.1
+      semver-ts:
+        specifier: ^1.0.3
+        version: 1.0.3
       tiny-invariant:
         specifier: ^1.3.3
         version: 1.3.3


### PR DESCRIPTION
complete ontology input currently drops Value Type definitions and property associations during SDK metadata conversion

• convert owned and imported Value Type definitions into SDK metadata
• retain Value Type API names on object, shared, and interface properties
• preserve legacy complete-input compatibility with deterministic reference reconstruction