### PR TITLE
preserve exact value type references

### DIFF
--- a/.changeset/preserve-exact-value-type-references.md
+++ b/.changeset/preserve-exact-value-type-references.md
@@ -1,0 +1,7 @@
+---
+"@osdk/client.unstable": patch
+"@osdk/maker-experimental": patch
+"@osdk/generator-converters.ontologyir": patch
+---
+
+Preserve exact Value Type references from Maker ontology IR through SDK metadata generation.

--- a/packages/client.unstable/src/blockDataIr.ts
+++ b/packages/client.unstable/src/blockDataIr.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import type { ValueTypeReference } from "./generated/ontology-metadata/api/__components.js";
 import type {
   OntologyBlockDataV2,
   OntologyIrOntologyBlockDataV2,
@@ -28,6 +29,10 @@ export type ObjectTypeFieldApiName = string;
 export type InterfaceLinkTypeApiName = string;
 export type { OntologyIrOntologyBlockDataV2 } from "./generated/ontology-metadata/api/blockdata/index.js";
 
+export type ValueTypeReferencesByApiName = Readonly<
+  Record<string, Readonly<Record<string, ValueTypeReference>>>
+>;
+
 export interface OntologyIr {
   ontology: OntologyIrOntologyBlockDataV2;
   importedOntology: OntologyIrOntologyBlockDataV2;
@@ -41,6 +46,7 @@ export interface OntologyIrV2 {
   importedOntology: OntologyBlockDataV2;
   valueTypes: ValueTypeBlockData[];
   importedValueTypes: ValueTypeBlockData[];
+  valueTypeReferences?: ValueTypeReferencesByApiName;
   transitiveImportedOntology: OntologyBlockDataV2;
   randomnessKey?: string;
 }

--- a/packages/client.unstable/src/index.ts
+++ b/packages/client.unstable/src/index.ts
@@ -82,6 +82,7 @@ export type {
   OntologyIr,
   OntologyIrOntologyBlockDataV2,
   OntologyIrV2,
+  ValueTypeReferencesByApiName,
 } from "./blockDataIr.js";
 
 export type {

--- a/packages/generator-converters.ontologyir/src/OntologyIrToFullMetadaConvert.test.ts
+++ b/packages/generator-converters.ontologyir/src/OntologyIrToFullMetadaConvert.test.ts
@@ -63,6 +63,11 @@ const LEGACY_VALUE_TYPE_REFERENCE = legacyValueTypeReference(
   VALUE_TYPE_VERSION,
   RANDOMNESS_KEY,
 );
+const EXACT_VALUE_TYPE_REFERENCE: ValueTypeReference = {
+  rid: "ri.value-type.exact.track-quality",
+  versionId: "exact-track-quality-version",
+};
+
 function emptyOntologyBlock(): OntologyBlock {
   return {
     actionTypes: {},
@@ -384,7 +389,12 @@ function importedDefinitionsEnvelope(): OntologyIrV2 {
 }
 
 function valueTypeEnvelope(
-  propertyReference: ValueTypeReference = LEGACY_VALUE_TYPE_REFERENCE,
+  propertyReference: ValueTypeReference = EXACT_VALUE_TYPE_REFERENCE,
+  valueTypeReferences: OntologyIrV2["valueTypeReferences"] = {
+    [VALUE_TYPE_API_NAME]: {
+      [VALUE_TYPE_VERSION]: EXACT_VALUE_TYPE_REFERENCE,
+    },
+  },
   ownedValueTypes: ValueTypeBlockData[] = [
     valueType(VALUE_TYPE_API_NAME, ["2.0.0", VALUE_TYPE_VERSION, "1.0.0"]),
   ],
@@ -434,6 +444,7 @@ function valueTypeEnvelope(
       ...emptyOntologyBlock(),
       interfaceTypes: { [ancestor.interfaceType.rid]: ancestor },
     },
+    valueTypeReferences,
     valueTypes: ownedValueTypes,
   };
 }
@@ -4072,14 +4083,14 @@ describe(OntologyIrToFullMetadataConverter, () => {
   });
 
   describe("full ontology V2 Value Types", () => {
-    it("preserves metadata and property api names", () => {
+    it("preserves exact references in metadata and property api names", () => {
       const metadata = OntologyIrToFullMetadataConverter
         .getFullMetadataFromEnvelope(valueTypeEnvelope());
       const child = metadata.interfaceTypes["local.Item"];
 
       expect(metadata.valueTypes.trackQuality).toMatchObject({
         apiName: VALUE_TYPE_API_NAME,
-        rid: LEGACY_VALUE_TYPE_REFERENCE.rid,
+        rid: EXACT_VALUE_TYPE_REFERENCE.rid,
         version: VALUE_TYPE_VERSION,
       });
       expect(child.propertiesV2.trackQuality.valueTypeApiName).toBe(
@@ -4093,15 +4104,22 @@ describe(OntologyIrToFullMetadataConverter, () => {
       );
     });
 
-    it.each([RANDOMNESS_KEY, ""])(
-      "resolves legacy property references with randomness key %s",
-      (randomnessKey) => {
+    it.each([
+      [undefined, RANDOMNESS_KEY],
+      [{}, RANDOMNESS_KEY],
+      [{}, ""],
+    ])(
+      "falls back to legacy references when the reference map is %s",
+      (valueTypeReferences, randomnessKey) => {
         const propertyReference = legacyValueTypeReference(
           VALUE_TYPE_API_NAME,
           VALUE_TYPE_VERSION,
           randomnessKey,
         );
-        const input = valueTypeEnvelope(propertyReference);
+        const input = valueTypeEnvelope(
+          propertyReference,
+          valueTypeReferences,
+        );
         input.randomnessKey = randomnessKey;
         const metadata = OntologyIrToFullMetadataConverter
           .getFullMetadataFromEnvelope(input);
@@ -4110,22 +4128,56 @@ describe(OntologyIrToFullMetadataConverter, () => {
           metadata.interfaceTypes["local.Item"].propertiesV2.trackQuality
             .valueTypeApiName,
         ).toBe(VALUE_TYPE_API_NAME);
-        expect(metadata.valueTypes.trackQuality.rid).toBe(
-          propertyReference.rid,
-        );
       },
     );
 
-    it("selects a stable version over a prerelease", () => {
-      const stableReference = legacyValueTypeReference(
+    it("falls back per missing version in a partial exact-reference map", () => {
+      const missingVersionReference = legacyValueTypeReference(
         VALUE_TYPE_API_NAME,
-        "1.0.0",
+        "2.0.0",
         RANDOMNESS_KEY,
       );
       const metadata = OntologyIrToFullMetadataConverter
         .getFullMetadataFromEnvelope(
           valueTypeEnvelope(
+            missingVersionReference,
+            {
+              [VALUE_TYPE_API_NAME]: {
+                [VALUE_TYPE_VERSION]: EXACT_VALUE_TYPE_REFERENCE,
+              },
+            },
+            [valueType(VALUE_TYPE_API_NAME, ["2.0.0"])],
+          ),
+        );
+
+      expect(metadata.valueTypes.trackQuality.rid).toBe(
+        missingVersionReference.rid,
+      );
+      expect(
+        metadata.interfaceTypes["local.Item"].propertiesV2.trackQuality
+          .valueTypeApiName,
+      ).toBe(VALUE_TYPE_API_NAME);
+    });
+
+    it("selects a stable version over a prerelease", () => {
+      const stableReference: ValueTypeReference = {
+        rid: "ri.value-type.stable",
+        versionId: "stable-version",
+      };
+      const prereleaseReference: ValueTypeReference = {
+        rid: "ri.value-type.prerelease",
+        versionId: "prerelease-version",
+      };
+      const metadata = OntologyIrToFullMetadataConverter
+        .getFullMetadataFromEnvelope(
+          valueTypeEnvelope(
             stableReference,
+            {
+              [VALUE_TYPE_API_NAME]: {
+                "1.0.0": stableReference,
+                "1.0.0-alpha": prereleaseReference,
+              },
+            },
             [valueType(VALUE_TYPE_API_NAME, ["1.0.0-alpha", "1.0.0"])],
           ),
         );
@@ -4137,21 +4189,47 @@ describe(OntologyIrToFullMetadataConverter, () => {
     });
 
     it("orders prerelease identifiers and build metadata consistently", () => {
-      const stableReference = legacyValueTypeReference(
-        "stableCase",
-        "1.0.0",
-        RANDOMNESS_KEY,
-      );
-      const buildFirstReference = legacyValueTypeReference(
-        "buildCase",
-        "1.0.0+first",
-        RANDOMNESS_KEY,
-      );
+      const stableReference: ValueTypeReference = {
+        rid: "ri.value-type.stable-case",
+        versionId: "stable-case-version",
+      };
+      const uppercaseReference: ValueTypeReference = {
+        rid: "ri.value-type.uppercase-prerelease",
+        versionId: "uppercase-version",
+      };
+      const lowercaseReference: ValueTypeReference = {
+        rid: "ri.value-type.lowercase-prerelease",
+        versionId: "lowercase-version",
+      };
+      const largeNumericReference: ValueTypeReference = {
+        rid: "ri.value-type.large-numeric-prerelease",
+        versionId: "large-numeric-version",
+      };
+      const buildFirstReference: ValueTypeReference = {
+        rid: "ri.value-type.build-first",
+        versionId: "build-first-version",
+      };
+      const buildSecondReference: ValueTypeReference = {
+        rid: "ri.value-type.build-second",
+        versionId: "build-second-version",
+      };
 
       const stableMetadata = OntologyIrToFullMetadataConverter
         .getFullMetadataFromEnvelope(
           valueTypeEnvelope(
             stableReference,
+            {
+              stableCase: {
+                "1.0.0": stableReference,
+                "1.0.0-A": uppercaseReference,
+                "1.0.0-a": lowercaseReference,
+                "1.0.0-999999999999999999999999999999": largeNumericReference,
+              },
+              buildCase: {
+                "1.0.0+first": buildFirstReference,
+                "1.0.0+second": buildSecondReference,
+              },
+            },
             [
               valueType("stableCase", [
                 "1.0.0-A",
@@ -4174,16 +4252,39 @@ describe(OntologyIrToFullMetadataConverter, () => {
       });
     });
 
-    it("uses owned definitions for equal-version duplicates", () => {
-      const reference = legacyValueTypeReference(
-        VALUE_TYPE_API_NAME,
-        VALUE_TYPE_VERSION,
-        RANDOMNESS_KEY,
+    it("resolves legacy property references beside supplied exact references", () => {
+      const metadata = OntologyIrToFullMetadataConverter
+        .getFullMetadataFromEnvelope(
+          valueTypeEnvelope(LEGACY_VALUE_TYPE_REFERENCE),
+        );
+
+      expect(
+        metadata.interfaceTypes["local.Item"].propertiesV2.trackQuality
+          .valueTypeApiName,
+      ).toBe(VALUE_TYPE_API_NAME);
+      expect(metadata.valueTypes.trackQuality.rid).toBe(
+        EXACT_VALUE_TYPE_REFERENCE.rid,
       );
+    });
+
+    it("uses owned definitions and references for equal-version duplicates", () => {
+      const importedReference: ValueTypeReference = {
+        rid: "ri.value-type.imported",
+        versionId: "imported-version",
+      };
+      const ownedReference: ValueTypeReference = {
+        rid: "ri.value-type.owned",
+        versionId: "owned-version",
+      };
       const metadata = OntologyIrToFullMetadataConverter
         .getFullMetadataFromEnvelope(
           valueTypeEnvelope(
-            reference,
+            ownedReference,
+            {
+              [VALUE_TYPE_API_NAME]: {
+                [VALUE_TYPE_VERSION]: ownedReference,
+              },
+            },
             [valueType(VALUE_TYPE_API_NAME, [VALUE_TYPE_VERSION], "Owned")],
             [
               valueType(
@@ -4197,8 +4298,11 @@ describe(OntologyIrToFullMetadataConverter, () => {
 
       expect(metadata.valueTypes.trackQuality).toMatchObject({
         displayName: "Owned",
-        rid: reference.rid,
+        rid: ownedReference.rid,
       });
+      expect(metadata.valueTypes.trackQuality.rid).not.toBe(
+        importedReference.rid,
+      );
     });
   });
 

--- a/packages/generator-converters.ontologyir/src/OntologyIrToFullMetadataConverter.ts
+++ b/packages/generator-converters.ontologyir/src/OntologyIrToFullMetadataConverter.ts
@@ -1665,6 +1665,11 @@ function buildValueTypeApiNameLookup(
         ),
         apiName,
       );
+      const exactReference = ir.valueTypeReferences?.[apiName]
+        ?.[version.version];
+      if (exactReference !== undefined) {
+        result.set(valueTypeReferenceKey(exactReference), apiName);
+      }
     }
   }
   return result;
@@ -1839,7 +1844,9 @@ function convertEnvelopeValueTypes(
     ) {
       continue;
     }
-    const reference = legacyValueTypeReference(
+    const reference = ir.valueTypeReferences?.[valueType.metadata.apiName]?.[
+      version.version
+    ] ?? legacyValueTypeReference(
       valueType.metadata.apiName,
       version.version,
       ir.randomnessKey,

--- a/packages/maker-experimental/package.json
+++ b/packages/maker-experimental/package.json
@@ -48,6 +48,7 @@
     "@osdk/maker": "workspace:~",
     "consola": "^3.4.2",
     "jiti": "^2.5.1",
+    "semver-ts": "^1.0.3",
     "tiny-invariant": "^1.3.3",
     "yargs": "^17.7.2"
   },

--- a/packages/maker-experimental/src/api/overall.test.ts
+++ b/packages/maker-experimental/src/api/overall.test.ts
@@ -19,7 +19,11 @@ import * as os from "node:os";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
 
-import type { ActionType, InterfaceType } from "@osdk/maker";
+import type {
+  ActionType,
+  InterfaceType,
+  ValueTypeDefinitionVersion,
+} from "@osdk/maker";
 import {
   addDependency,
   defineCreateObjectAction,
@@ -29,6 +33,7 @@ import {
   defineObject,
   defineOntology,
   defineSharedPropertyType,
+  defineValueType,
   dumpOntologyFullMetadata,
   importOntologyEntity,
   importSharedPropertyType,
@@ -1278,6 +1283,261 @@ describe("Experimental Test Suite", () => {
       expect(
         result.importedInputPresets.get(interfacePropertyReadableId),
       ).toEqual(apiNamePreset(sptApiName));
+    });
+  });
+
+  describe("Value Type references", () => {
+    it("serializes exact references for owned and imported definitions", async () => {
+      const result = await defineOntologyV2("com.palantir.", () => {
+        const referencedOwned = defineValueType({
+          apiName: "referencedOwned",
+          displayName: "Referenced Owned",
+          type: { type: "string" },
+          version: "1.0.0",
+        });
+        defineValueType({
+          apiName: "referencedOwned",
+          displayName: "Referenced Owned",
+          type: { type: "string" },
+          version: "1.1.0",
+        });
+        defineValueType({
+          apiName: "unreferencedOwned",
+          displayName: "Unreferenced Owned",
+          type: { type: "string" },
+          version: "2.0.0",
+        });
+
+        const importedValue: ValueTypeDefinitionVersion = {
+          apiName: "importedValue",
+          packageNamespace: "com.external",
+          displayMetadata: {
+            displayName: "Imported Value",
+            description: "",
+          },
+          status: { type: "active", active: {} },
+          version: "3.0.0",
+          baseType: {
+            type: "string",
+            string: {},
+          },
+          constraints: [],
+          exampleValues: [],
+          __type: OntologyEntityTypeEnum.VALUE_TYPE,
+        };
+        importOntologyEntity(importedValue);
+
+        const importedCollision: ValueTypeDefinitionVersion = {
+          apiName: "collision",
+          packageNamespace: "com.external",
+          displayMetadata: {
+            displayName: "Imported Collision",
+            description: "",
+          },
+          status: { type: "active", active: {} },
+          version: "1.0.0",
+          baseType: {
+            type: "string",
+            string: {},
+          },
+          constraints: [],
+          exampleValues: [],
+          __type: OntologyEntityTypeEnum.VALUE_TYPE,
+        };
+        importOntologyEntity(importedCollision);
+        const ownedCollision = defineValueType({
+          apiName: "collision",
+          displayName: "Owned Collision",
+          type: { type: "string" },
+          version: "1.0.0",
+        });
+
+        const sharedReference = defineSharedPropertyType({
+          apiName: "sharedReference",
+          type: "string",
+          valueType: referencedOwned,
+        });
+        defineInterface({
+          apiName: "referencedInterface",
+          properties: {
+            sharedReference: {
+              sharedPropertyType: sharedReference,
+              required: true,
+            },
+          },
+        });
+
+        defineObject({
+          apiName: "employee",
+          displayName: "Employee",
+          pluralDisplayName: "Employees",
+          titlePropertyApiName: "id",
+          primaryKeyPropertyApiName: "id",
+          properties: {
+            id: { type: "string", valueType: referencedOwned },
+            imported: { type: "string", valueType: importedValue },
+            collision: { type: "string", valueType: ownedCollision },
+          },
+        });
+      });
+
+      const references = result.ontologyIr.valueTypeReferences;
+      if (references === undefined) {
+        throw new Error("Expected serialized Value Type references");
+      }
+      expect(Object.keys(references).sort()).toEqual([
+        "collision",
+        "importedValue",
+        "referencedOwned",
+        "unreferencedOwned",
+      ]);
+      expect(references.importedValue["3.0.0"]).toEqual({
+        rid: expect.any(String),
+        versionId: expect.any(String),
+      });
+      expect(references.unreferencedOwned["2.0.0"]).toEqual({
+        rid: expect.any(String),
+        versionId: expect.any(String),
+      });
+      expect(Object.keys(references.referencedOwned).sort()).toEqual([
+        "1.0.0",
+        "1.1.0",
+      ]);
+
+      const employee = Object.values(
+        result.ontologyIr.ontology.objectTypes,
+      ).find(({ objectType }) => {
+        return objectType.apiName === "com.palantir.employee";
+      });
+      if (employee === undefined) {
+        throw new Error("Expected employee object type");
+      }
+      const idProperty = Object.values(employee.objectType.propertyTypes).find(
+        ({ apiName }) => {
+          return apiName === "id";
+        },
+      );
+      if (idProperty === undefined) {
+        throw new Error("Expected employee.id property");
+      }
+      expect(references.referencedOwned["1.0.0"]).toBe(idProperty.valueType);
+      const importedProperty = Object.values(
+        employee.objectType.propertyTypes,
+      ).find(({ apiName }) => {
+        return apiName === "imported";
+      });
+      if (importedProperty === undefined) {
+        throw new Error("Expected employee.imported property");
+      }
+      expect(references.importedValue["3.0.0"]).toBe(
+        importedProperty.valueType,
+      );
+      const collisionProperty = Object.values(
+        employee.objectType.propertyTypes,
+      ).find(({ apiName }) => {
+        return apiName === "collision";
+      });
+      if (collisionProperty === undefined) {
+        throw new Error("Expected employee.collision property");
+      }
+      expect(references.collision["1.0.0"]).toBe(collisionProperty.valueType);
+
+      const convertedSpt = Object.values(
+        result.ontologyIr.ontology.sharedPropertyTypes,
+      ).find(({ sharedPropertyType }) => {
+        return sharedPropertyType.apiName === "com.palantir.sharedReference";
+      });
+      if (convertedSpt === undefined) {
+        throw new Error("Expected sharedReference shared property type");
+      }
+      expect(convertedSpt.sharedPropertyType.valueType).toBe(
+        references.referencedOwned["1.0.0"],
+      );
+
+      const convertedInterface = Object.values(
+        result.ontologyIr.ontology.interfaceTypes,
+      ).find(({ interfaceType }) => {
+        return interfaceType.apiName === "com.palantir.referencedInterface";
+      });
+      if (convertedInterface === undefined) {
+        throw new Error("Expected referencedInterface");
+      }
+      const propertyV2 = Object.values(
+        convertedInterface.interfaceType.propertiesV2,
+      )[0];
+      if (propertyV2 === undefined) {
+        throw new Error("Expected interface propertiesV2 entry");
+      }
+      expect(propertyV2.sharedPropertyType.valueType).toBe(
+        references.referencedOwned["1.0.0"],
+      );
+      const propertyV3 = Object.values(
+        convertedInterface.interfaceType.propertiesV3,
+      )[0];
+      if (propertyV3 === undefined) {
+        throw new Error("Expected interface propertiesV3 entry");
+      }
+      if (propertyV3.type !== "sharedPropertyBasedPropertyType") {
+        throw new Error("Expected shared-property-backed interface property");
+      }
+      expect(
+        propertyV3.sharedPropertyBasedPropertyType.sharedPropertyType.valueType,
+      ).toBe(references.referencedOwned["1.0.0"]);
+
+      expect(
+        result.ontologyIr.valueTypes
+          .map(({ metadata }) => metadata.apiName)
+          .sort(),
+      ).toEqual(["collision", "referencedOwned", "unreferencedOwned"]);
+      expect(
+        result.ontologyIr.importedValueTypes
+          .map(({ metadata }) => metadata.apiName)
+          .sort(),
+      ).toEqual(["collision", "importedValue"]);
+    });
+
+    it("selects Value Type metadata using semantic version precedence", async () => {
+      const result = await defineOntologyV2("com.palantir.", () => {
+        defineValueType({
+          apiName: "releaseState",
+          displayName: "Release State",
+          type: { type: "boolean" },
+          version: "1.0.0-alpha",
+        });
+        defineValueType({
+          apiName: "releaseState",
+          displayName: "Release State",
+          type: { type: "string" },
+          version: "1.0.0",
+        });
+        defineValueType({
+          apiName: "buildState",
+          displayName: "Build State",
+          type: { type: "boolean" },
+          version: "1.0.0+first",
+        });
+        defineValueType({
+          apiName: "buildState",
+          displayName: "Build State",
+          type: { type: "string" },
+          version: "1.0.0+second",
+        });
+      });
+
+      const releaseState = result.ontologyIr.valueTypes.find(
+        ({ metadata }) => metadata.apiName === "releaseState",
+      );
+      const buildState = result.ontologyIr.valueTypes.find(
+        ({ metadata }) => metadata.apiName === "buildState",
+      );
+      expect(releaseState?.metadata.baseType.type).toBe("string");
+      expect(buildState?.metadata.baseType.type).toBe("boolean");
+    });
+
+    it("serializes an empty reference map without Value Types", async () => {
+      const result = await defineOntologyV2("com.palantir.", () => {});
+
+      expect(result.ontologyIr.valueTypeReferences).toEqual({});
     });
   });
 

--- a/packages/maker-experimental/src/conversion/toMarketplace/convertOntologyDefinition.ts
+++ b/packages/maker-experimental/src/conversion/toMarketplace/convertOntologyDefinition.ts
@@ -14,7 +14,11 @@
  * limitations under the License.
  */
 
-import type { OntologyIrV2 } from "@osdk/client.unstable";
+import type {
+  OntologyIrV2,
+  ValueTypeReference,
+  ValueTypeReferencesByApiName,
+} from "@osdk/client.unstable";
 import type { InterfaceType, OntologyDefinition } from "@osdk/maker";
 import { getImportedTypes } from "@osdk/maker";
 
@@ -92,13 +96,41 @@ export function convertOntologyDefinition(
     transitiveOntology,
     throwawayRidGenerator,
   );
+  const importedValueTypes = convertValueTypeToWireBlockData(
+    importedTypes,
+    ridGenerator,
+  );
+  const ownedValueTypes = convertValueTypeToWireBlockData(
+    ontology,
+    ridGenerator,
+  );
 
   return {
     ontology: mainOntology,
     importedOntology,
     transitiveImportedOntology,
-    valueTypes: convertValueTypeToWireBlockData(ontology),
-    importedValueTypes: convertValueTypeToWireBlockData(importedTypes),
+    valueTypes: ownedValueTypes.valueTypes,
+    importedValueTypes: importedValueTypes.valueTypes,
+    valueTypeReferences: mergeValueTypeReferences(
+      importedValueTypes.valueTypeReferences,
+      ownedValueTypes.valueTypeReferences,
+    ),
     randomnessKey,
   };
+}
+
+function mergeValueTypeReferences(
+  imported: ValueTypeReferencesByApiName,
+  owned: ValueTypeReferencesByApiName,
+): ValueTypeReferencesByApiName {
+  const merged: Record<string, Readonly<Record<string, ValueTypeReference>>> = {
+    ...imported,
+  };
+  for (const [apiName, versions] of Object.entries(owned)) {
+    merged[apiName] = {
+      ...merged[apiName],
+      ...versions,
+    };
+  }
+  return merged;
 }

--- a/packages/maker-experimental/src/conversion/toMarketplace/convertValueTypeToWireBlockData.ts
+++ b/packages/maker-experimental/src/conversion/toMarketplace/convertValueTypeToWireBlockData.ts
@@ -14,32 +14,63 @@
  * limitations under the License.
  */
 
-import type { ValueTypeBlockData } from "@osdk/client.unstable";
+import type {
+  ValueTypeBlockData,
+  ValueTypeReference,
+  ValueTypeReferencesByApiName,
+} from "@osdk/client.unstable";
 import type {
   OntologyDefinition,
   ValueTypeDefinitionVersion,
 } from "@osdk/maker";
 import { OntologyEntityTypeEnum } from "@osdk/maker";
+import { compare as compareSemver, valid as validSemver } from "semver-ts";
+
+import type { OntologyRidGenerator } from "../../util/generateRid.js";
+
+export interface ConvertedValueTypes {
+  valueTypes: ValueTypeBlockData[];
+  valueTypeReferences: ValueTypeReferencesByApiName;
+}
 
 export function convertValueTypeToWireBlockData(
   ontology: OntologyDefinition,
-): ValueTypeBlockData[] {
-  return Object.values(
+  ridGenerator: OntologyRidGenerator,
+): ConvertedValueTypes {
+  const valueTypeReferences: Record<
+    string,
+    Record<string, ValueTypeReference>
+  > = {};
+  const valueTypes = Object.values(
     ontology[OntologyEntityTypeEnum.VALUE_TYPE],
   ).map<ValueTypeBlockData>((definitions) => {
-    const version = getLatestVersion(definitions);
+    const uniqueDefinitions = Array.from(
+      new Map(
+        definitions.map((definition) => [definition.version, definition]),
+      ).values(),
+    );
+    const firstDefinition = uniqueDefinitions[0];
+    if (firstDefinition === undefined) {
+      throw new Error("Value type must have at least one version");
+    }
+    const latestVersion = getLatestVersion(uniqueDefinitions);
+    valueTypeReferences[firstDefinition.apiName] = Object.fromEntries(
+      uniqueDefinitions.map((definition) => [
+        definition.version,
+        ridGenerator.generateRidForValueType(
+          definition.apiName,
+          definition.version,
+        ),
+      ]),
+    );
     return {
       metadata: {
-        apiName: definitions[0].apiName,
-        baseType: version.baseType,
-        displayMetadata: definitions[0].displayMetadata,
-        status: definitions[0].status,
+        apiName: firstDefinition.apiName,
+        baseType: latestVersion.baseType,
+        displayMetadata: firstDefinition.displayMetadata,
+        status: firstDefinition.status,
       },
-      versions: Array.from(
-        new Map(
-          definitions.map((definition) => [definition.version, definition]),
-        ).values(),
-      ).map((definition) => ({
+      versions: uniqueDefinitions.map((definition) => ({
         version: definition.version,
         baseType: definition.baseType,
         constraints: definition.constraints,
@@ -47,6 +78,7 @@ export function convertValueTypeToWireBlockData(
       })),
     };
   });
+  return { valueTypes, valueTypeReferences };
 }
 
 function getLatestVersion(
@@ -63,13 +95,16 @@ function getLatestVersion(
 }
 
 function compareSlsVersions(a: string, b: string): number {
-  const partsA = a.split(".").map(Number);
-  const partsB = b.split(".").map(Number);
-  const maxLen = Math.max(partsA.length, partsB.length);
-  for (let i = 0; i < maxLen; i++) {
-    const segA = partsA[i] ?? 0;
-    const segB = partsB[i] ?? 0;
-    if (segA !== segB) return segA - segB;
+  const validA = validSemver(a);
+  const validB = validSemver(b);
+  if (validA != null && validB != null) {
+    return compareSemver(validA, validB);
   }
-  return 0;
+  if (validA != null) {
+    return 1;
+  }
+  if (validB != null) {
+    return -1;
+  }
+  return a < b ? -1 : a > b ? 1 : 0;
 }

--- a/packages/maker-experimental/src/util/generateRid.ts
+++ b/packages/maker-experimental/src/util/generateRid.ts
@@ -728,6 +728,15 @@ export class OntologyRidGeneratorImpl implements OntologyRidGenerator {
     apiName: string,
     version: string,
   ): ValueTypeReference {
+    const readableId = ReadableIdGenerator.getForConsumedValueType(
+      apiName,
+      version,
+    );
+    const existing = this.consumedValueTypeReferences.get(readableId);
+    if (existing !== undefined) {
+      return existing;
+    }
+
     const rid = `ri.ontology-metadata.temp.value-type.${this.hashString(
       apiName,
     )}`;
@@ -746,10 +755,7 @@ export class OntologyRidGeneratorImpl implements OntologyRidGenerator {
       versionId: versionAsUuid,
     } as ValueTypeReference;
 
-    this.consumedValueTypeReferences.put(
-      ReadableIdGenerator.getForConsumedValueType(apiName, version),
-      valueTypeReference,
-    );
+    this.consumedValueTypeReferences.put(readableId, valueTypeReference);
     this.producedValueTypeReferences.set(
       valueTypeReference,
       ReadableIdGenerator.getForProducedValueType(apiName, version),


### PR DESCRIPTION
reconstructing Value Type identifiers during SDK conversion can disagree with the exact references Maker assigned to properties

• serialize exact RID and version identifiers beside complete Value Type definitions
• reuse the same reference object across properties and the serialized map
• retain per-version fallback for older complete SDK inputs