### PR TITLE
write separate marketplace and sdk inputs

### DIFF
--- a/.changeset/write-complete-sdk-input.md
+++ b/.changeset/write-complete-sdk-input.md
@@ -1,0 +1,5 @@
+---
+"@osdk/maker-experimental": patch
+---
+
+Write complete SDK-generation input separately from existing Marketplace block data.

--- a/packages/maker-experimental/src/cli/main.test.ts
+++ b/packages/maker-experimental/src/cli/main.test.ts
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+
+import type { OntologyIrV2 } from "@osdk/client.unstable";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { writeOntologyArtifacts } from "./main.js";
+
+function emptyBlock(): OntologyIrV2["ontology"] {
+  return {
+    actionTypes: {},
+    blockOutputCompassLocations: {},
+    interfaceTypes: {},
+    knownIdentifiers: {
+      actionParameterIds: {},
+      actionParameters: {},
+      actionTypes: {},
+      datasourceColumns: {},
+      datasources: {},
+      filesDatasources: {},
+      functions: {},
+      geotimeSeriesSyncs: {},
+      groupIds: {},
+      interfaceActionTypeConstraints: {},
+      interfaceLinkTypes: {},
+      interfaceParameterConstraints: {},
+      interfacePropertyTypes: {},
+      interfaceTypes: {},
+      linkTypeIds: {},
+      linkTypes: {},
+      markings: {},
+      objectPropertyTypeIdsToRids: {},
+      objectTypeIds: {},
+      objectTypes: {},
+      propertyTypeIds: {},
+      propertyTypes: {},
+      sharedPropertyTypes: {},
+      structFieldRidsToApiNames: {},
+      timeSeriesSyncs: {},
+      valueTypes: {},
+      webhooks: {},
+      workshopModules: {},
+    },
+    linkTypes: {},
+    objectTypes: {},
+    ruleSets: {},
+    sharedPropertyTypes: {},
+  };
+}
+
+describe("writeOntologyArtifacts", () => {
+  let buildDir: string;
+
+  beforeEach(() => {
+    buildDir = fs.mkdtempSync(path.join(os.tmpdir(), "maker-artifacts-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(buildDir, { recursive: true, force: true });
+  });
+
+  it("rejects an SDK output inside the Marketplace block data directory", async () => {
+    const ontologyIr: OntologyIrV2 = {
+      importedOntology: emptyBlock(),
+      importedValueTypes: [],
+      ontology: emptyBlock(),
+      randomnessKey: "00000000-0000-0000-0000-000000000000",
+      transitiveImportedOntology: emptyBlock(),
+      valueTypes: [],
+    };
+
+    await expect(
+      writeOntologyArtifacts(
+        ontologyIr,
+        buildDir,
+        path.join(buildDir, "temp_block_data", "ontology.json"),
+      ),
+    ).rejects.toThrow(
+      "sdkOutput must be outside the Marketplace block data directory",
+    );
+  });
+
+  it("separates Marketplace block data from the SDK generation envelope", async () => {
+    const ontology = emptyBlock();
+    const ontologyIr: OntologyIrV2 = {
+      importedOntology: emptyBlock(),
+      importedValueTypes: [],
+      ontology,
+      randomnessKey: "00000000-0000-0000-0000-000000000000",
+      transitiveImportedOntology: emptyBlock(),
+      valueTypes: [],
+    };
+    const sdkOutput = path.join(buildDir, "sdk_input", "ontology.json");
+
+    await writeOntologyArtifacts(ontologyIr, buildDir, sdkOutput);
+
+    const marketplaceFile = JSON.parse(
+      fs.readFileSync(
+        path.join(buildDir, "temp_block_data", "ontology.json"),
+        "utf-8",
+      ),
+    );
+    expect(marketplaceFile).toEqual(ontology);
+    expect(marketplaceFile).toHaveProperty("objectTypes");
+    expect(marketplaceFile).toHaveProperty("actionTypes");
+    expect(marketplaceFile).not.toHaveProperty("ontology");
+    expect(marketplaceFile).not.toHaveProperty("valueTypes");
+    expect(marketplaceFile).not.toHaveProperty("transitiveImportedOntology");
+
+    const sdkInputFile = JSON.parse(fs.readFileSync(sdkOutput, "utf-8"));
+    expect(sdkInputFile).toEqual(ontologyIr);
+    expect(sdkInputFile).toHaveProperty("ontology");
+    expect(sdkInputFile).toHaveProperty("valueTypes", []);
+    expect(sdkInputFile).toHaveProperty("importedValueTypes", []);
+    expect(sdkInputFile).toHaveProperty("transitiveImportedOntology");
+  });
+});

--- a/packages/maker-experimental/src/cli/main.ts
+++ b/packages/maker-experimental/src/cli/main.ts
@@ -21,6 +21,7 @@ import { pathToFileURL } from "node:url";
 import type {
   LinkTypeBlockDataV2,
   ObjectTypeBlockDataV2,
+  OntologyIrV2,
 } from "@osdk/client.unstable";
 import type { OntologyFullMetadata } from "@osdk/foundry.ontologies";
 import {
@@ -63,6 +64,7 @@ export default async function main(
     input: string;
     output: string;
     valueTypesOutput: string;
+    sdkOutput: string;
     apiNamespace: string;
     buildDir: string;
     codegenDir?: string;
@@ -96,6 +98,12 @@ export default async function main(
         describe: "Output file for value types BlockGeneratorResult JSON",
         type: "string",
         default: "build/value_types_block_generator_result.json",
+        coerce: path.resolve,
+      },
+      sdkOutput: {
+        describe: "Output file for the complete SDK generation input",
+        type: "string",
+        default: "build/sdk_input/ontology.json",
         coerce: path.resolve,
       },
       apiNamespace: {
@@ -248,17 +256,11 @@ export default async function main(
     importedLinkTypeIdsByApiName,
   );
 
-  // Create temp directory for block data
-  const blockDataDir = path.join(commandLineOpts.buildDir, "temp_block_data");
-  if (!fs.existsSync(blockDataDir)) {
-    await fs.promises.mkdir(blockDataDir, { recursive: true });
-  }
-
-  // Write ontology.json to the block data directory
-  const ontologyJsonPath = path.join(blockDataDir, "ontology.json");
-  const ontologyJson = JSON.stringify(ontologyIr.ontology, null, 2);
-  await fs.promises.writeFile(ontologyJsonPath, ontologyJson);
-  consola.info(`Wrote ontology.json to ${ontologyJsonPath}`);
+  const blockDataDir = await writeOntologyArtifacts(
+    ontologyIr,
+    commandLineOpts.buildDir,
+    commandLineOpts.sdkOutput,
+  );
 
   const importedMetadata =
     OntologyBlockDataToFullMetadataConverter.getFullMetadataFromBlockData(
@@ -478,6 +480,37 @@ export default async function main(
       `Value type BlockGeneratorResult written to ${commandLineOpts.valueTypesOutput}`,
     );
   }
+}
+
+export async function writeOntologyArtifacts(
+  ontologyIr: OntologyIrV2,
+  buildDir: string,
+  sdkOutput: string,
+): Promise<string> {
+  const blockDataDir = path.resolve(buildDir, "temp_block_data");
+  const resolvedSdkOutput = path.resolve(sdkOutput);
+  invariant(
+    resolvedSdkOutput !== blockDataDir &&
+      !resolvedSdkOutput.startsWith(`${blockDataDir}${path.sep}`),
+    "sdkOutput must be outside the Marketplace block data directory",
+  );
+  await fs.promises.mkdir(blockDataDir, { recursive: true });
+
+  const ontologyJsonPath = path.join(blockDataDir, "ontology.json");
+  await fs.promises.writeFile(
+    ontologyJsonPath,
+    JSON.stringify(ontologyIr.ontology, null, 2),
+  );
+  consola.info(`Wrote ontology.json to ${ontologyJsonPath}`);
+
+  await fs.promises.mkdir(path.dirname(resolvedSdkOutput), { recursive: true });
+  await fs.promises.writeFile(
+    resolvedSdkOutput,
+    JSON.stringify(ontologyIr, null, 2),
+  );
+  consola.info(`Wrote SDK generation input to ${resolvedSdkOutput}`);
+
+  return blockDataDir;
 }
 
 async function loadOntology(


### PR DESCRIPTION
Maker currently writes only Marketplace block data, which cannot carry the complete metadata required by SDK generation

• keep the existing Marketplace ontology file unchanged
• write complete ontology IR to a separate SDK-generation path
• reject output paths that overlap the Marketplace artifact directory