### PR TITLE
omit installation-specific bindings from generated SDKs

### DIFF
--- a/.changeset/portable-sdk-ontology-rid.md
+++ b/.changeset/portable-sdk-ontology-rid.md
@@ -1,0 +1,5 @@
+---
+"@osdk/generator": minor
+---
+
+Allow generated SDKs to omit the installed ontology RID and branch identity.

--- a/.changeset/portable-sdk-ontology-rid.md
+++ b/.changeset/portable-sdk-ontology-rid.md
@@ -2,4 +2,4 @@
 "@osdk/generator": minor
 ---
 
-Allow generated SDKs to omit the installed ontology RID and branch identity.
+Allow generated SDKs to omit installed ontology identity and include entity documentation on generated symbols.

--- a/packages/generator/src/GenerateContext/GenerateContext.ts
+++ b/packages/generator/src/GenerateContext/GenerateContext.ts
@@ -28,4 +28,5 @@ export interface GenerateContext {
   ontologyApiNamespace?: string | undefined;
   apiNamespacePackageMap?: Map<string, string>;
   forInternalUse?: boolean;
+  omitOntologyRid?: boolean;
 }

--- a/packages/generator/src/shared/entityJsdoc.test.ts
+++ b/packages/generator/src/shared/entityJsdoc.test.ts
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+import { entityJsdoc } from "./entityJsdoc.js";
+
+describe("entityJsdoc", () => {
+  it("renders display names and descriptions", () => {
+    expect(entityJsdoc("Todo", "Todo item", "Tracks work.")).toBe(`/**
+ * Display name: Todo item
+ * Tracks work.
+ */
+`);
+  });
+
+  it("omits display names matching the API name", () => {
+    expect(entityJsdoc("Todo", "Todo", undefined)).toBe("");
+  });
+
+  it("neutralizes tag-like display name lines", () => {
+    expect(entityJsdoc("Todo", "@experimental\n@deprecated", undefined)).toBe(
+      `/**
+ * Display name: &#64;experimental
+ * &#64;deprecated
+ */
+`,
+    );
+  });
+
+  it("neutralizes tag-like description lines", () => {
+    expect(
+      entityJsdoc(
+        "Todo",
+        undefined,
+        "@experimental\nTracks work.\n@deprecated\nContains */ safely.",
+      ),
+    ).toBe(`/**
+ * &#64;experimental
+ * Tracks work.
+ * &#64;deprecated
+ * Contains *\\/ safely.
+ */
+`);
+  });
+});

--- a/packages/generator/src/shared/entityJsdoc.ts
+++ b/packages/generator/src/shared/entityJsdoc.ts
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { escapeJsDocText } from "../util/escapeJsDocText.js";
+
+export function entityJsdoc(
+  apiName: string,
+  displayName: string | undefined,
+  description: string | undefined,
+): string {
+  const lines: string[] = [];
+  if (displayName != null && displayName !== apiName) {
+    lines.push(
+      ...escapeMetadata(displayName).map((line, index) =>
+        index === 0 ? `Display name: ${line}` : line
+      ),
+    );
+  }
+  if (description != null) {
+    lines.push(...escapeMetadata(description));
+  }
+  if (lines.length === 0) {
+    return "";
+  }
+  return `/**\n${lines.map((line) => ` * ${line}`).join("\n")}\n */\n`;
+}
+
+function escapeMetadata(metadata: string): string[] {
+  return escapeJsDocText(metadata)
+    .split("\n")
+    .map(line => line.startsWith("@") ? `&#64;${line.slice(1)}` : line);
+}

--- a/packages/generator/src/v2.0/generateClientSdkVersionTwoPointZero.test.ts
+++ b/packages/generator/src/v2.0/generateClientSdkVersionTwoPointZero.test.ts
@@ -1976,6 +1976,34 @@ describe("generator", () => {
 
       expect(helper.getFiles()["/foo/index.ts"]).toContain("$ontologyRid");
     });
+
+    it("omits the ontology and branch identities for portable SDKs", async () => {
+      const BASE_PATH = "/foo";
+
+      await generateClientSdkVersionTwoPointZero(
+        TodoWireOntology,
+        "",
+        helper.minimalFiles,
+        BASE_PATH,
+        "module",
+        new Map(),
+        new Map(),
+        new Map(),
+        false,
+        [],
+        false,
+        true,
+      );
+
+      expect(helper.getFiles()["/foo/index.ts"]).not.toContain("$ontologyRid");
+      expect(helper.getFiles()["/foo/index.ts"]).not.toContain("$branch");
+      expect(helper.getFiles()["/foo/OntologyMetadata.ts"]).not.toContain(
+        "$ontologyRid",
+      );
+      expect(helper.getFiles()["/foo/OntologyMetadata.ts"]).not.toContain(
+        "$branch",
+      );
+    });
   });
 
   describe("exportOntologyMetadata", () => {

--- a/packages/generator/src/v2.0/generateClientSdkVersionTwoPointZero.ts
+++ b/packages/generator/src/v2.0/generateClientSdkVersionTwoPointZero.ts
@@ -41,6 +41,7 @@ export async function generateClientSdkVersionTwoPointZero(
   forInternalUse: boolean = false,
   fixedVersionQueryTypes: string[] = [],
   exportOntologyMetadata: boolean = false,
+  omitOntologyRid: boolean = false,
 ): Promise<void> {
   const importExt = ".js"; // turns out you can always use the extension
 
@@ -65,6 +66,7 @@ export async function generateClientSdkVersionTwoPointZero(
     outDir,
     forInternalUse,
     fixedVersionQueryTypes,
+    omitOntologyRid,
   };
 
   await generateRootIndexTsFile(ctx);

--- a/packages/generator/src/v2.0/generateMetadata.ts
+++ b/packages/generator/src/v2.0/generateMetadata.ts
@@ -24,7 +24,13 @@ const ExpectedOsdkVersion = "2.59.0";
 // END: THIS IS GENERATED CODE. DO NOT EDIT.
 
 export async function generateOntologyMetadataTypeFile(
-  { fs, outDir, ontology, ontologyApiNamespace }: GenerateContext,
+  {
+    fs,
+    outDir,
+    ontology,
+    ontologyApiNamespace,
+    omitOntologyRid,
+  }: GenerateContext,
   userAgent: string,
 ): Promise<void> {
   await fs.writeFile(
@@ -34,7 +40,7 @@ export async function generateOntologyMetadataTypeFile(
       export type $ExpectedClientVersion = "${ExpectedOsdkVersion}";
       export const $osdkMetadata = { extraUserAgent: "${userAgent}" };
       ${
-        ontologyApiNamespace == null
+        ontologyApiNamespace == null && !omitOntologyRid
           ? `
         export const $ontologyRid = "${ontology.ontology.rid}";
         /**

--- a/packages/generator/src/v2.0/generateRootIndexTsFile.ts
+++ b/packages/generator/src/v2.0/generateRootIndexTsFile.ts
@@ -20,7 +20,14 @@ import type { GenerateContext } from "../GenerateContext/GenerateContext.js";
 import { formatTs } from "../util/test/formatTs.js";
 
 export async function generateRootIndexTsFile(
-  { fs, outDir, importExt, ontologyApiNamespace, ontology }: GenerateContext,
+  {
+    fs,
+    outDir,
+    importExt,
+    ontologyApiNamespace,
+    ontology,
+    omitOntologyRid,
+  }: GenerateContext,
 ): Promise<void> {
   await fs.writeFile(
     path.join(outDir, "index.ts"),
@@ -43,7 +50,7 @@ export async function generateRootIndexTsFile(
         export * as $Queries from "./ontology/queries${importExt}";
         export { $osdkMetadata } from "./OntologyMetadata${importExt}";
         ${
-        ontologyApiNamespace == null
+        ontologyApiNamespace == null && !omitOntologyRid
           ? `export { $branch, $ontologyRid } from "./OntologyMetadata${importExt}";`
           : ``
       }

--- a/packages/generator/src/v2.0/wireInterfaceTypeV2ToSdkObjectConst.test.ts
+++ b/packages/generator/src/v2.0/wireInterfaceTypeV2ToSdkObjectConst.test.ts
@@ -272,6 +272,10 @@ describe(wireInterfaceTypeV2ToSdkObjectConst, () => {
         > = OsdkInstance<OPTIONS, K>;
       }
 
+      /**
+       * Display name: Foo interface dn
+       * Foo interface desc
+       */
       export interface Foo extends $InterfaceDefinition {
         osdkMetadata: typeof $osdkMetadata;
         type: "interface";
@@ -300,6 +304,10 @@ describe(wireInterfaceTypeV2ToSdkObjectConst, () => {
         };
       }
 
+      /**
+       * Display name: Foo interface dn
+       * Foo interface desc
+       */
       export const Foo = {
         type: "interface",
         apiName: "Foo",
@@ -382,6 +390,10 @@ describe(wireInterfaceTypeV2ToSdkObjectConst, () => {
         > = OsdkInstance<OPTIONS, K>;
       }
 
+      /**
+       * Display name: Foo interface dn
+       * Foo interface desc
+       */
       export interface Foo extends $InterfaceDefinition {
         osdkMetadata: typeof $osdkMetadata;
         type: "interface";
@@ -416,6 +428,10 @@ describe(wireInterfaceTypeV2ToSdkObjectConst, () => {
         };
       }
 
+      /**
+       * Display name: Foo interface dn
+       * Foo interface desc
+       */
       export const Foo = {
         type: "interface",
         apiName: "Foo",
@@ -492,6 +508,10 @@ describe(wireInterfaceTypeV2ToSdkObjectConst, () => {
         > = OsdkInstance<OPTIONS, K>;
       }
 
+      /**
+       * Display name: Foo interface dn
+       * Foo interface desc
+       */
       export interface Foo extends $InterfaceDefinition {
         osdkMetadata: typeof $osdkMetadata;
         type: "interface";
@@ -520,6 +540,10 @@ describe(wireInterfaceTypeV2ToSdkObjectConst, () => {
         };
       }
 
+      /**
+       * Display name: Foo interface dn
+       * Foo interface desc
+       */
       export const Foo = {
         type: "interface",
         apiName: "Foo",

--- a/packages/generator/src/v2.0/wireInterfaceTypeV2ToSdkObjectConst.ts
+++ b/packages/generator/src/v2.0/wireInterfaceTypeV2ToSdkObjectConst.ts
@@ -25,6 +25,7 @@ import invariant from "tiny-invariant";
 import { extractNamespace } from "../GenerateContext/EnhancedBase.js";
 import { EnhancedInterfaceType } from "../GenerateContext/EnhancedInterfaceType.js";
 import type { EnhancedOntologyDefinition } from "../GenerateContext/EnhancedOntologyDefinition.js";
+import { entityJsdoc } from "../shared/entityJsdoc.js";
 import { getObjectImports } from "../shared/getObjectImports.js";
 import { deleteUndefineds } from "../util/deleteUndefineds.js";
 import { stringify } from "../util/stringify.js";
@@ -203,7 +204,16 @@ ${
       
     }    
 
-    ${createDefinition(interfaceDef, ontology, interfaceDef.shortApiName, ids)}
+    ${
+      entityJsdoc(
+        interfaceDef.fullApiName,
+        interfaceDef.raw.displayName,
+        interfaceDef.raw.description,
+      )
+    }${
+      createDefinition(interfaceDef, ontology, interfaceDef.shortApiName, ids)
+        .trimStart()
+    }
 
 `;
   }
@@ -218,7 +228,13 @@ ${
   return `${imports}
     ${v2 ? getV2Types(forInternalUse) : ""}
 
-    export const ${interfaceDef.shortApiName} = {
+    ${
+    entityJsdoc(
+      interfaceDef.fullApiName,
+      interfaceDef.raw.displayName,
+      interfaceDef.raw.description,
+    )
+  }export const ${interfaceDef.shortApiName} = {
       type: "interface",
       apiName: "${interfaceDef.fullApiName}",
       osdkMetadata: $osdkMetadata,

--- a/packages/generator/src/v2.0/wireObjectTypeV2ToSdkObjectConstV2.ts
+++ b/packages/generator/src/v2.0/wireObjectTypeV2ToSdkObjectConstV2.ts
@@ -33,6 +33,7 @@ import { EnhancedObjectType } from "../GenerateContext/EnhancedObjectType.js";
 import type { EnhancedOntologyDefinition } from "../GenerateContext/EnhancedOntologyDefinition.js";
 import { ForeignType } from "../GenerateContext/ForeignType.js";
 import type { GenerateContext } from "../GenerateContext/GenerateContext.js";
+import { entityJsdoc } from "../shared/entityJsdoc.js";
 import { getObjectImports } from "../shared/getObjectImports.js";
 import { propertyJsdoc } from "../shared/propertyJsdoc.js";
 import { stringify } from "../util/stringify.js";
@@ -123,7 +124,16 @@ export function wireObjectTypeV2ToSdkObjectConstV2(
 
 
 
-    ${createDefinition(object, ontology, object.shortApiName, identifiers)}
+    ${
+      entityJsdoc(
+        object.fullApiName,
+        object.raw.objectType.displayName,
+        object.raw.objectType.description,
+      )
+    }${
+      createDefinition(object, ontology, object.shortApiName, identifiers)
+        .trimStart()
+    }
     `;
   }
 
@@ -136,7 +146,13 @@ export function wireObjectTypeV2ToSdkObjectConstV2(
 
   return `${imports}${getV2Types(object, forInternalUse)}
 
-    export const ${object.shortApiName}
+    ${
+    entityJsdoc(
+      object.fullApiName,
+      object.raw.objectType.displayName,
+      object.raw.objectType.description,
+    )
+  }export const ${object.shortApiName}
     = {
       type: "${object instanceof EnhancedObjectType ? "object" : "interface"}",
       apiName: "${object.fullApiName}",


### PR DESCRIPTION
generated SDKs can currently imply a binding to one installed ontology even when their source model is installation-independent

• add an explicit option to omit installation-specific bindings
• omit ontology RID and branch declarations when enabled
• preserve installation-specific output by default