### PR TITLE
add osdk oac generate command

### DIFF
--- a/.changeset/generated-sdk-metadata-manifest.md
+++ b/.changeset/generated-sdk-metadata-manifest.md
@@ -1,0 +1,5 @@
+---
+"@osdk/generator-converters.ontologyir": minor
+---
+
+Add a deterministic metadata manifest for reviewing generated SDK semantics.

--- a/.changeset/narrow-representable-value-type-enums.md
+++ b/.changeset/narrow-representable-value-type-enums.md
@@ -1,0 +1,8 @@
+---
+"@osdk/generator": patch
+"@osdk/generator-converters.ontologyir": patch
+"@osdk/maker": patch
+"@osdk/maker-experimental": patch
+---
+
+Narrow generated Value Type properties only to representable string, boolean, integer, and short enum literals; mirror those semantics in semantic manifests; preserve authoritative interface implementer metadata; and recursively convert supported nested array constraints while clearly rejecting unsupported nested shapes.

--- a/.changeset/oac-generate-command.md
+++ b/.changeset/oac-generate-command.md
@@ -1,0 +1,5 @@
+---
+"@osdk/cli": minor
+---
+
+Add an OaC command that generates a portable TypeScript SDK from complete ontology input.

--- a/.changeset/portable-sdk-ontology-rid.md
+++ b/.changeset/portable-sdk-ontology-rid.md
@@ -1,0 +1,5 @@
+---
+"@osdk/generator": minor
+---
+
+Allow generated SDKs to omit the installed ontology RID and branch identity.

--- a/packages/cli.cmd.typescript/package.json
+++ b/packages/cli.cmd.typescript/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@osdk/cli.cmd.typescript",
   "private": true,
-  "version": "0.84.0",
+  "version": "0.82.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
@@ -36,13 +36,16 @@
   "dependencies": {
     "@arethetypeswrong/cli": "^0.17.4",
     "@osdk/cli.common": "workspace:~",
+    "@osdk/client.unstable": "workspace:~",
     "@osdk/foundry.ontologies": "catalog:foundry-platform-typescript",
     "@osdk/generator": "workspace:~",
+    "@osdk/generator-converters.ontologyir": "workspace:~",
     "@osdk/shared.client.impl": "workspace:~",
     "consola": "^3.4.2",
     "fast-deep-equal": "^3.1.3",
     "find-up": "^7.0.0",
     "tslib": "^2.8.1",
+    "yaml": "^2.8.1",
     "yargs": "^17.7.2"
   },
   "devDependencies": {

--- a/packages/cli.cmd.typescript/src/oac/handleOacGenerate.test.ts
+++ b/packages/cli.cmd.typescript/src/oac/handleOacGenerate.test.ts
@@ -1,0 +1,218 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import type { OntologyIrV2 } from "@osdk/client.unstable";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { handleOacGenerate } from "./handleOacGenerate.js";
+
+const emptyOntologyBlock: OntologyIrV2["ontology"] = {
+  actionTypes: {},
+  blockOutputCompassLocations: {},
+  interfaceTypes: {},
+  knownIdentifiers: {
+    actionParameterIds: {},
+    actionParameters: {},
+    actionTypes: {},
+    datasourceColumns: {},
+    datasources: {},
+    filesDatasources: {},
+    functions: {},
+    geotimeSeriesSyncs: {},
+    groupIds: {},
+    interfaceActionTypeConstraints: {},
+    interfaceLinkTypes: {},
+    interfaceParameterConstraints: {},
+    interfacePropertyTypes: {},
+    interfaceTypes: {},
+    linkTypeIds: {},
+    linkTypes: {},
+    markings: {},
+    objectPropertyTypeIdsToRids: {},
+    objectTypeIds: {},
+    objectTypes: {},
+    propertyTypeIds: {},
+    propertyTypes: {},
+    sharedPropertyTypes: {},
+    structFieldRidsToApiNames: {},
+    timeSeriesSyncs: {},
+    valueTypes: {},
+    webhooks: {},
+    workshopModules: {},
+  },
+  linkTypes: {},
+  objectTypes: {},
+  ruleSets: {},
+  sharedPropertyTypes: {},
+};
+
+const emptyMakerIr: OntologyIrV2 = {
+  ontology: emptyOntologyBlock,
+  importedOntology: emptyOntologyBlock,
+  transitiveImportedOntology: emptyOntologyBlock,
+  valueTypes: [],
+  importedValueTypes: [],
+  randomnessKey: "test-randomness-key",
+};
+
+const tempDirs: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    tempDirs.splice(0).map((dir) => rm(dir, { recursive: true, force: true })),
+  );
+});
+
+async function makeTempDir(): Promise<string> {
+  const dir = await mkdtemp(join(tmpdir(), "oac-generate-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+describe(handleOacGenerate, () => {
+  it("rejects block data instead of complete ontology input", async () => {
+    const dir = await makeTempDir();
+    const irPath = join(dir, "ir.json");
+    await writeFile(irPath, JSON.stringify(emptyOntologyBlock));
+
+    await expect(
+      handleOacGenerate({
+        ir: irPath,
+        outDir: join(dir, "out"),
+        version: "0.0.0-dev",
+        packageName: "@example/item-sdk",
+        packageType: "module",
+        ontologyIdentity: "portable",
+      }),
+    ).rejects.toThrow("IR must be complete ontology input");
+  });
+
+  it("writes portable generated source and semantic metadata", async () => {
+    const dir = await makeTempDir();
+    const irPath = join(dir, "ir.json");
+    const outDir = join(dir, "out");
+    await writeFile(irPath, JSON.stringify(emptyMakerIr));
+
+    await handleOacGenerate({
+      ir: irPath,
+      outDir,
+      version: "0.0.0-dev",
+      packageName: "@example/item-sdk",
+      packageType: "module",
+      ontologyIdentity: "portable",
+    });
+
+    const metadata = await readFile(
+      join(outDir, "OntologyMetadata.ts"),
+      "utf-8",
+    );
+    expect(metadata).not.toContain("$ontologyRid");
+    expect(metadata).not.toContain("$branch");
+    expect(
+      JSON.parse(
+        await readFile(join(outDir, "semantic-manifest.json"), "utf-8"),
+      ),
+    ).toMatchObject({
+      formatVersion: 1,
+      packageName: "@example/item-sdk",
+      packageVersion: "0.0.0-dev",
+    });
+  });
+
+  it("rejects an existing output directory", async () => {
+    const dir = await makeTempDir();
+    const irPath = join(dir, "ir.json");
+    const outDir = join(dir, "out");
+    await writeFile(irPath, JSON.stringify(emptyMakerIr));
+    await mkdir(outDir);
+
+    await expect(
+      handleOacGenerate({
+        ir: irPath,
+        outDir,
+        version: "0.0.0-dev",
+        packageName: "@example/item-sdk",
+        packageType: "module",
+        ontologyIdentity: "portable",
+      }),
+    ).rejects.toThrow("Output directory already exists");
+  });
+
+  it("rejects an import that does not match imported metadata", async () => {
+    const dir = await makeTempDir();
+    const irPath = join(dir, "ir.json");
+    const importMapPath = join(dir, "imports.yaml");
+    await writeFile(irPath, JSON.stringify(emptyMakerIr));
+    await writeFile(
+      importMapPath,
+      [
+        "imports:",
+        "  - kind: interface",
+        "    apiName: imported.Missing",
+        '    package: "@example/imported-sdk"',
+      ].join("\n"),
+    );
+
+    await expect(
+      handleOacGenerate({
+        ir: irPath,
+        outDir: join(dir, "out"),
+        version: "0.0.0-dev",
+        packageName: "@example/item-sdk",
+        packageType: "module",
+        ontologyIdentity: "portable",
+        importMap: importMapPath,
+      }),
+    ).rejects.toThrow("Import 'interface:imported.Missing'");
+  });
+
+  it("rejects duplicate import keys", async () => {
+    const dir = await makeTempDir();
+    const irPath = join(dir, "ir.json");
+    const importMapPath = join(dir, "imports.yaml");
+    await writeFile(irPath, JSON.stringify(emptyMakerIr));
+    await writeFile(
+      importMapPath,
+      [
+        "imports:",
+        "  - kind: interface",
+        "    apiName: imported.Parent",
+        '    package: "@example/one"',
+        "  - kind: interface",
+        "    apiName: imported.Parent",
+        '    package: "@example/two"',
+      ].join("\n"),
+    );
+
+    await expect(
+      handleOacGenerate({
+        ir: irPath,
+        outDir: join(dir, "out"),
+        version: "0.0.0-dev",
+        packageName: "@example/item-sdk",
+        packageType: "module",
+        ontologyIdentity: "portable",
+        importMap: importMapPath,
+      }),
+    ).rejects.toThrow(
+      "Import map must be { imports: [{ kind, apiName, package }] }",
+    );
+  });
+});

--- a/packages/cli.cmd.typescript/src/oac/handleOacGenerate.ts
+++ b/packages/cli.cmd.typescript/src/oac/handleOacGenerate.ts
@@ -1,0 +1,276 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+import { ExitProcessError } from "@osdk/cli.common";
+import type { OntologyIrV2 } from "@osdk/client.unstable";
+import { generateClientSdkVersionTwoPointZero } from "@osdk/generator";
+import {
+  buildSemanticManifest,
+  OntologyIrToFullMetadataConverter,
+} from "@osdk/generator-converters.ontologyir";
+import { consola } from "consola";
+import { parse as parseYaml } from "yaml";
+
+import type { OacGenerateArgs } from "./oacGenerate.js";
+
+const USER_AGENT = `osdk-oac/${process.env.PACKAGE_VERSION ?? "dev"}`;
+
+type ImportedEntityKind = "interface" | "object" | "sharedPropertyType";
+
+interface ImportedEntityMapping {
+  kind: ImportedEntityKind;
+  apiName: string;
+  package: string;
+}
+
+export async function handleOacGenerate(args: OacGenerateArgs): Promise<void> {
+  try {
+    const ir = await readMakerIr(args.ir);
+    const imports = args.importMap ? await readImportMap(args.importMap) : [];
+    validateImports(imports, ir, args.importMap);
+    if (fs.existsSync(args.outDir)) {
+      throw new ExitProcessError(
+        1,
+        `Output directory already exists: ${path.resolve(args.outDir)}`,
+      );
+    }
+
+    const metadata =
+      OntologyIrToFullMetadataConverter.getFullMetadataFromEnvelope(ir);
+    await generateClientSdkVersionTwoPointZero(
+      metadata,
+      getUserAgent(args.version),
+      {
+        writeFile: async (filePath, contents) => {
+          await fs.promises.writeFile(filePath, contents);
+        },
+        mkdir: async (dirPath, options) => {
+          await fs.promises.mkdir(dirPath, options);
+        },
+        readdir: async (dirPath) => {
+          return await fs.promises.readdir(dirPath);
+        },
+      },
+      args.outDir,
+      args.packageType,
+      toExternalMap(imports, "object"),
+      toExternalMap(imports, "interface"),
+      toExternalMap(imports, "sharedPropertyType"),
+      false,
+      [],
+      false,
+      args.ontologyIdentity === "portable",
+    );
+
+    const manifest = buildSemanticManifest(metadata, {
+      packageName: args.packageName,
+      packageVersion: args.version,
+    });
+    await fs.promises.writeFile(
+      path.join(args.outDir, "semantic-manifest.json"),
+      `${JSON.stringify(manifest, null, 2)}\n`,
+    );
+    consola.info("OSDK generated from Maker IR");
+  } catch (error) {
+    if (error instanceof ExitProcessError) {
+      throw error;
+    }
+    const message = error instanceof Error ? error.message : String(error);
+    throw new ExitProcessError(1, message);
+  }
+}
+
+function getUserAgent(version: string): string {
+  return version === "dev"
+    ? "osdk-oac/dev"
+    : `${USER_AGENT} typescript-sdk/${version}`;
+}
+
+function validateImports(
+  imports: ReadonlyArray<ImportedEntityMapping>,
+  ir: OntologyIrV2,
+  importMapPath: string | undefined,
+): void {
+  for (const entry of imports) {
+    if (!hasImportedEntity(ir, entry)) {
+      const source = importMapPath ?? "import map";
+      throw new ExitProcessError(
+        1,
+        `Import '${entry.kind}:${entry.apiName}' from ${source} does not match an imported Maker entity`,
+      );
+    }
+  }
+}
+
+function hasImportedEntity(
+  ir: OntologyIrV2,
+  entry: ImportedEntityMapping,
+): boolean {
+  switch (entry.kind) {
+    case "interface":
+      return Object.values(ir.importedOntology.interfaceTypes).some(
+        ({ interfaceType }) => interfaceType.apiName === entry.apiName,
+      );
+    case "object":
+      return Object.values(ir.importedOntology.objectTypes).some(
+        ({ objectType }) => objectType.apiName === entry.apiName,
+      );
+    case "sharedPropertyType":
+      return Object.values(ir.importedOntology.sharedPropertyTypes).some(
+        ({ sharedPropertyType }) =>
+          sharedPropertyType.apiName === entry.apiName,
+      );
+  }
+}
+
+function toExternalMap(
+  imports: ReadonlyArray<ImportedEntityMapping>,
+  kind: ImportedEntityKind,
+): Map<string, string> {
+  const result = new Map<string, string>();
+  for (const entry of imports) {
+    if (entry.kind === kind) {
+      result.set(entry.apiName, entry.package);
+    }
+  }
+  return result;
+}
+
+async function readMakerIr(irPath: string): Promise<OntologyIrV2> {
+  if (!fs.existsSync(irPath)) {
+    throw new ExitProcessError(1, `Maker IR file does not exist: ${irPath}`);
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(await fs.promises.readFile(irPath, "utf-8"));
+  } catch {
+    throw new ExitProcessError(1, `Maker IR is not valid JSON: ${irPath}`);
+  }
+  if (!isOntologyIr(parsed)) {
+    throw new ExitProcessError(
+      1,
+      "IR must be complete ontology input with ontology, importedOntology, transitiveImportedOntology, valueTypes, and importedValueTypes",
+    );
+  }
+  return parsed;
+}
+
+async function readImportMap(
+  importMapPath: string,
+): Promise<ImportedEntityMapping[]> {
+  if (!fs.existsSync(importMapPath)) {
+    throw new ExitProcessError(
+      1,
+      `Import map file does not exist: ${importMapPath}`,
+    );
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = parseYaml(await fs.promises.readFile(importMapPath, "utf-8"));
+  } catch {
+    throw new ExitProcessError(
+      1,
+      "Import map must be valid YAML: { imports: [{ kind, apiName, package }] }",
+    );
+  }
+  if (!isImportMap(parsed)) {
+    throw new ExitProcessError(
+      1,
+      "Import map must be { imports: [{ kind, apiName, package }] }",
+    );
+  }
+  return parsed.imports;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value != null && !Array.isArray(value);
+}
+
+function isOntologyBlock(value: unknown): boolean {
+  return (
+    isRecord(value) &&
+    isRecord(value.actionTypes) &&
+    isRecord(value.interfaceTypes) &&
+    isRecord(value.linkTypes) &&
+    isRecord(value.objectTypes) &&
+    isRecord(value.sharedPropertyTypes)
+  );
+}
+
+function isOntologyIr(value: unknown): value is OntologyIrV2 {
+  if (!isRecord(value)) {
+    return false;
+  }
+  if (
+    value.randomnessKey !== undefined &&
+    typeof value.randomnessKey !== "string"
+  ) {
+    return false;
+  }
+  return (
+    isOntologyBlock(value.ontology) &&
+    isOntologyBlock(value.importedOntology) &&
+    isOntologyBlock(value.transitiveImportedOntology) &&
+    Array.isArray(value.valueTypes) &&
+    Array.isArray(value.importedValueTypes)
+  );
+}
+
+const importedEntityKinds: ReadonlyArray<ImportedEntityKind> = [
+  "interface",
+  "object",
+  "sharedPropertyType",
+];
+
+function isImportedEntityKind(value: unknown): value is ImportedEntityKind {
+  return importedEntityKinds.some((kind) => value === kind);
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return (
+    typeof value === "string" && value.length > 0 && value === value.trim()
+  );
+}
+
+function isImportMap(
+  value: unknown,
+): value is { imports: ImportedEntityMapping[] } {
+  if (!isRecord(value) || !Array.isArray(value.imports)) {
+    return false;
+  }
+  const seen = new Set<string>();
+  for (const entry of value.imports) {
+    if (
+      !isRecord(entry) ||
+      !isImportedEntityKind(entry.kind) ||
+      !isNonEmptyString(entry.apiName) ||
+      !isNonEmptyString(entry.package)
+    ) {
+      return false;
+    }
+    const key = `${entry.kind}:${entry.apiName}`;
+    if (seen.has(key)) {
+      return false;
+    }
+    seen.add(key);
+  }
+  return true;
+}

--- a/packages/cli.cmd.typescript/src/oac/oacCommand.ts
+++ b/packages/cli.cmd.typescript/src/oac/oacCommand.ts
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 Palantir Technologies, Inc. All rights reserved.
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,16 @@
  * limitations under the License.
  */
 
-export { cli } from "./cli.js";
-export type { TypescriptGenerateArgs } from "./generate/TypescriptGenerateArgs.js";
-export { oacCommand } from "./oac/oacCommand.js";
-export { typescriptCommand as default } from "./typescriptCommand.js";
+import type { CliCommonArgs } from "@osdk/cli.common";
+import type * as yargs from "yargs";
+
+import { oacGenerateCommand } from "./oacGenerate.js";
+
+export const oacCommand: yargs.CommandModule<CliCommonArgs, CliCommonArgs> = {
+  command: "oac",
+  describe: "Generate from Ontology as Code",
+  builder: (argv) => {
+    return argv.command(oacGenerateCommand).demandCommand();
+  },
+  handler: async (_args) => {},
+};

--- a/packages/cli.cmd.typescript/src/oac/oacGenerate.test.ts
+++ b/packages/cli.cmd.typescript/src/oac/oacGenerate.test.ts
@@ -1,0 +1,92 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+import yargs from "yargs";
+
+import { oacGenerateCommand } from "./oacGenerate.js";
+
+describe("oac generate", () => {
+  it("requires a package name", () => {
+    expect(() =>
+      yargs([
+        "generate",
+        "--ir",
+        "ontology.json",
+        "--outDir",
+        "generated",
+        "--version",
+        "0.0.0-dev",
+      ])
+        .version(false)
+        .exitProcess(false)
+        .fail((message) => {
+          throw new Error(message);
+        })
+        .command(oacGenerateCommand)
+        .parse(),
+    ).toThrow("Missing required argument: packageName");
+  });
+
+  it.each(["", "   "])("rejects package name %j", (packageName) => {
+    expect(() =>
+      yargs([
+        "generate",
+        "--ir",
+        "ontology.json",
+        "--outDir",
+        "generated",
+        "--version",
+        "0.0.0-dev",
+        "--packageName",
+        packageName,
+      ])
+        .version(false)
+        .exitProcess(false)
+        .fail((_message, error) => {
+          throw error;
+        })
+        .command(oacGenerateCommand)
+        .parse(),
+    ).toThrow("packageName must not be empty");
+  });
+
+  it.each([" 1.2.3 ", "v1.2.3"])(
+    "rejects non-canonical version %j",
+    (version) => {
+      expect(() =>
+        yargs([
+          "generate",
+          "--ir",
+          "ontology.json",
+          "--outDir",
+          "generated",
+          "--version",
+          version,
+          "--packageName",
+          "@example/item-sdk",
+        ])
+          .version(false)
+          .exitProcess(false)
+          .fail((_message, error) => {
+            throw error;
+          })
+          .command(oacGenerateCommand)
+          .parse(),
+      ).toThrow("Version must be 'dev' or a valid semver version");
+    },
+  );
+});

--- a/packages/cli.cmd.typescript/src/oac/oacGenerate.ts
+++ b/packages/cli.cmd.typescript/src/oac/oacGenerate.ts
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { isValidSemver, YargsCheckError } from "@osdk/cli.common";
+import type { CommandModule } from "yargs";
+
+export interface OacGenerateArgs {
+  ir: string;
+  outDir: string;
+  version: string;
+  packageName: string;
+  packageType: "module";
+  ontologyIdentity: "portable" | "installationSpecific";
+  importMap?: string;
+}
+
+export const oacGenerateCommand: CommandModule<{}, OacGenerateArgs> = {
+  command: "generate",
+  describe: "Generate a TypeScript SDK from Maker IR",
+  builder: (argv) => {
+    return argv
+      .options({
+        ir: {
+          type: "string",
+          description: "Path to the complete Maker IR json",
+          demandOption: true,
+        },
+        outDir: {
+          type: "string",
+          description: "Where to place the generated files",
+          demandOption: true,
+        },
+        version: {
+          type: "string",
+          description: "Version of the generated code, or 'dev'",
+          demandOption: true,
+        },
+        packageName: {
+          type: "string",
+          description: "Name of the package to generate",
+          demandOption: true,
+        },
+        packageType: {
+          default: "module",
+          choices: ["module"],
+        },
+        ontologyIdentity: {
+          type: "string",
+          choices: ["portable", "installationSpecific"],
+          default: "portable",
+          description:
+            "portable omits installation-specific ontology and branch ids",
+        },
+        importMap: {
+          type: "string",
+          description:
+            "Path to a YAML import map of { imports: [{ kind, apiName, package }] }",
+        },
+      } as const)
+      .check((args) => {
+        if (args.packageName.trim().length === 0) {
+          throw new YargsCheckError("packageName must not be empty");
+        }
+        if (
+          args.version !== "dev" &&
+          (args.version !== args.version.trim() ||
+            args.version.startsWith("v") ||
+            !isValidSemver(args.version))
+        ) {
+          throw new YargsCheckError(
+            "Version must be 'dev' or a valid semver version",
+          );
+        }
+        return true;
+      });
+  },
+  handler: async (args) => {
+    const command = await import("./handleOacGenerate.js");
+    await command.handleOacGenerate(args);
+  },
+};

--- a/packages/cli/src/cli.ts
+++ b/packages/cli/src/cli.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import typescript from "@osdk/cli.cmd.typescript";
+import typescript, { oacCommand } from "@osdk/cli.cmd.typescript";
 import type { CliCommonArgs } from "@osdk/cli.common";
 import { ExitProcessError, getYargsBase } from "@osdk/cli.common";
 import { consola } from "consola";
@@ -37,6 +37,7 @@ export async function cli(
     return await base
       .command(site)
       .command(widgetSet)
+      .command(oacCommand)
       .command({
         command: "unstable",
         aliases: ["experimental"],

--- a/packages/generator-converters.ontologyir/src/index.ts
+++ b/packages/generator-converters.ontologyir/src/index.ts
@@ -41,3 +41,7 @@ export {
   OntologyIrToFullMetadataConverter,
 } from "./OntologyIrToFullMetadataConverter.js";
 export { toStructFieldRid, toUuid } from "./ridUtils.js";
+export {
+  buildSemanticManifest,
+  type SemanticManifest,
+} from "./semanticManifest.js";

--- a/packages/generator-converters.ontologyir/src/semanticManifest.test.ts
+++ b/packages/generator-converters.ontologyir/src/semanticManifest.test.ts
@@ -219,21 +219,63 @@ describe(buildSemanticManifest, () => {
     }]);
   });
 
-  it("rejects value types that generation cannot narrow", () => {
-    const invalidValueType: Ontologies.OntologyValueType = {
+  it("finds a representable enum without throwing for multiple constraints", () => {
+    const multiConstraint: Ontologies.OntologyValueType = {
       ...itemCode,
       constraints: [
-        { type: "enum", options: ["alpha"] },
-        { type: "enum", options: ["beta"] },
+        { type: "regex", pattern: "[a-z]+", partialMatch: false },
+        { type: "enum", options: [undefined, 7, "alpha"] },
+        { type: "enum", options: ["ignored"] },
       ],
     };
 
-    expect(() =>
-      buildSemanticManifest(
-        metadata({}, { invalidValueType }, {}),
-        { packageName: "@example/item-sdk", packageVersion: "1.2.3" },
-      )
-    ).toThrowError("Expected exactly one constraint for value type itemCode");
+    const manifest = buildSemanticManifest(
+      metadata({}, { multiConstraint }, {}),
+      { packageName: "@example/item-sdk", packageVersion: "1.2.3" },
+    );
+
+    expect(manifest.valueTypes).toEqual([{
+      apiName: "itemCode",
+      version: "2.0.0",
+      narrowed: true,
+    }]);
+  });
+
+  it("mirrors numeric narrowing supported by generation", () => {
+    const valueType = (
+      apiName: string,
+      fieldType: "integer" | "short" | "long" | "decimal" | "float" | "double",
+      options: Array<string | number | undefined>,
+    ): Ontologies.OntologyValueType => ({
+      apiName,
+      displayName: apiName,
+      rid: `ri.value-type.main.value-type.${apiName}`,
+      fieldType: { type: fieldType },
+      version: "1.0.0",
+      constraints: [{ type: "enum", options }],
+    });
+    const valueTypes = {
+      integer: valueType("integer", "integer", [1, 2.5, "3"]),
+      short: valueType("short", "short", [32_768, 7]),
+      long: valueType("long", "long", [1]),
+      decimal: valueType("decimal", "decimal", ["1.0"]),
+      float: valueType("float", "float", [1]),
+      double: valueType("double", "double", [1]),
+    };
+
+    const manifest = buildSemanticManifest(
+      metadata({}, valueTypes, {}),
+      { packageName: "@example/item-sdk", packageVersion: "1.2.3" },
+    );
+
+    expect(manifest.valueTypes).toEqual([
+      { apiName: "decimal", version: "1.0.0", narrowed: false },
+      { apiName: "double", version: "1.0.0", narrowed: false },
+      { apiName: "float", version: "1.0.0", narrowed: false },
+      { apiName: "integer", version: "1.0.0", narrowed: true },
+      { apiName: "long", version: "1.0.0", narrowed: false },
+      { apiName: "short", version: "1.0.0", narrowed: true },
+    ]);
   });
 
   it("records transitive interface extensions", () => {

--- a/packages/generator-converters.ontologyir/src/semanticManifest.test.ts
+++ b/packages/generator-converters.ontologyir/src/semanticManifest.test.ts
@@ -1,0 +1,297 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type * as Ontologies from "@osdk/foundry.ontologies";
+import { describe, expect, it } from "vitest";
+import { buildSemanticManifest } from "./semanticManifest.js";
+
+const itemInterface: Ontologies.InterfaceType = {
+  rid: "ri.interface-type.main.interface-type.Item",
+  apiName: "Item",
+  displayName: "Item",
+  properties: {},
+  allProperties: {},
+  propertiesV2: {},
+  allPropertiesV2: {
+    zeta: {
+      rid: "ri.interface-property-type.main.interface-property-type.zeta",
+      apiName: "zeta",
+      displayName: "Zeta",
+      dataType: { type: "string" },
+      requireImplementation: false,
+    },
+    alpha: {
+      rid: "ri.interface-property-type.main.interface-property-type.alpha",
+      apiName: "alpha",
+      displayName: "Alpha",
+      dataType: { type: "string" },
+      requireImplementation: true,
+      valueTypeApiName: "itemCode",
+    },
+  },
+  extendsInterfaces: ["Named", "Asset"],
+  allExtendsInterfaces: ["Named", "Asset"],
+  implementedByObjectTypes: [],
+  links: {},
+  allLinks: {
+    owner: {
+      rid: "ri.interface-link-type.main.interface-link-type.owner",
+      apiName: "owner",
+      displayName: "Owner",
+      linkedEntityApiName: {
+        type: "objectTypeApiName",
+        apiName: "Person",
+      },
+      cardinality: "ONE",
+      required: true,
+    },
+    children: {
+      rid: "ri.interface-link-type.main.interface-link-type.children",
+      apiName: "children",
+      displayName: "Children",
+      linkedEntityApiName: {
+        type: "interfaceTypeApiName",
+        apiName: "Item",
+      },
+      cardinality: "MANY",
+      required: false,
+    },
+  },
+};
+
+const itemCode: Ontologies.OntologyValueType = {
+  apiName: "itemCode",
+  displayName: "Item Code",
+  rid: "ri.value-type.main.value-type.item-code",
+  fieldType: { type: "string" },
+  version: "2.0.0",
+  constraints: [{ type: "enum", options: ["beta", "alpha"] }],
+};
+
+const quantity: Ontologies.OntologyValueType = {
+  apiName: "quantity",
+  displayName: "Quantity",
+  rid: "ri.value-type.main.value-type.quantity",
+  fieldType: { type: "integer" },
+  version: "1.0.0",
+  constraints: [],
+};
+
+const updateItem: Ontologies.ActionTypeV2 = {
+  apiName: "updateItem",
+  status: "ACTIVE",
+  rid: "ri.actions.main.action-type.update-item",
+  parameters: {
+    zeta: {
+      displayName: "Zeta",
+      dataType: { type: "string" },
+      required: false,
+      typeClasses: [],
+    },
+    alpha: {
+      displayName: "Alpha",
+      dataType: { type: "string" },
+      required: true,
+      typeClasses: [],
+    },
+  },
+  operations: [
+    {
+      type: "deleteLink",
+      linkTypeApiNameAtoB: "children",
+      linkTypeApiNameBtoA: "parent",
+      aSideObjectTypeApiName: "Item",
+      bSideObjectTypeApiName: "Item",
+    },
+    { type: "modifyObject", objectTypeApiName: "Item" },
+    {
+      type: "applyScenario",
+      scenarioParameter: "scenario",
+      objectTypeApiNames: ["Person", "Item"],
+      linkTypes: [{
+        objectTypeApiName: "Item",
+        linkTypes: ["owner", "children"],
+      }],
+    },
+  ],
+};
+
+function metadata(
+  interfaceTypes: Record<string, Ontologies.InterfaceType>,
+  valueTypes: Record<string, Ontologies.OntologyValueType>,
+  actionTypes: Record<string, Ontologies.ActionTypeV2>,
+): Ontologies.OntologyFullMetadata {
+  return {
+    ontology: {
+      apiName: "exampleOntology",
+      displayName: "Example Ontology",
+      description: "Example ontology",
+      rid: "ri.ontology.main.ontology.example",
+    },
+    objectTypes: {},
+    actionTypes,
+    queryTypes: {},
+    interfaceTypes,
+    sharedPropertyTypes: {},
+    valueTypes,
+  };
+}
+
+describe(buildSemanticManifest, () => {
+  it("summarizes the generated SDK semantics", () => {
+    const manifest = buildSemanticManifest(
+      metadata(
+        { item: itemInterface },
+        { quantity, itemCode },
+        { updateItem },
+      ),
+      { packageName: "@example/item-sdk", packageVersion: "1.2.3" },
+    );
+
+    expect(manifest).toEqual({
+      formatVersion: 1,
+      packageName: "@example/item-sdk",
+      packageVersion: "1.2.3",
+      interfaces: [{
+        apiName: "Item",
+        extends: ["Asset", "Named"],
+        properties: [
+          { apiName: "alpha", required: true, valueTypeApiName: "itemCode" },
+          { apiName: "zeta", required: false },
+        ],
+        links: [
+          { apiName: "children", cardinality: "MANY", target: "Item" },
+          { apiName: "owner", cardinality: "ONE", target: "Person" },
+        ],
+      }],
+      valueTypes: [
+        { apiName: "itemCode", version: "2.0.0", narrowed: true },
+        { apiName: "quantity", version: "1.0.0", narrowed: false },
+      ],
+      actions: [{
+        apiName: "updateItem",
+        parameters: ["alpha", "zeta"],
+        operations: [
+          { type: "applyScenario", target: "Item" },
+          { type: "applyScenario", target: "Item.children" },
+          { type: "applyScenario", target: "Item.owner" },
+          { type: "applyScenario", target: "Person" },
+          { type: "deleteLink", target: "Item.children" },
+          { type: "deleteLink", target: "Item.parent" },
+          { type: "modifyObject", target: "Item" },
+        ],
+      }],
+    });
+  });
+
+  it("does not narrow a string enum with only undefined values", () => {
+    const emptyStringEnum: Ontologies.OntologyValueType = {
+      apiName: "emptyStringEnum",
+      displayName: "Empty String Enum",
+      rid: "ri.value-type.main.value-type.empty-string-enum",
+      fieldType: { type: "string" },
+      version: "1.0.0",
+      constraints: [{ type: "enum", options: [undefined] }],
+    };
+
+    const manifest = buildSemanticManifest(
+      metadata({}, { emptyStringEnum }, {}),
+      { packageName: "@example/item-sdk", packageVersion: "1.2.3" },
+    );
+
+    expect(manifest.valueTypes).toEqual([{
+      apiName: "emptyStringEnum",
+      version: "1.0.0",
+      narrowed: false,
+    }]);
+  });
+
+  it("rejects value types that generation cannot narrow", () => {
+    const invalidValueType: Ontologies.OntologyValueType = {
+      ...itemCode,
+      constraints: [
+        { type: "enum", options: ["alpha"] },
+        { type: "enum", options: ["beta"] },
+      ],
+    };
+
+    expect(() =>
+      buildSemanticManifest(
+        metadata({}, { invalidValueType }, {}),
+        { packageName: "@example/item-sdk", packageVersion: "1.2.3" },
+      )
+    ).toThrowError("Expected exactly one constraint for value type itemCode");
+  });
+
+  it("records transitive interface extensions", () => {
+    const manifest = buildSemanticManifest(
+      metadata(
+        {
+          item: {
+            ...itemInterface,
+            extendsInterfaces: ["Named"],
+            allExtendsInterfaces: ["Named", "Asset"],
+          },
+        },
+        {},
+        {},
+      ),
+      { packageName: "@example/item-sdk", packageVersion: "1.2.3" },
+    );
+
+    expect(manifest.interfaces[0]?.extends).toEqual(["Asset", "Named"]);
+  });
+
+  it("rejects duplicate entity API names", () => {
+    expect(() =>
+      buildSemanticManifest(
+        metadata(
+          { first: itemInterface, second: itemInterface },
+          {},
+          {},
+        ),
+        { packageName: "@example/item-sdk", packageVersion: "1.2.3" },
+      )
+    ).toThrowError("Duplicate interface API name: Item");
+  });
+
+  it("produces the same JSON regardless of metadata insertion order", () => {
+    const first = buildSemanticManifest(
+      metadata(
+        { zeta: itemInterface, alpha: { ...itemInterface, apiName: "Asset" } },
+        { quantity, itemCode },
+        {
+          zeta: updateItem,
+          alpha: { ...updateItem, apiName: "archiveItem", operations: [] },
+        },
+      ),
+      { packageName: "@example/item-sdk", packageVersion: "1.2.3" },
+    );
+    const second = buildSemanticManifest(
+      metadata(
+        { alpha: { ...itemInterface, apiName: "Asset" }, zeta: itemInterface },
+        { itemCode, quantity },
+        {
+          alpha: { ...updateItem, apiName: "archiveItem", operations: [] },
+          zeta: updateItem,
+        },
+      ),
+      { packageName: "@example/item-sdk", packageVersion: "1.2.3" },
+    );
+
+    expect(JSON.stringify(first)).toBe(JSON.stringify(second));
+  });
+});

--- a/packages/generator-converters.ontologyir/src/semanticManifest.ts
+++ b/packages/generator-converters.ontologyir/src/semanticManifest.ts
@@ -1,0 +1,253 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type * as Ontologies from "@osdk/foundry.ontologies";
+
+interface SemanticOperation {
+  type: string;
+  target: string;
+}
+
+interface SemanticProperty {
+  apiName: string;
+  required: boolean;
+  valueTypeApiName?: string;
+}
+
+export interface SemanticManifest {
+  formatVersion: 1;
+  packageName: string;
+  packageVersion: string;
+  interfaces: Array<{
+    apiName: string;
+    extends: string[];
+    properties: Array<{
+      apiName: string;
+      required: boolean;
+      valueTypeApiName?: string;
+    }>;
+    links: Array<{
+      apiName: string;
+      cardinality: string;
+      target: string;
+    }>;
+  }>;
+  valueTypes: Array<{
+    apiName: string;
+    version: string;
+    narrowed: boolean;
+  }>;
+  actions: Array<{
+    apiName: string;
+    parameters: string[];
+    operations: SemanticOperation[];
+  }>;
+}
+
+function compareText(left: string, right: string): number {
+  return left < right ? -1 : left > right ? 1 : 0;
+}
+
+function compareApiName(
+  left: { apiName: string },
+  right: { apiName: string },
+): number {
+  return compareText(left.apiName, right.apiName);
+}
+
+function sortedByApiName<T extends { apiName: string }>(
+  values: Iterable<T>,
+  kind: string,
+): T[] {
+  const result = [...values].sort(compareApiName);
+  for (let index = 1; index < result.length; index++) {
+    if (result[index - 1]?.apiName === result[index]?.apiName) {
+      throw new Error(`Duplicate ${kind} API name: ${result[index]?.apiName}`);
+    }
+  }
+  return result;
+}
+
+function compareOperation(
+  left: SemanticOperation,
+  right: SemanticOperation,
+): number {
+  const typeComparison = compareText(left.type, right.type);
+  return typeComparison !== 0
+    ? typeComparison
+    : compareText(left.target, right.target);
+}
+
+function actionOperations(
+  action: Ontologies.ActionTypeV2,
+): SemanticOperation[] {
+  const result: SemanticOperation[] = [];
+  for (const operation of action.operations) {
+    switch (operation.type) {
+      case "createObject":
+      case "modifyObject":
+      case "deleteObject":
+        result.push({
+          type: operation.type,
+          target: operation.objectTypeApiName,
+        });
+        break;
+      case "createInterfaceObject":
+      case "modifyInterfaceObject":
+      case "deleteInterfaceObject":
+        result.push({
+          type: operation.type,
+          target: operation.interfaceTypeApiName,
+        });
+        break;
+      case "createLink":
+      case "deleteLink":
+        result.push(
+          {
+            type: operation.type,
+            target:
+              `${operation.aSideObjectTypeApiName}.${operation.linkTypeApiNameAtoB}`,
+          },
+          {
+            type: operation.type,
+            target:
+              `${operation.bSideObjectTypeApiName}.${operation.linkTypeApiNameBtoA}`,
+          },
+        );
+        break;
+      case "applyScenario":
+        for (const objectTypeApiName of operation.objectTypeApiNames) {
+          result.push({ type: operation.type, target: objectTypeApiName });
+        }
+        for (const linkGroup of operation.linkTypes) {
+          for (const linkTypeApiName of linkGroup.linkTypes) {
+            result.push({
+              type: operation.type,
+              target: `${linkGroup.objectTypeApiName}.${linkTypeApiName}`,
+            });
+          }
+        }
+        break;
+    }
+  }
+  return result.sort(compareOperation);
+}
+
+function usableFieldType(
+  fieldType: Ontologies.ValueTypeFieldType,
+): "string" | "boolean" | undefined {
+  if (fieldType.type === "string" || fieldType.type === "boolean") {
+    return fieldType.type;
+  }
+  if (fieldType.type === "array" && fieldType.subType != null) {
+    return usableFieldType(fieldType.subType);
+  }
+  return undefined;
+}
+
+function isNarrowed(valueType: Ontologies.OntologyValueType): boolean {
+  const fieldType = usableFieldType(valueType.fieldType);
+  if (fieldType == null || valueType.constraints.length === 0) {
+    return false;
+  }
+  if (valueType.constraints.length !== 1) {
+    throw new Error(
+      `Expected exactly one constraint for value type ${valueType.apiName}`,
+    );
+  }
+
+  let constraint = valueType.constraints[0];
+  if (constraint.type === "array" && constraint.valueConstraint != null) {
+    constraint = constraint.valueConstraint;
+  }
+  if (constraint.type !== "enum" || constraint.options.length === 0) {
+    return false;
+  }
+
+  if (fieldType === "string") {
+    return constraint.options.some((value) => typeof value === "string");
+  }
+  return constraint.options.some((value) => value === true || value === false);
+}
+
+export function buildSemanticManifest(
+  metadata: Ontologies.OntologyFullMetadata,
+  packageMetadata: {
+    packageName: string;
+    packageVersion: string;
+  },
+): SemanticManifest {
+  return {
+    formatVersion: 1,
+    packageName: packageMetadata.packageName,
+    packageVersion: packageMetadata.packageVersion,
+    interfaces: sortedByApiName(
+      Object.values(metadata.interfaceTypes),
+      "interface",
+    ).map((interfaceType) => {
+      const properties: SemanticProperty[] = interfaceType.allPropertiesV2
+          && Object.keys(interfaceType.allPropertiesV2).length > 0
+        ? Object.values(interfaceType.allPropertiesV2).map((property) => ({
+          apiName: property.apiName,
+          required: property.requireImplementation,
+          ...(property.valueTypeApiName == null
+            ? {}
+            : { valueTypeApiName: property.valueTypeApiName }),
+        }))
+        : Object.values(
+          interfaceType.allProperties ?? interfaceType.properties,
+        ).map((property) => ({
+          apiName: property.apiName,
+          required: property.required,
+          ...(property.valueTypeApiName == null
+            ? {}
+            : { valueTypeApiName: property.valueTypeApiName }),
+        }));
+      const links = Object.values(
+        interfaceType.allLinks ?? interfaceType.links,
+      ).map((link) => ({
+        apiName: link.apiName,
+        cardinality: link.cardinality,
+        target: link.linkedEntityApiName.apiName,
+      }));
+      return {
+        apiName: interfaceType.apiName,
+        extends: [
+          ...(interfaceType.allExtendsInterfaces
+            ?? interfaceType.extendsInterfaces),
+        ].sort(compareText),
+        properties: sortedByApiName(properties, "interface property"),
+        links: sortedByApiName(links, "interface link"),
+      };
+    }),
+    valueTypes: sortedByApiName(
+      Object.values(metadata.valueTypes),
+      "value type",
+    ).map((valueType) => ({
+      apiName: valueType.apiName,
+      version: valueType.version,
+      narrowed: isNarrowed(valueType),
+    })),
+    actions: sortedByApiName(
+      Object.values(metadata.actionTypes),
+      "action",
+    ).map((action) => ({
+      apiName: action.apiName,
+      parameters: Object.keys(action.parameters).sort(compareText),
+      operations: actionOperations(action),
+    })),
+  };
+}

--- a/packages/generator-converters.ontologyir/src/semanticManifest.ts
+++ b/packages/generator-converters.ontologyir/src/semanticManifest.ts
@@ -148,8 +148,11 @@ function actionOperations(
 
 function usableFieldType(
   fieldType: Ontologies.ValueTypeFieldType,
-): "string" | "boolean" | undefined {
-  if (fieldType.type === "string" || fieldType.type === "boolean") {
+): "string" | "boolean" | "integer" | "short" | undefined {
+  if (
+    fieldType.type === "string" || fieldType.type === "boolean"
+    || fieldType.type === "integer" || fieldType.type === "short"
+  ) {
     return fieldType.type;
   }
   if (fieldType.type === "array" && fieldType.subType != null) {
@@ -158,29 +161,37 @@ function usableFieldType(
   return undefined;
 }
 
+function isRepresentableEnum(
+  constraint: Ontologies.ValueTypeConstraint,
+  fieldType: "string" | "boolean" | "integer" | "short",
+): boolean {
+  const candidate = constraint.type === "array"
+    ? constraint.valueConstraint
+    : constraint;
+  if (candidate?.type !== "enum") {
+    return false;
+  }
+
+  return candidate.options.some((value) => {
+    if (fieldType === "string") {
+      return typeof value === "string";
+    }
+    if (fieldType === "boolean") {
+      return typeof value === "boolean";
+    }
+    return typeof value === "number" && Number.isInteger(value)
+      && (fieldType !== "integer"
+        || (value >= -2_147_483_648 && value <= 2_147_483_647))
+      && (fieldType !== "short" || (value >= -32_768 && value <= 32_767));
+  });
+}
+
 function isNarrowed(valueType: Ontologies.OntologyValueType): boolean {
   const fieldType = usableFieldType(valueType.fieldType);
-  if (fieldType == null || valueType.constraints.length === 0) {
-    return false;
-  }
-  if (valueType.constraints.length !== 1) {
-    throw new Error(
-      `Expected exactly one constraint for value type ${valueType.apiName}`,
+  return fieldType != null
+    && valueType.constraints.some((constraint) =>
+      isRepresentableEnum(constraint, fieldType)
     );
-  }
-
-  let constraint = valueType.constraints[0];
-  if (constraint.type === "array" && constraint.valueConstraint != null) {
-    constraint = constraint.valueConstraint;
-  }
-  if (constraint.type !== "enum" || constraint.options.length === 0) {
-    return false;
-  }
-
-  if (fieldType === "string") {
-    return constraint.options.some((value) => typeof value === "string");
-  }
-  return constraint.options.some((value) => value === true || value === false);
 }
 
 export function buildSemanticManifest(

--- a/packages/generator/src/GenerateContext/GenerateContext.ts
+++ b/packages/generator/src/GenerateContext/GenerateContext.ts
@@ -28,4 +28,5 @@ export interface GenerateContext {
   ontologyApiNamespace?: string | undefined;
   apiNamespacePackageMap?: Map<string, string>;
   forInternalUse?: boolean;
+  omitOntologyRid?: boolean;
 }

--- a/packages/generator/src/v2.0/generateClientSdkVersionTwoPointZero.test.ts
+++ b/packages/generator/src/v2.0/generateClientSdkVersionTwoPointZero.test.ts
@@ -1897,6 +1897,184 @@ describe("generator", () => {
       `);
   });
 
+  describe("Value Type literal narrowing", () => {
+    async function generateProps(
+      properties: WireOntologyDefinition["objectTypes"][string]["objectType"][
+        "properties"
+      ],
+      valueTypes: WireOntologyDefinition["valueTypes"],
+    ): Promise<string> {
+      const objectType = {
+        ...TodoWireOntology.objectTypes.Todo,
+        implementsInterfaces: [],
+        implementsInterfaces2: {},
+        linkTypes: [],
+        objectType: {
+          ...TodoWireOntology.objectTypes.Todo.objectType,
+          properties,
+          primaryKey: "id",
+          titleProperty: "id",
+        },
+      };
+      await generateClientSdkVersionTwoPointZero(
+        {
+          ...TodoWireOntology,
+          actionTypes: {},
+          interfaceTypes: {},
+          objectTypes: { Todo: objectType },
+          queryTypes: {},
+          sharedPropertyTypes: {},
+          valueTypes,
+        },
+        "",
+        helper.minimalFiles,
+        BASE_PATH,
+      );
+      return helper.getFiles()[`${BASE_PATH}/ontology/objects/Todo.ts`];
+    }
+
+    it("uses the first representable enum across multiple constraints", async () => {
+      const generated = await generateProps({
+        id: {
+          dataType: { type: "string" },
+          rid: "rid",
+          typeClasses: [],
+          valueTypeApiName: "multiConstraint",
+        },
+      }, {
+        multiConstraint: {
+          apiName: "multiConstraint",
+          displayName: "Multi constraint",
+          rid: "ridForMultiConstraint",
+          version: "1.0.0",
+          fieldType: { type: "string" },
+          constraints: [
+            { type: "regex", pattern: "[a-z]+", partialMatch: false },
+            { type: "enum", options: [undefined, 7, "alpha", "beta"] },
+            { type: "enum", options: ["ignored"] },
+          ],
+        },
+      });
+
+      expect(generated).toContain("readonly id: 'alpha' | 'beta';");
+    });
+
+    it("narrows boolean, integer, and short enums while keeping other numerics broad", async () => {
+      const valueType = (
+        apiName: string,
+        fieldType:
+          | "boolean"
+          | "integer"
+          | "short"
+          | "long"
+          | "decimal"
+          | "float"
+          | "double",
+        options: Array<string | number | boolean | null | undefined>,
+      ) => ({
+        apiName,
+        displayName: apiName,
+        rid: `ridFor${apiName}`,
+        version: "1.0.0",
+        fieldType: { type: fieldType },
+        constraints: [{ type: "enum" as const, options }],
+      });
+      const property = (
+        type:
+          | "boolean"
+          | "integer"
+          | "short"
+          | "long"
+          | "decimal"
+          | "float"
+          | "double",
+        valueTypeApiName: string,
+      ) => ({
+        dataType: { type },
+        rid: `ridFor${valueTypeApiName}Property`,
+        typeClasses: [],
+        valueTypeApiName,
+      });
+      const generated = await generateProps({
+        id: property("integer", "integerEnum"),
+        booleanValue: property("boolean", "booleanEnum"),
+        shortValue: property("short", "shortEnum"),
+        longValue: property("long", "longEnum"),
+        decimalValue: property("decimal", "decimalEnum"),
+        floatValue: property("float", "floatEnum"),
+        doubleValue: property("double", "doubleEnum"),
+      }, {
+        booleanEnum: valueType("booleanEnum", "boolean", [
+          true,
+          null,
+          "true",
+          false,
+        ]),
+        integerEnum: valueType("integerEnum", "integer", [1, 2.5, "3", 4]),
+        shortEnum: valueType("shortEnum", "short", [-32_768, 32_768, 7]),
+        longEnum: valueType("longEnum", "long", [1, 2]),
+        decimalEnum: valueType("decimalEnum", "decimal", ["1.0", "2.0"]),
+        floatEnum: valueType("floatEnum", "float", [1, 2]),
+        doubleEnum: valueType("doubleEnum", "double", [1, 2]),
+      });
+
+      expect(generated).toContain(
+        "readonly booleanValue: true | false | undefined;",
+      );
+      expect(generated).toContain("readonly id: 1 | 4;");
+      expect(generated).toContain(
+        "readonly shortValue: -32768 | 7 | undefined;",
+      );
+      expect(generated).toContain(
+        "readonly longValue: $PropType['long'] | undefined;",
+      );
+      expect(generated).toContain(
+        "readonly decimalValue: $PropType['decimal'] | undefined;",
+      );
+      expect(generated).toContain(
+        "readonly floatValue: $PropType['float'] | undefined;",
+      );
+      expect(generated).toContain(
+        "readonly doubleValue: $PropType['double'] | undefined;",
+      );
+    });
+
+    it("parenthesizes narrowed unions only for multiplicity", async () => {
+      const generated = await generateProps({
+        id: {
+          dataType: { type: "string" },
+          rid: "idRid",
+          typeClasses: [],
+          valueTypeApiName: "stringEnum",
+        },
+        values: {
+          dataType: {
+            type: "array",
+            subType: { type: "string" },
+            reducers: [],
+          },
+          rid: "valuesRid",
+          typeClasses: [],
+          valueTypeApiName: "stringEnum",
+        },
+      }, {
+        stringEnum: {
+          apiName: "stringEnum",
+          displayName: "String enum",
+          rid: "stringEnumRid",
+          version: "1.0.0",
+          fieldType: { type: "string" },
+          constraints: [{ type: "enum", options: ["a", "b"] }],
+        },
+      });
+
+      expect(generated).toContain("readonly id: 'a' | 'b';");
+      expect(generated).toContain(
+        "readonly values: ('a' | 'b')[] | undefined;",
+      );
+    });
+  });
+
   it("guards against empty objects", async () => {
     await generateClientSdkVersionTwoPointZero(
       {

--- a/packages/generator/src/v2.0/generateClientSdkVersionTwoPointZero.test.ts
+++ b/packages/generator/src/v2.0/generateClientSdkVersionTwoPointZero.test.ts
@@ -1976,6 +1976,34 @@ describe("generator", () => {
 
       expect(helper.getFiles()["/foo/index.ts"]).toContain("$ontologyRid");
     });
+
+    it("omits the ontology and branch identities for portable SDKs", async () => {
+      const BASE_PATH = "/foo";
+
+      await generateClientSdkVersionTwoPointZero(
+        TodoWireOntology,
+        "",
+        helper.minimalFiles,
+        BASE_PATH,
+        "module",
+        new Map(),
+        new Map(),
+        new Map(),
+        false,
+        [],
+        false,
+        true,
+      );
+
+      expect(helper.getFiles()["/foo/index.ts"]).not.toContain("$ontologyRid");
+      expect(helper.getFiles()["/foo/index.ts"]).not.toContain("$branch");
+      expect(helper.getFiles()["/foo/OntologyMetadata.ts"]).not.toContain(
+        "$ontologyRid",
+      );
+      expect(helper.getFiles()["/foo/OntologyMetadata.ts"]).not.toContain(
+        "$branch",
+      );
+    });
   });
 
   describe("exportOntologyMetadata", () => {

--- a/packages/generator/src/v2.0/generateClientSdkVersionTwoPointZero.ts
+++ b/packages/generator/src/v2.0/generateClientSdkVersionTwoPointZero.ts
@@ -41,6 +41,7 @@ export async function generateClientSdkVersionTwoPointZero(
   forInternalUse: boolean = false,
   fixedVersionQueryTypes: string[] = [],
   exportOntologyMetadata: boolean = false,
+  omitOntologyRid: boolean = false,
 ): Promise<void> {
   const importExt = ".js"; // turns out you can always use the extension
 
@@ -65,6 +66,7 @@ export async function generateClientSdkVersionTwoPointZero(
     outDir,
     forInternalUse,
     fixedVersionQueryTypes,
+    omitOntologyRid,
   };
 
   await generateRootIndexTsFile(ctx);

--- a/packages/generator/src/v2.0/generateMetadata.ts
+++ b/packages/generator/src/v2.0/generateMetadata.ts
@@ -24,7 +24,13 @@ const ExpectedOsdkVersion = "2.59.0";
 // END: THIS IS GENERATED CODE. DO NOT EDIT.
 
 export async function generateOntologyMetadataTypeFile(
-  { fs, outDir, ontology, ontologyApiNamespace }: GenerateContext,
+  {
+    fs,
+    outDir,
+    ontology,
+    ontologyApiNamespace,
+    omitOntologyRid,
+  }: GenerateContext,
   userAgent: string,
 ): Promise<void> {
   await fs.writeFile(
@@ -34,7 +40,7 @@ export async function generateOntologyMetadataTypeFile(
       export type $ExpectedClientVersion = "${ExpectedOsdkVersion}";
       export const $osdkMetadata = { extraUserAgent: "${userAgent}" };
       ${
-        ontologyApiNamespace == null
+        ontologyApiNamespace == null && !omitOntologyRid
           ? `
         export const $ontologyRid = "${ontology.ontology.rid}";
         /**

--- a/packages/generator/src/v2.0/generateRootIndexTsFile.ts
+++ b/packages/generator/src/v2.0/generateRootIndexTsFile.ts
@@ -20,7 +20,14 @@ import type { GenerateContext } from "../GenerateContext/GenerateContext.js";
 import { formatTs } from "../util/test/formatTs.js";
 
 export async function generateRootIndexTsFile(
-  { fs, outDir, importExt, ontologyApiNamespace, ontology }: GenerateContext,
+  {
+    fs,
+    outDir,
+    importExt,
+    ontologyApiNamespace,
+    ontology,
+    omitOntologyRid,
+  }: GenerateContext,
 ): Promise<void> {
   await fs.writeFile(
     path.join(outDir, "index.ts"),
@@ -43,7 +50,7 @@ export async function generateRootIndexTsFile(
         export * as $Queries from "./ontology/queries${importExt}";
         export { $osdkMetadata } from "./OntologyMetadata${importExt}";
         ${
-        ontologyApiNamespace == null
+        ontologyApiNamespace == null && !omitOntologyRid
           ? `export { $branch, $ontologyRid } from "./OntologyMetadata${importExt}";`
           : ``
       }

--- a/packages/generator/src/v2.0/wireObjectTypeV2ToSdkObjectConstV2.ts
+++ b/packages/generator/src/v2.0/wireObjectTypeV2ToSdkObjectConstV2.ts
@@ -23,10 +23,7 @@ import type {
   ValueTypeApiName,
   ValueTypeConstraint,
 } from "@osdk/foundry.ontologies";
-import {
-  GeneratorError,
-  wireObjectTypeFullMetadataToSdkObjectMetadata,
-} from "@osdk/generator-converters";
+import { wireObjectTypeFullMetadataToSdkObjectMetadata } from "@osdk/generator-converters";
 import consola from "consola";
 import { EnhancedInterfaceType } from "../GenerateContext/EnhancedInterfaceType.js";
 import { EnhancedObjectType } from "../GenerateContext/EnhancedObjectType.js";
@@ -455,68 +452,79 @@ function getPropTypeOrValueTypeEnum(
     JSON.stringify(propertyDefinition.type)
   }]`;
   if (
-    !(propertyDefinition.type === "string"
-      || propertyDefinition.type === "boolean")
+    !isLiteralNarrowablePropertyType(propertyDefinition.type)
     || !propertyDefinition.valueTypeApiName
   ) {
     return defaultPropString;
   }
   const valueType = valueTypeMetadata[propertyDefinition.valueTypeApiName];
-  if (valueType == null || valueType.constraints.length === 0) {
+  if (valueType == null) {
     return defaultPropString;
   }
-  if (valueType.constraints.length !== 1) {
-    throw new GeneratorError(
-      "Expected exactly one constraint for value type",
-      { valueTypeApiName: propertyDefinition.valueTypeApiName },
-      { constraintCount: valueType.constraints.length },
-    );
-  }
 
-  let shouldWrapWithParentheses = false;
-  let constraint = valueType.constraints[0];
-  if (constraint.type === "array" && constraint.valueConstraint) {
-    constraint = constraint.valueConstraint;
-    shouldWrapWithParentheses = true;
-  }
-
-  const maybeEnumString = maybeGetEnumString(
-    propertyDefinition,
-    constraint,
+  const maybeEnumString = findRepresentableEnum(
+    valueType.constraints,
+    propertyDefinition.type,
   );
 
-  return maybeEnumString
-    ? (
-      shouldWrapWithParentheses ? `(${maybeEnumString})` : maybeEnumString
-    )
-    : defaultPropString;
+  return maybeEnumString == null
+    ? defaultPropString
+    : propertyDefinition.multiplicity
+    ? `(${maybeEnumString})`
+    : maybeEnumString;
 }
 
-function maybeGetEnumString(
-  propertyDefinition: ObjectMetadata.Property,
-  constraint: ValueTypeConstraint,
-) {
-  if (constraint.type !== "enum" || constraint.options.length === 0) {
-    return undefined;
-  }
-  if (propertyDefinition.type === "string") {
-    return stringUnionFrom(constraint.options.map(x => String(x)));
-  }
-  if (propertyDefinition.type === "boolean") {
-    return constraint.options.map(value => {
-      if (value === true) {
-        return true;
-      } else if (value === false) {
-        return false;
-      } else if (value == null) {
-        // Always infer nullability from the property definition
-        return undefined;
-      } else {
-        consola.warn(`Unexpected boolean value in enum: ${value}. Ignoring.`);
-      }
-    }).filter(value => value != null).join(
-      " | ",
-    );
+type LiteralNarrowablePropertyType = "string" | "boolean" | "integer" | "short";
+
+function isLiteralNarrowablePropertyType(
+  type: ObjectMetadata.Property["type"],
+): type is LiteralNarrowablePropertyType {
+  return type === "string" || type === "boolean" || type === "integer"
+    || type === "short";
+}
+
+function findRepresentableEnum(
+  constraints: readonly ValueTypeConstraint[],
+  propertyType: LiteralNarrowablePropertyType,
+): string | undefined {
+  for (const constraint of constraints) {
+    const candidate = constraint.type === "array"
+      ? constraint.valueConstraint
+      : constraint;
+    if (candidate?.type !== "enum") {
+      continue;
+    }
+
+    const literalUnion = enumLiteralUnion(candidate.options, propertyType);
+    if (literalUnion != null) {
+      return literalUnion;
+    }
   }
   return undefined;
+}
+
+function enumLiteralUnion(
+  options: Extract<ValueTypeConstraint, { type: "enum" }>["options"],
+  propertyType: LiteralNarrowablePropertyType,
+): string | undefined {
+  const literals = options.flatMap((value): string[] => {
+    if (propertyType === "string" && typeof value === "string") {
+      return [JSON.stringify(value)];
+    }
+    if (propertyType === "boolean" && typeof value === "boolean") {
+      return [String(value)];
+    }
+    if (
+      (propertyType === "integer" || propertyType === "short")
+      && typeof value === "number"
+      && Number.isInteger(value)
+      && (propertyType !== "integer"
+        || (value >= -2_147_483_648 && value <= 2_147_483_647))
+      && (propertyType !== "short" || (value >= -32_768 && value <= 32_767))
+    ) {
+      return [Object.is(value, -0) ? "0" : String(value)];
+    }
+    return [];
+  });
+  return literals.length === 0 ? undefined : [...new Set(literals)].join(" | ");
 }

--- a/packages/maker-experimental/src/conversion/toMarketplace/dataConstraintToPropertyTypeDataConstraint.test.ts
+++ b/packages/maker-experimental/src/conversion/toMarketplace/dataConstraintToPropertyTypeDataConstraint.test.ts
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { DataConstraint } from "@osdk/client.unstable";
+import { describe, expect, it } from "vitest";
+
+import { dataConstraintToPropertyTypeDataConstraint } from "./dataConstraintToPropertyTypeDataConstraint.js";
+
+const nestedStringArray: DataConstraint = {
+  type: "array",
+  array: {
+    size: { minSize: 1, maxSize: 3 },
+    elementsUnique: false,
+    elementsConstraint: {
+      type: "array",
+      array: {
+        size: undefined,
+        elementsUnique: true,
+        elementsConstraint: {
+          type: "string",
+          string: {
+            type: "oneOf",
+            oneOf: { values: ["alpha", "beta"], useIgnoreCase: false },
+          },
+        },
+      },
+    },
+  },
+};
+
+const defenseLikeArrayOfStruct: DataConstraint = {
+  type: "array",
+  array: {
+    size: undefined,
+    elementsUnique: undefined,
+    elementsConstraint: {
+      type: "structV2",
+      structV2: {
+        elementConstraints: {
+          heading: {
+            rid: "ri.value-type.main.value-type.heading",
+            versionId: "1.0.0",
+          },
+        },
+      },
+    },
+  },
+};
+
+describe(dataConstraintToPropertyTypeDataConstraint, () => {
+  it("recursively converts supported nested array element constraints", () => {
+    expect(
+      dataConstraintToPropertyTypeDataConstraint(nestedStringArray),
+    ).toEqual({
+      type: "array",
+      array: {
+        size: { minSize: 1, maxSize: 3 },
+        elementsUnique: false,
+        elementsConstraint: {
+          type: "array",
+          array: {
+            size: undefined,
+            elementsUnique: true,
+            elementsConstraint: {
+              type: "string",
+              string: {
+                type: "oneOf",
+                oneOf: {
+                  values: ["alpha", "beta"],
+                  useIgnoreCase: false,
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+  });
+
+  it("rejects a Defense-like nested structV2 instead of emitting an invalid payload", () => {
+    expect(() =>
+      dataConstraintToPropertyTypeDataConstraint(defenseLikeArrayOfStruct),
+    ).toThrowError(
+      "Unsupported nested array element constraint (structV2): StructV2 constraints are not supported",
+    );
+  });
+
+  it.each(["binary", "map", "nullable"] as const)(
+    "rejects unsupported nested %s constraints clearly",
+    (type) => {
+      const nestedConstraint: DataConstraint =
+        type === "binary"
+          ? {
+              type,
+              binary: { size: { minSize: 0, maxSize: 4 } },
+            }
+          : type === "map"
+            ? {
+                type,
+                map: {
+                  keyTypeDataConstraints: [],
+                  valueTypeDataConstraints: [],
+                  uniqueValues: undefined,
+                },
+              }
+            : { type, nullable: { option: "NULLABLE" } };
+      const arrayConstraint: DataConstraint = {
+        type: "array",
+        array: {
+          size: undefined,
+          elementsUnique: undefined,
+          elementsConstraint: nestedConstraint,
+        },
+      };
+
+      expect(() =>
+        dataConstraintToPropertyTypeDataConstraint(arrayConstraint),
+      ).toThrowError(`Unsupported nested array element constraint (${type})`);
+    },
+  );
+});

--- a/packages/maker-experimental/src/conversion/toMarketplace/dataConstraintToPropertyTypeDataConstraint.ts
+++ b/packages/maker-experimental/src/conversion/toMarketplace/dataConstraintToPropertyTypeDataConstraint.ts
@@ -33,36 +33,62 @@ import type {
 
 import { convertDataConstraintToDataConstraints } from "./convertDataConstraintToDataConstraints.js";
 
+function convertNestedArrayElementConstraint(
+  constraint: DataConstraint,
+): PropertyTypeDataConstraints {
+  try {
+    return dataConstraintToPropertyTypeDataConstraint(constraint);
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    throw new Error(
+      `Unsupported nested array element constraint (${constraint.type}): ${detail}`,
+      { cause: error },
+    );
+  }
+}
+
 export function dataConstraintToPropertyTypeDataConstraint(
   dc: DataConstraint,
 ): PropertyTypeDataConstraints {
   switch (dc.type) {
     case "array":
-      return { ...dc } as PropertyTypeDataConstraints_array;
+      return {
+        type: "array",
+        array: {
+          size: dc.array.size,
+          elementsUnique: dc.array.elementsUnique,
+          elementsConstraint:
+            dc.array.elementsConstraint === undefined
+              ? undefined
+              : convertNestedArrayElementConstraint(
+                  dc.array.elementsConstraint,
+                ),
+        },
+      } satisfies PropertyTypeDataConstraints_array;
 
     case "boolean":
-      return { ...dc } as PropertyTypeDataConstraints_boolean;
+      return { ...dc } satisfies PropertyTypeDataConstraints_boolean;
 
     case "binary":
       throw new Error("Binary type constraints are not supported");
 
     case "date":
-      return { ...dc } as PropertyTypeDataConstraints_date;
+      return { ...dc } satisfies PropertyTypeDataConstraints_date;
 
     case "decimal":
-      return { ...dc } as PropertyTypeDataConstraints_decimal;
+      return { ...dc } satisfies PropertyTypeDataConstraints_decimal;
 
     case "double":
-      return { ...dc } as PropertyTypeDataConstraints_double;
+      return { ...dc } satisfies PropertyTypeDataConstraints_double;
 
     case "float":
-      return { ...dc } as PropertyTypeDataConstraints_float;
+      return { ...dc } satisfies PropertyTypeDataConstraints_float;
 
     case "integer":
-      return { ...dc } as PropertyTypeDataConstraints_integer;
+      return { ...dc } satisfies PropertyTypeDataConstraints_integer;
 
     case "long":
-      return { ...dc } as PropertyTypeDataConstraints_long;
+      return { ...dc } satisfies PropertyTypeDataConstraints_long;
 
     case "map":
       throw new Error("Map type constraints are not supported");
@@ -71,10 +97,10 @@ export function dataConstraintToPropertyTypeDataConstraint(
       throw new Error("Nullable constraints are not supported");
 
     case "short":
-      return { ...dc } as PropertyTypeDataConstraints_short;
+      return { ...dc } satisfies PropertyTypeDataConstraints_short;
 
     case "string":
-      return { ...dc } as PropertyTypeDataConstraints_string;
+      return { ...dc } satisfies PropertyTypeDataConstraints_string;
 
     case "struct":
       return {
@@ -89,15 +115,19 @@ export function dataConstraintToPropertyTypeDataConstraint(
             ),
           ),
         },
-      } as PropertyTypeDataConstraints_struct;
+      } satisfies PropertyTypeDataConstraints_struct;
 
     case "structV2":
       throw new Error("StructV2 constraints are not supported");
 
     case "timestamp":
-      return { ...dc } as PropertyTypeDataConstraints_timestamp;
+      return { ...dc } satisfies PropertyTypeDataConstraints_timestamp;
 
-    default:
-      throw new Error(`Unknown DataConstraint type: ${(dc as any).type}`);
+    default: {
+      const exhaustiveCheck: never = dc;
+      throw new Error(
+        `Unknown DataConstraint type: ${String(exhaustiveCheck)}`,
+      );
+    }
   }
 }

--- a/packages/maker/src/conversion/toMarketplace/dataConstraintToPropertyTypeDataConstraint.test.ts
+++ b/packages/maker/src/conversion/toMarketplace/dataConstraintToPropertyTypeDataConstraint.test.ts
@@ -1,0 +1,134 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { DataConstraint } from "@osdk/client.unstable";
+import { describe, expect, it } from "vitest";
+
+import { dataConstraintToPropertyTypeDataConstraint } from "./dataConstraintToPropertyTypeDataConstraint.js";
+
+const nestedStringArray: DataConstraint = {
+  type: "array",
+  array: {
+    size: { minSize: 1, maxSize: 3 },
+    elementsUnique: false,
+    elementsConstraint: {
+      type: "array",
+      array: {
+        size: undefined,
+        elementsUnique: true,
+        elementsConstraint: {
+          type: "string",
+          string: {
+            type: "oneOf",
+            oneOf: { values: ["alpha", "beta"], useIgnoreCase: false },
+          },
+        },
+      },
+    },
+  },
+};
+
+const defenseLikeArrayOfStruct: DataConstraint = {
+  type: "array",
+  array: {
+    size: undefined,
+    elementsUnique: undefined,
+    elementsConstraint: {
+      type: "structV2",
+      structV2: {
+        elementConstraints: {
+          heading: {
+            rid: "ri.value-type.main.value-type.heading",
+            versionId: "1.0.0",
+          },
+        },
+      },
+    },
+  },
+};
+
+describe(dataConstraintToPropertyTypeDataConstraint, () => {
+  it("recursively converts supported nested array element constraints", () => {
+    expect(
+      dataConstraintToPropertyTypeDataConstraint(nestedStringArray),
+    ).toEqual({
+      type: "array",
+      array: {
+        size: { minSize: 1, maxSize: 3 },
+        elementsUnique: false,
+        elementsConstraint: {
+          type: "array",
+          array: {
+            size: undefined,
+            elementsUnique: true,
+            elementsConstraint: {
+              type: "string",
+              string: {
+                type: "oneOf",
+                oneOf: {
+                  values: ["alpha", "beta"],
+                  useIgnoreCase: false,
+                },
+              },
+            },
+          },
+        },
+      },
+    });
+  });
+
+  it("rejects a Defense-like nested structV2 instead of emitting an invalid payload", () => {
+    expect(() =>
+      dataConstraintToPropertyTypeDataConstraint(defenseLikeArrayOfStruct),
+    ).toThrowError(
+      "Unsupported nested array element constraint (structV2): StructV2 constraints are not supported",
+    );
+  });
+
+  it.each(["binary", "map", "nullable"] as const)(
+    "rejects unsupported nested %s constraints clearly",
+    (type) => {
+      const nestedConstraint: DataConstraint =
+        type === "binary"
+          ? {
+              type,
+              binary: { size: { minSize: 0, maxSize: 4 } },
+            }
+          : type === "map"
+            ? {
+                type,
+                map: {
+                  keyTypeDataConstraints: [],
+                  valueTypeDataConstraints: [],
+                  uniqueValues: undefined,
+                },
+              }
+            : { type, nullable: { option: "NULLABLE" } };
+      const arrayConstraint: DataConstraint = {
+        type: "array",
+        array: {
+          size: undefined,
+          elementsUnique: undefined,
+          elementsConstraint: nestedConstraint,
+        },
+      };
+
+      expect(() =>
+        dataConstraintToPropertyTypeDataConstraint(arrayConstraint),
+      ).toThrowError(`Unsupported nested array element constraint (${type})`);
+    },
+  );
+});

--- a/packages/maker/src/conversion/toMarketplace/dataConstraintToPropertyTypeDataConstraint.ts
+++ b/packages/maker/src/conversion/toMarketplace/dataConstraintToPropertyTypeDataConstraint.ts
@@ -33,36 +33,62 @@ import type {
 
 import { convertDataConstraintToDataConstraints } from "./convertDataConstraintToDataConstraints.js";
 
+function convertNestedArrayElementConstraint(
+  constraint: DataConstraint,
+): PropertyTypeDataConstraints {
+  try {
+    return dataConstraintToPropertyTypeDataConstraint(constraint);
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    throw new Error(
+      `Unsupported nested array element constraint (${constraint.type}): ${detail}`,
+      { cause: error },
+    );
+  }
+}
+
 export function dataConstraintToPropertyTypeDataConstraint(
   dc: DataConstraint,
 ): PropertyTypeDataConstraints {
   switch (dc.type) {
     case "array":
-      return { ...dc } as PropertyTypeDataConstraints_array;
+      return {
+        type: "array",
+        array: {
+          size: dc.array.size,
+          elementsUnique: dc.array.elementsUnique,
+          elementsConstraint:
+            dc.array.elementsConstraint === undefined
+              ? undefined
+              : convertNestedArrayElementConstraint(
+                  dc.array.elementsConstraint,
+                ),
+        },
+      } satisfies PropertyTypeDataConstraints_array;
 
     case "boolean":
-      return { ...dc } as PropertyTypeDataConstraints_boolean;
+      return { ...dc } satisfies PropertyTypeDataConstraints_boolean;
 
     case "binary":
       throw new Error("Binary type constraints are not supported");
 
     case "date":
-      return { ...dc } as PropertyTypeDataConstraints_date;
+      return { ...dc } satisfies PropertyTypeDataConstraints_date;
 
     case "decimal":
-      return { ...dc } as PropertyTypeDataConstraints_decimal;
+      return { ...dc } satisfies PropertyTypeDataConstraints_decimal;
 
     case "double":
-      return { ...dc } as PropertyTypeDataConstraints_double;
+      return { ...dc } satisfies PropertyTypeDataConstraints_double;
 
     case "float":
-      return { ...dc } as PropertyTypeDataConstraints_float;
+      return { ...dc } satisfies PropertyTypeDataConstraints_float;
 
     case "integer":
-      return { ...dc } as PropertyTypeDataConstraints_integer;
+      return { ...dc } satisfies PropertyTypeDataConstraints_integer;
 
     case "long":
-      return { ...dc } as PropertyTypeDataConstraints_long;
+      return { ...dc } satisfies PropertyTypeDataConstraints_long;
 
     case "map":
       throw new Error("Map type constraints are not supported");
@@ -71,10 +97,10 @@ export function dataConstraintToPropertyTypeDataConstraint(
       throw new Error("Nullable constraints are not supported");
 
     case "short":
-      return { ...dc } as PropertyTypeDataConstraints_short;
+      return { ...dc } satisfies PropertyTypeDataConstraints_short;
 
     case "string":
-      return { ...dc } as PropertyTypeDataConstraints_string;
+      return { ...dc } satisfies PropertyTypeDataConstraints_string;
 
     case "struct":
       return {
@@ -89,15 +115,19 @@ export function dataConstraintToPropertyTypeDataConstraint(
             ),
           ),
         },
-      } as PropertyTypeDataConstraints_struct;
+      } satisfies PropertyTypeDataConstraints_struct;
 
     case "structV2":
       throw new Error("StructV2 constraints are not supported");
 
     case "timestamp":
-      return { ...dc } as PropertyTypeDataConstraints_timestamp;
+      return { ...dc } satisfies PropertyTypeDataConstraints_timestamp;
 
-    default:
-      throw new Error(`Unknown DataConstraint type: ${(dc as any).type}`);
+    default: {
+      const exhaustiveCheck: never = dc;
+      throw new Error(
+        `Unknown DataConstraint type: ${String(exhaustiveCheck)}`,
+      );
+    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1888,12 +1888,18 @@ importers:
       '@osdk/cli.common':
         specifier: workspace:~
         version: link:../cli.common
+      '@osdk/client.unstable':
+        specifier: workspace:~
+        version: link:../client.unstable
       '@osdk/foundry.ontologies':
         specifier: catalog:foundry-platform-typescript
         version: 2.73.0
       '@osdk/generator':
         specifier: workspace:~
         version: link:../generator
+      '@osdk/generator-converters.ontologyir':
+        specifier: workspace:~
+        version: link:../generator-converters.ontologyir
       '@osdk/shared.client.impl':
         specifier: workspace:~
         version: link:../shared.client.impl
@@ -1907,6 +1913,9 @@ importers:
         specifier: ^7.0.0
         version: 7.0.0
       tslib:
+        specifier: ^2.8.1
+        version: 2.8.1
+      yaml:
         specifier: ^2.8.1
         version: 2.8.1
       yargs:


### PR DESCRIPTION
OaC projects need one supported command that turns complete ontology input into reviewable, TypeScript SDK output

• generate through the shared ontology IR converter and SDK generator
• write the deterministic semantic manifest beside generated source
• keep imported definitions local unless an import map marks them external