### PR TITLE
[ScenariosV2] Support scenario-aware subscriptions

### DIFF
--- a/.changeset/swift-scenarios-subscribe.md
+++ b/.changeset/swift-scenarios-subscribe.md
@@ -1,0 +1,5 @@
+---
+"@osdk/client": patch
+---
+
+Support object set subscriptions through clients scoped to ontology scenarios.

--- a/packages/client/src/objectSet/ObjectSetListenerWebsocket.test.ts
+++ b/packages/client/src/objectSet/ObjectSetListenerWebsocket.test.ts
@@ -203,6 +203,41 @@ describe("ObjectSetListenerWebsocket", () => {
       expect(listener.onError).not.toHaveBeenCalled();
     });
 
+    it("includes scenario context in subscription requests", async () => {
+      const scenarioRid = "ri.actions.main.scenario.123";
+      const scopedClient = new ObjectSetListenerWebsocket({
+        ...minimalClient,
+        scenarioRid,
+      });
+
+      const [ws, unsubscribe] = await subscribeAndExpectWebSocket(
+        scopedClient,
+        listener,
+      );
+
+      try {
+        await vi.waitFor(() => {
+          const request = ws.send.mock.calls
+            .map(
+              ([message]) =>
+                JSON.parse(
+                  message.toString(),
+                ) as ObjectSetStreamSubscribeRequests,
+            )
+            .find(({ requests }) => requests.length > 0);
+          expect(request?.requests).toHaveLength(1);
+          expect(request?.requests[0]).toEqual(
+            expect.objectContaining({ scenarioRid }),
+          );
+        });
+      } finally {
+        unsubscribe();
+        setWebSocketState(ws, "close");
+        vi.runAllTicks();
+        expectEqualRemoveAndAddListeners(ws);
+      }
+    });
+
     describe("requests subscription", () => {
       let ws: MockedWebSocket;
       let unsubscribe: () => void;

--- a/packages/client/src/objectSet/ObjectSetListenerWebsocket.ts
+++ b/packages/client/src/objectSet/ObjectSetListenerWebsocket.ts
@@ -142,6 +142,7 @@ export class ObjectSetListenerWebsocket extends SubscriptionWebsocket<
       requests: readySubscriptions.map<ObjectSetStreamSubscribeRequest>(
         ({ objectSet, requestedProperties, requestedReferenceProperties }) => ({
           objectSet,
+          scenarioRid: this.client.scenarioRid,
           propertySet: requestedProperties,
           referenceSet: requestedReferenceProperties,
           objectLoadingResponseOptions: { shouldLoadObjectRids: true },


### PR DESCRIPTION
## Description
Prior to this PR, we did not support subscribing to object set changes on scenarios. Since this feature has been recently established in the backend, we wire it through here for end-to-end support.

## Testing
Automated