### PR TITLE
[ScenariosV2] Support branch-aware subscriptions

### DIFF
--- a/.changeset/bright-branches-subscribe.md
+++ b/.changeset/bright-branches-subscribe.md
@@ -1,0 +1,5 @@
+---
+"@osdk/client": patch
+---
+
+Forward branch context for object set subscriptions.

--- a/.changeset/swift-scenarios-subscribe.md
+++ b/.changeset/swift-scenarios-subscribe.md
@@ -1,0 +1,5 @@
+---
+"@osdk/client": patch
+---
+
+Support object set subscriptions through clients scoped to ontology scenarios.

--- a/packages/client/src/objectSet/ObjectSetListenerWebsocket.test.ts
+++ b/packages/client/src/objectSet/ObjectSetListenerWebsocket.test.ts
@@ -193,10 +193,12 @@ describe("ObjectSetListenerWebsocket", () => {
       expect(listener.onError).not.toHaveBeenCalled();
     });
 
-    it("includes scenario context in subscription requests", async () => {
+    it("includes scenario and branch context in subscription requests", async () => {
+      const branch = "ri.branch.main.branch.123";
       const scenarioRid = "ri.actions.main.scenario.123";
       const scopedClient = new ObjectSetListenerWebsocket({
         ...minimalClient,
+        branch,
         scenarioRid,
       });
 
@@ -217,7 +219,7 @@ describe("ObjectSetListenerWebsocket", () => {
             .find(({ requests }) => requests.length > 0);
           expect(request?.requests).toHaveLength(1);
           expect(request?.requests[0]).toEqual(
-            expect.objectContaining({ scenarioRid }),
+            expect.objectContaining({ branch, scenarioRid }),
           );
         });
       } finally {

--- a/packages/client/src/objectSet/ObjectSetListenerWebsocket.test.ts
+++ b/packages/client/src/objectSet/ObjectSetListenerWebsocket.test.ts
@@ -193,6 +193,41 @@ describe("ObjectSetListenerWebsocket", () => {
       expect(listener.onError).not.toHaveBeenCalled();
     });
 
+    it("includes scenario context in subscription requests", async () => {
+      const scenarioRid = "ri.actions.main.scenario.123";
+      const scopedClient = new ObjectSetListenerWebsocket({
+        ...minimalClient,
+        scenarioRid,
+      });
+
+      const [ws, unsubscribe] = await subscribeAndExpectWebSocket(
+        scopedClient,
+        listener,
+      );
+
+      try {
+        await vi.waitFor(() => {
+          const request = ws.send.mock.calls
+            .map(
+              ([message]) =>
+                JSON.parse(
+                  message.toString(),
+                ) as ObjectSetStreamSubscribeRequests,
+            )
+            .find(({ requests }) => requests.length > 0);
+          expect(request?.requests).toHaveLength(1);
+          expect(request?.requests[0]).toEqual(
+            expect.objectContaining({ scenarioRid }),
+          );
+        });
+      } finally {
+        unsubscribe();
+        setWebSocketState(ws, "close");
+        vi.runAllTicks();
+        expectEqualRemoveAndAddListeners(ws);
+      }
+    });
+
     describe("requests subscription", () => {
       let ws: MockedWebSocket;
       let unsubscribe: () => void;

--- a/packages/client/src/objectSet/ObjectSetListenerWebsocket.ts
+++ b/packages/client/src/objectSet/ObjectSetListenerWebsocket.ts
@@ -358,6 +358,7 @@ export class ObjectSetListenerWebsocket {
         }) => {
           return {
             objectSet,
+            branch: this.#client.branch,
             scenarioRid: this.#client.scenarioRid,
             propertySet: requestedProperties,
             referenceSet: requestedReferenceProperties,

--- a/packages/client/src/objectSet/ObjectSetListenerWebsocket.ts
+++ b/packages/client/src/objectSet/ObjectSetListenerWebsocket.ts
@@ -358,6 +358,7 @@ export class ObjectSetListenerWebsocket {
         }) => {
           return {
             objectSet,
+            scenarioRid: this.#client.scenarioRid,
             propertySet: requestedProperties,
             referenceSet: requestedReferenceProperties,
             objectLoadingResponseOptions: { shouldLoadObjectRids: true },


### PR DESCRIPTION
## Description
Prior to this PR, we only supported subscribing to object set changes on scenarios, or on main. This specifically meant that subscribing to changes on indexed branches or scenarios on branches was not possible. Since support for this was however added recently in the backend, we wire it through here.

Stacked on https://github.com/palantir/osdk-ts/pull/3928

## Testing
Automated