### PR TITLE
Fix maker-import shapes

### DIFF
--- a/.changeset/swift-pillows-push.md
+++ b/.changeset/swift-pillows-push.md
@@ -1,0 +1,5 @@
+---
+"@osdk/maker-import": patch
+---
+
+Emit metadata needed for shape parity

--- a/packages/maker-import/src/generate/convertActionType.ts
+++ b/packages/maker-import/src/generate/convertActionType.ts
@@ -20,7 +20,6 @@ import { OntologyEntityTypeEnum } from "@osdk/maker";
 import { consola } from "consola";
 
 import { mapActionParameterType } from "./mapActionParameterType.js";
-import { withoutNamespace } from "./utils.js";
 
 export function convertActionType(action: Ontologies.ActionTypeV2): ActionType {
   const parameters: Array<ActionParameter> = [];
@@ -37,6 +36,7 @@ export function convertActionType(action: Ontologies.ActionTypeV2): ActionType {
     parameters.push({
       id: paramId,
       displayName: paramV2.displayName ?? paramId,
+      description: paramV2.description,
       type: mappedType,
       validation: {
         required: paramV2.required,
@@ -44,12 +44,11 @@ export function convertActionType(action: Ontologies.ActionTypeV2): ActionType {
     });
   }
 
-  const shortName = withoutNamespace(action.apiName);
-
   return {
     __type: OntologyEntityTypeEnum.ACTION_TYPE,
     apiName: action.apiName,
-    displayName: action.displayName ?? shortName,
+    displayName: action.displayName ?? action.apiName,
+    description: action.description,
     status: mapActionStatus(action.status),
     rules: [],
     parameters,

--- a/packages/maker-import/src/generate/convertInterfaceType.ts
+++ b/packages/maker-import/src/generate/convertInterfaceType.ts
@@ -49,7 +49,10 @@ export function convertInterfaceType(
     if (prop.type === "interfaceSharedPropertyType") {
       const converted = convertSharedPropertyType(prop);
       if (converted) {
-        const entry = { sharedPropertyType: converted, required: true };
+        const entry = {
+          sharedPropertyType: converted,
+          required: prop.required,
+        };
         propertiesV2[prop.apiName] = entry;
         propertiesV3[withoutNamespace(prop.apiName)] = entry;
       }
@@ -85,7 +88,7 @@ export function convertInterfaceType(
     apiName: iface.apiName,
     displayMetadata: {
       displayName: iface.displayName ?? shortName,
-      description: iface.description ?? shortName,
+      description: iface.description ?? "",
     },
     extendsInterfaces,
     links: [],

--- a/packages/maker-import/src/generate/convertObjectType.ts
+++ b/packages/maker-import/src/generate/convertObjectType.ts
@@ -15,18 +15,32 @@
  */
 
 import type * as Ontologies from "@osdk/foundry.ontologies";
-import type { ObjectPropertyType, ObjectType } from "@osdk/maker";
+import type {
+  ObjectPropertyType,
+  ObjectType,
+  SharedPropertyType,
+} from "@osdk/maker";
 import { OntologyEntityTypeEnum } from "@osdk/maker";
 import { consola } from "consola";
 
+import { convertSharedPropertyType } from "./convertSharedPropertyType.js";
 import { mapPropertyType } from "./mapPropertyType.js";
 import { withoutNamespace } from "./utils.js";
 
 export function convertObjectType(
   fullMetadata: Ontologies.ObjectTypeFullMetadata,
+  sharedPropertyTypes: Ontologies.OntologyFullMetadata["sharedPropertyTypes"] = {},
 ): ObjectType {
   const obj = fullMetadata.objectType;
   const properties: Array<ObjectPropertyType> = [];
+  const sharedPropertyTypeApiNameByPropertyApiName = new Map(
+    Object.entries(fullMetadata.sharedPropertyTypeMapping).map(
+      ([sharedPropertyTypeApiName, propertyApiName]) => [
+        propertyApiName,
+        sharedPropertyTypeApiName,
+      ],
+    ),
+  );
 
   for (const [propApiName, propV2] of Object.entries(obj.properties)) {
     const mapped = mapPropertyType(propV2.dataType);
@@ -37,10 +51,22 @@ export function convertObjectType(
       continue;
     }
 
+    const sharedPropertyTypeApiName =
+      sharedPropertyTypeApiNameByPropertyApiName.get(propApiName);
+    const sharedPropertyTypeMetadata = sharedPropertyTypeApiName
+      ? sharedPropertyTypes[sharedPropertyTypeApiName]
+      : undefined;
+    const sharedPropertyType: SharedPropertyType | undefined =
+      sharedPropertyTypeMetadata
+        ? convertSharedPropertyType(sharedPropertyTypeMetadata)
+        : undefined;
+
     const prop: ObjectPropertyType = {
       apiName: propApiName,
       displayName: propV2.displayName ?? propApiName,
+      description: propV2.description,
       type: mapped.type,
+      sharedPropertyType,
     };
     if (mapped.array) {
       (prop as ObjectPropertyType & { array?: boolean }).array = true;

--- a/packages/maker-import/src/generate/convertObjectType.ts
+++ b/packages/maker-import/src/generate/convertObjectType.ts
@@ -23,13 +23,11 @@ import type {
 import { OntologyEntityTypeEnum } from "@osdk/maker";
 import { consola } from "consola";
 
-import { convertSharedPropertyType } from "./convertSharedPropertyType.js";
 import { mapPropertyType } from "./mapPropertyType.js";
 import { withoutNamespace } from "./utils.js";
 
 export function convertObjectType(
   fullMetadata: Ontologies.ObjectTypeFullMetadata,
-  sharedPropertyTypes: Ontologies.OntologyFullMetadata["sharedPropertyTypes"] = {},
 ): ObjectType {
   const obj = fullMetadata.objectType;
   const properties: Array<ObjectPropertyType> = [];
@@ -53,12 +51,16 @@ export function convertObjectType(
 
     const sharedPropertyTypeApiName =
       sharedPropertyTypeApiNameByPropertyApiName.get(propApiName);
-    const sharedPropertyTypeMetadata = sharedPropertyTypeApiName
-      ? sharedPropertyTypes[sharedPropertyTypeApiName]
-      : undefined;
+    // Imported property shapes only need the SPT API name.
     const sharedPropertyType: SharedPropertyType | undefined =
-      sharedPropertyTypeMetadata
-        ? convertSharedPropertyType(sharedPropertyTypeMetadata)
+      sharedPropertyTypeApiName
+        ? {
+            __type: OntologyEntityTypeEnum.SHARED_PROPERTY_TYPE,
+            apiName: sharedPropertyTypeApiName,
+            nonNameSpacedApiName: withoutNamespace(sharedPropertyTypeApiName),
+            type: mapped.type,
+            array: mapped.array,
+          }
         : undefined;
 
     const prop: ObjectPropertyType = {


### PR DESCRIPTION
We didn't emit all necessary information in our maker-import generated files for input shapes. Ontology generates external input shapes from the generated files while other integrations generate them from the full metedata file so they must agree