### PR TITLE
Bump @osdk/foundry.* to 2.75.0 + Add support for streaming queries w/ SSE

### DIFF
--- a/.changeset/four-parents-hear.md
+++ b/.changeset/four-parents-hear.md
@@ -1,0 +1,21 @@
+---
+"@osdk/api": minor
+"@osdk/client": minor
+"@osdk/faux": patch
+"@osdk/foundry-sdk-generator": patch
+"@osdk/generator": patch
+"@osdk/generator-converters": patch
+"@osdk/generator-converters.ontologyir": patch
+"@osdk/generator-converters.preview": patch
+"@osdk/maker-experimental": patch
+"@osdk/maker-import": patch
+"@osdk/react": patch
+"@osdk/react-sdk-docs": patch
+"@osdk/seed-compiler": patch
+"@osdk/seed-helpers": patch
+"@osdk/typescript-sdk-docs": patch
+"@osdk/unit-testing": patch
+"@osdk/vite-plugin-oac": patch
+---
+
+Bump the `@osdk/foundry.*` and `@osdk/internal.foundry.*` catalog entries to `2.75.0`, which reinstates the `streamingExecute` query endpoint as a Server-Sent Events (`text/event-stream`) stream. The experimental `executeStreamingFunction` helper is reimplemented on top of it and no longer throws: it yields each result as it arrives, flattening batched results so array-returning queries emit one element at a time.

--- a/packages/api/src/experimental/executeStreamingFunction.ts
+++ b/packages/api/src/experimental/executeStreamingFunction.ts
@@ -35,9 +35,10 @@ type StreamingElement<QD extends QueryDefinition<any>> =
 /**
  * @experimental This feature is experimental and might change in the future.
  *
- * Intended to execute a query as a streaming function, yielding results as
- * they arrive from the server. Streaming query execution is not currently
- * supported in the TypeScript OSDK.
+ * Executes a query as a streaming function, yielding results as they arrive
+ * from the server. Queries whose declared output is an array are delivered in
+ * batches and flattened, so the iterable yields one element at a time rather
+ * than one batch at a time.
  */
 type executeStreamingFunctionFn = <QD extends QueryDefinition<any>>(
   query: QD,

--- a/packages/client/src/queries/applyStreamingQuery.ts
+++ b/packages/client/src/queries/applyStreamingQuery.ts
@@ -14,25 +14,88 @@
  * limitations under the License.
  */
 
-import type { CompileTimeMetadata, QueryDefinition } from "@osdk/api";
+import type {
+  CompileTimeMetadata,
+  QueryDefinition,
+  QueryMetadata,
+} from "@osdk/api";
+import * as Functions from "@osdk/foundry.functions/Query";
 
 import type { MinimalClient } from "../MinimalClientContext.js";
+import { addUserAgentAndRequestContextHeaders } from "../util/addUserAgentAndRequestContextHeaders.js";
+import { augmentRequestContext } from "../util/augmentRequestContext.js";
+import {
+  getRequiredDefinitions,
+  remapQueryParams,
+  remapQueryResponse,
+} from "./applyQuery.js";
 import type { QueryParameterType, QueryReturnType } from "./types.js";
 
-// Streaming query execution is not currently supported in the TypeScript OSDK
-export function applyStreamingQuery<
+export async function* applyStreamingQuery<
   QD extends QueryDefinition<any>,
   P extends QueryParameterType<CompileTimeMetadata<QD>["parameters"]>,
 >(
-  _client: MinimalClient,
-  _query: QD,
-  _params?: P,
+  client: MinimalClient,
+  query: QD,
+  params?: P,
 ): AsyncGenerator<
   QueryReturnType<CompileTimeMetadata<QD>["output"]>,
   void,
   unknown
 > {
-  throw new Error(
-    "Streaming query execution is not currently supported in the TypeScript OSDK.",
+  const qd: QueryMetadata = await client.ontologyProvider.getQueryDefinition(
+    query.apiName,
+    query.isFixedVersion ? query.version : undefined,
   );
+
+  if (client.flushEdits != null) {
+    await client.flushEdits();
+  }
+
+  const response = await Functions.streamingExecute(
+    addUserAgentAndRequestContextHeaders(
+      augmentRequestContext(client, (_) => ({
+        finalMethodCall: "applyStreamingQuery",
+      })),
+      query,
+    ),
+    query.apiName,
+    {
+      ontology: await client.ontologyRid,
+      parameters: params
+        ? await remapQueryParams(
+            params as { [parameterId: string]: any },
+            client,
+            qd.parameters,
+          )
+        : {},
+      version: query.isFixedVersion ? query.version : undefined,
+      branch: client.branch,
+    },
+    {
+      transactionId: client.transactionId,
+      preview: true,
+    },
+  );
+
+  const definitions = await getRequiredDefinitions(qd.output, client);
+
+  for await (const event of response) {
+    if (event.type !== "data") continue;
+
+    const remapped = await remapQueryResponse(
+      client,
+      qd.output,
+      event.value,
+      definitions,
+    );
+
+    if (qd.output.type === "array" && Array.isArray(remapped)) {
+      for (const item of remapped) {
+        yield item as QueryReturnType<CompileTimeMetadata<QD>["output"]>;
+      }
+    } else {
+      yield remapped as QueryReturnType<CompileTimeMetadata<QD>["output"]>;
+    }
+  }
 }

--- a/packages/client/src/queries/queries.test.ts
+++ b/packages/client/src/queries/queries.test.ts
@@ -46,18 +46,31 @@ import {
   threeDimensionalAggregationFunction,
   twoDimensionalAggregationFunction,
 } from "@osdk/client.test.ontology";
-import { LegacyFauxFoundry, startNodeApiServer } from "@osdk/shared.test";
-import { beforeAll, describe, expect, expectTypeOf, it } from "vitest";
+import {
+  LegacyFauxFoundry,
+  msw,
+  type SetupServer,
+  startNodeApiServer,
+} from "@osdk/shared.test";
+import {
+  afterEach,
+  beforeAll,
+  describe,
+  expect,
+  expectTypeOf,
+  it,
+} from "vitest";
 
 import type { Client } from "../Client.js";
 import { createClient } from "../createClient.js";
 
 describe("queries", () => {
   let client: Client;
+  let apiServer: SetupServer;
 
   beforeAll(() => {
     const testSetup = startNodeApiServer(new LegacyFauxFoundry(), createClient);
-    ({ client } = testSetup);
+    ({ client, apiServer } = testSetup);
     return () => {
       testSetup.apiServer.close();
     };
@@ -602,20 +615,151 @@ describe("queries", () => {
   });
 
   describe("executeStreamingFunction", () => {
-    it("throws because streaming execution is not currently supported", async () => {
-      let caught: unknown;
+    const STREAMING_URL_BASE =
+      "https://stack.palantir.com/api/v2/functions/queries";
+
+    function sseResponse(events: unknown[]): Response {
+      const encoder = new TextEncoder();
+      const stream = new ReadableStream<Uint8Array>({
+        start(controller) {
+          for (const event of events) {
+            controller.enqueue(
+              encoder.encode(`data: ${JSON.stringify(event)}\n\n`),
+            );
+          }
+          controller.close();
+        },
+      });
+      return new Response(stream, {
+        headers: { "Content-Type": "text/event-stream" },
+      });
+    }
+
+    afterEach(() => {
+      apiServer.resetHandlers();
+    });
+
+    it("yields the value of a single-event non-streaming response", async () => {
+      apiServer.use(
+        msw.http.post(
+          `${STREAMING_URL_BASE}/${addOne.apiName}/streamingExecute`,
+          () => sseResponse([{ type: "data", value: 3 }]),
+        ),
+      );
+
+      const items: number[] = [];
+      for await (const item of client(
+        __EXPERIMENTAL__NOT_SUPPORTED_YET__executeStreamingFunction,
+      ).executeStreamingFunction(addOne, { n: 2 })) {
+        items.push(item);
+      }
+      expect(items).toEqual([3]);
+    });
+
+    it("flattens batched array results across multiple events", async () => {
+      apiServer.use(
+        msw.http.post(
+          `${STREAMING_URL_BASE}/${queryTypeReturnsArrayOfObjects.apiName}/streamingExecute`,
+          () =>
+            sseResponse([
+              { type: "data", value: [50030, 50031] },
+              { type: "data", value: [50032] },
+            ]),
+        ),
+      );
+
+      const items: Array<OsdkBase<Employee>> = [];
+      for await (const item of client(
+        __EXPERIMENTAL__NOT_SUPPORTED_YET__executeStreamingFunction,
+      ).executeStreamingFunction(queryTypeReturnsArrayOfObjects, {
+        people: ["Brad", "George", "Ryan"],
+      })) {
+        items.push(item);
+      }
+      expect(items).toEqual([
+        {
+          $apiName: "Employee",
+          $objectType: "Employee",
+          $primaryKey: 50030,
+          $objectSpecifier: "Employee:50030",
+          $title: undefined,
+        },
+        {
+          $apiName: "Employee",
+          $objectType: "Employee",
+          $primaryKey: 50031,
+          $objectSpecifier: "Employee:50031",
+          $title: undefined,
+        },
+        {
+          $apiName: "Employee",
+          $objectType: "Employee",
+          $primaryKey: 50032,
+          $objectSpecifier: "Employee:50032",
+          $title: undefined,
+        },
+      ]);
+    });
+
+    it("stops consuming when the caller breaks out of the loop", async () => {
+      apiServer.use(
+        msw.http.post(
+          `${STREAMING_URL_BASE}/${queryTypeReturnsArrayOfObjects.apiName}/streamingExecute`,
+          () =>
+            sseResponse([
+              { type: "data", value: [50030, 50031] },
+              { type: "data", value: [50032] },
+            ]),
+        ),
+      );
+
+      const items: Array<OsdkBase<Employee>> = [];
+      for await (const item of client(
+        __EXPERIMENTAL__NOT_SUPPORTED_YET__executeStreamingFunction,
+      ).executeStreamingFunction(queryTypeReturnsArrayOfObjects, {
+        people: ["Brad", "George", "Ryan"],
+      })) {
+        items.push(item);
+        break;
+      }
+      expect(items).toHaveLength(1);
+      expect(items[0].$primaryKey).toBe(50030);
+    });
+
+    it("throws on error events, attaching error fields", async () => {
+      apiServer.use(
+        msw.http.post(
+          `${STREAMING_URL_BASE}/${addOne.apiName}/streamingExecute`,
+          () =>
+            sseResponse([
+              {
+                type: "error",
+                errorCode: "INVALID_ARGUMENT",
+                errorName: "QueryRuntimeError",
+                errorInstanceId: "abc-123",
+                errorDescription: "Division by zero",
+                parameters: {},
+              },
+            ]),
+        ),
+      );
+
+      let caught: any;
       try {
         for await (const _ of client(
           __EXPERIMENTAL__NOT_SUPPORTED_YET__executeStreamingFunction,
         ).executeStreamingFunction(addOne, { n: 2 })) {
           // unreachable
         }
-        expect.fail("expected streaming execution to throw");
+        expect.fail("expected stream to throw");
       } catch (e) {
         caught = e;
       }
       expect(caught).toBeInstanceOf(Error);
-      expect((caught as Error).message).toContain("not currently supported");
+      expect((caught as Error).message).toContain("Division by zero");
+      expect(caught.errorName).toBe("QueryRuntimeError");
+      expect(caught.errorCode).toBe("INVALID_ARGUMENT");
+      expect(caught.errorInstanceId).toBe("abc-123");
     });
 
     it("yields elements of an array-returning query as the element type", () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,35 +13,35 @@ catalogs:
       specifier: 0.17.0
       version: 0.17.0
     '@osdk/foundry':
-      specifier: 2.73.0
-      version: 2.73.0
+      specifier: 2.75.0
+      version: 2.75.0
     '@osdk/foundry.admin':
-      specifier: 2.73.0
-      version: 2.73.0
+      specifier: 2.75.0
+      version: 2.75.0
     '@osdk/foundry.core':
-      specifier: 2.73.0
-      version: 2.73.0
+      specifier: 2.75.0
+      version: 2.75.0
     '@osdk/foundry.datasets':
       specifier: ~2.5.0
       version: 2.5.0
     '@osdk/foundry.functions':
-      specifier: 2.73.0
-      version: 2.73.0
+      specifier: 2.75.0
+      version: 2.75.0
     '@osdk/foundry.geo':
-      specifier: 2.73.0
-      version: 2.73.0
+      specifier: 2.75.0
+      version: 2.75.0
     '@osdk/foundry.mediasets':
-      specifier: 2.73.0
-      version: 2.73.0
+      specifier: 2.75.0
+      version: 2.75.0
     '@osdk/foundry.ontologies':
-      specifier: 2.73.0
-      version: 2.73.0
+      specifier: 2.75.0
+      version: 2.75.0
     '@osdk/foundry.thirdpartyapplications':
-      specifier: 2.73.0
-      version: 2.73.0
+      specifier: 2.75.0
+      version: 2.75.0
     '@osdk/internal.foundry.ontologies':
-      specifier: 2.73.0
-      version: 2.73.0
+      specifier: 2.75.0
+      version: 2.75.0
 
 overrides:
   trim@0.0.1: 0.0.3
@@ -1890,7 +1890,7 @@ importers:
         version: link:../cli.common
       '@osdk/foundry.ontologies':
         specifier: catalog:foundry-platform-typescript
-        version: 2.73.0
+        version: 2.75.0
       '@osdk/generator':
         specifier: workspace:~
         version: link:../generator
@@ -1973,16 +1973,16 @@ importers:
         version: link:../client.unstable
       '@osdk/foundry.core':
         specifier: catalog:foundry-platform-typescript
-        version: 2.73.0
+        version: 2.75.0
       '@osdk/foundry.functions':
         specifier: catalog:foundry-platform-typescript
-        version: 2.73.0
+        version: 2.75.0
       '@osdk/foundry.mediasets':
         specifier: catalog:foundry-platform-typescript
-        version: 2.73.0
+        version: 2.75.0
       '@osdk/foundry.ontologies':
         specifier: catalog:foundry-platform-typescript
-        version: 2.73.0
+        version: 2.75.0
       '@osdk/generator-converters':
         specifier: workspace:*
         version: link:../generator-converters
@@ -3259,7 +3259,7 @@ importers:
         version: link:../client
       '@osdk/foundry.ontologies':
         specifier: catalog:foundry-platform-typescript
-        version: 2.73.0
+        version: 2.75.0
     devDependencies:
       '@arethetypeswrong/cli':
         specifier: ^0.17.4
@@ -3296,7 +3296,7 @@ importers:
         version: link:../e2e.generated.catchall
       '@osdk/foundry':
         specifier: catalog:foundry-platform-typescript
-        version: 2.73.0
+        version: 2.75.0
       '@osdk/functions':
         specifier: workspace:~
         version: link:../functions
@@ -3849,25 +3849,25 @@ importers:
         version: link:../api
       '@osdk/foundry.admin':
         specifier: catalog:foundry-platform-typescript
-        version: 2.73.0
+        version: 2.75.0
       '@osdk/foundry.core':
         specifier: catalog:foundry-platform-typescript
-        version: 2.73.0
+        version: 2.75.0
       '@osdk/foundry.geo':
         specifier: catalog:foundry-platform-typescript
-        version: 2.73.0
+        version: 2.75.0
       '@osdk/foundry.mediasets':
         specifier: catalog:foundry-platform-typescript
-        version: 2.73.0
+        version: 2.75.0
       '@osdk/foundry.ontologies':
         specifier: catalog:foundry-platform-typescript
-        version: 2.73.0
+        version: 2.75.0
       '@osdk/generator-converters':
         specifier: workspace:~
         version: link:../generator-converters
       '@osdk/internal.foundry.ontologies':
         specifier: catalog:foundry-platform-typescript
-        version: 2.73.0
+        version: 2.75.0
       date-fns:
         specifier: ^4.1.0
         version: 4.1.0
@@ -3962,10 +3962,10 @@ importers:
         version: link:../client.unstable.tpsa
       '@osdk/foundry.ontologies':
         specifier: catalog:foundry-platform-typescript
-        version: 2.73.0
+        version: 2.75.0
       '@osdk/foundry.thirdpartyapplications':
         specifier: catalog:foundry-platform-typescript
-        version: 2.73.0
+        version: 2.75.0
       '@osdk/generator':
         specifier: workspace:*
         version: link:../generator
@@ -4084,7 +4084,7 @@ importers:
         version: link:../api
       '@osdk/foundry.ontologies':
         specifier: catalog:foundry-platform-typescript
-        version: 2.73.0
+        version: 2.75.0
       '@osdk/generator-converters':
         specifier: workspace:~
         version: link:../generator-converters
@@ -4133,7 +4133,7 @@ importers:
         version: link:../api
       '@osdk/foundry.ontologies':
         specifier: catalog:foundry-platform-typescript
-        version: 2.73.0
+        version: 2.75.0
     devDependencies:
       '@osdk/monorepo.api-extractor':
         specifier: workspace:~
@@ -4158,7 +4158,7 @@ importers:
         version: link:../client.unstable
       '@osdk/foundry.ontologies':
         specifier: catalog:foundry-platform-typescript
-        version: 2.73.0
+        version: 2.75.0
       consola:
         specifier: ^3.4.2
         version: 3.4.2
@@ -4192,7 +4192,7 @@ importers:
         version: link:../client.unstable
       '@osdk/foundry.ontologies':
         specifier: catalog:foundry-platform-typescript
-        version: 2.73.0
+        version: 2.75.0
       '@osdk/generator':
         specifier: workspace:~
         version: link:../generator
@@ -4260,7 +4260,7 @@ importers:
     dependencies:
       '@osdk/foundry.ontologies':
         specifier: catalog:foundry-platform-typescript
-        version: 2.73.0
+        version: 2.75.0
       '@osdk/generator-converters.preview':
         specifier: workspace:~
         version: link:../generator-converters.preview
@@ -4410,7 +4410,7 @@ importers:
         version: link:../client.unstable
       '@osdk/foundry.ontologies':
         specifier: catalog:foundry-platform-typescript
-        version: 2.73.0
+        version: 2.75.0
       '@osdk/generator-converters.ontologyir':
         specifier: workspace:~
         version: link:../generator-converters.ontologyir
@@ -4459,7 +4459,7 @@ importers:
         version: link:../client.unstable
       '@osdk/foundry.ontologies':
         specifier: catalog:foundry-platform-typescript
-        version: 2.73.0
+        version: 2.75.0
       '@osdk/maker':
         specifier: workspace:~
         version: link:../maker
@@ -4730,10 +4730,10 @@ importers:
         version: link:../client.test.ontology
       '@osdk/foundry.admin':
         specifier: catalog:foundry-platform-typescript
-        version: 2.73.0
+        version: 2.75.0
       '@osdk/foundry.core':
         specifier: catalog:foundry-platform-typescript
-        version: 2.73.0
+        version: 2.75.0
       '@osdk/monorepo.api-extractor':
         specifier: workspace:~
         version: link:../monorepo.api-extractor
@@ -5121,7 +5121,7 @@ importers:
     dependencies:
       '@osdk/foundry.ontologies':
         specifier: catalog:foundry-platform-typescript
-        version: 2.73.0
+        version: 2.75.0
       '@osdk/seed-helpers':
         specifier: workspace:~
         version: link:../seed-helpers
@@ -5173,7 +5173,7 @@ importers:
         version: link:../client
       '@osdk/foundry.ontologies':
         specifier: catalog:foundry-platform-typescript
-        version: 2.73.0
+        version: 2.75.0
       consola:
         specifier: ^3.4.2
         version: 3.4.2
@@ -5291,19 +5291,19 @@ importers:
         version: link:../api
       '@osdk/foundry.core':
         specifier: catalog:foundry-platform-typescript
-        version: 2.73.0
+        version: 2.75.0
       '@osdk/foundry.geo':
         specifier: catalog:foundry-platform-typescript
-        version: 2.73.0
+        version: 2.75.0
       '@osdk/foundry.ontologies':
         specifier: catalog:foundry-platform-typescript
-        version: 2.73.0
+        version: 2.75.0
       '@osdk/generator-converters':
         specifier: workspace:~
         version: link:../generator-converters
       '@osdk/internal.foundry.ontologies':
         specifier: catalog:foundry-platform-typescript
-        version: 2.73.0
+        version: 2.75.0
       date-fns:
         specifier: ^4.1.0
         version: 4.1.0
@@ -5653,7 +5653,7 @@ importers:
         version: link:../client.test.ontology
       '@osdk/foundry.admin':
         specifier: catalog:foundry-platform-typescript
-        version: 2.73.0
+        version: 2.75.0
       '@osdk/functions':
         specifier: workspace:~
         version: link:../functions
@@ -5729,7 +5729,7 @@ importers:
         version: link:../faux
       '@osdk/foundry.ontologies':
         specifier: catalog:foundry-platform-typescript
-        version: 2.73.0
+        version: 2.75.0
       '@osdk/generator-converters.ontologyir':
         specifier: workspace:*
         version: link:../generator-converters.ontologyir
@@ -9000,17 +9000,32 @@ packages:
   '@osdk/foundry.admin@2.73.0':
     resolution: {integrity: sha512-R8YvY1W4m0XtxWFPzTTbK9F9AGwXGw9/AKDC/LYwIWSMuFNhT2KL8wLA67MURIWxLniXt7vrnihwUoDe0O+p8g==}
 
+  '@osdk/foundry.admin@2.75.0':
+    resolution: {integrity: sha512-gpTVv25I0Y4DJ5O+pkvD6KXnyAN+IUKpapymCWpk4TDF5vaz4aIlCfOKdjivFYm2U6xGxGc/OfKkjhnCrGX6rw==}
+
   '@osdk/foundry.aipagents@2.73.0':
     resolution: {integrity: sha512-05MYhhNsvmtSC2jFLYPMNkYaLHhZ2aDmOeQOumI3w6i5ZqwVT7uDrt5lPOlmfjDhFEdvxn2xa89Ihgwi0ZYbvw==}
+
+  '@osdk/foundry.aipagents@2.75.0':
+    resolution: {integrity: sha512-tGJPgY3zA+9n4O6eLk4105Mx1e6rnSmHciFFtc16DnXyGK4vJMOnEu0xjtx9Kz45x0ND5jL1KNJhYRsQ4qFNvg==}
 
   '@osdk/foundry.audit@2.73.0':
     resolution: {integrity: sha512-IKXpZcNqeIwZjj3y9BBe1VgwHMd9eic9ywTmajP4i1CdumXhFGZpqaNCjMYWvMZB57HdM/16OtYr05XLcDO9eg==}
 
+  '@osdk/foundry.audit@2.75.0':
+    resolution: {integrity: sha512-xGBUnMAiSbO32cC8/e7YxSEVmRImT9Hi0WjOCsu1TvwDvj9goPrLktmTlCyGcWYpJZ8i8/+mKs/IpOY4F14Ahg==}
+
   '@osdk/foundry.checkpoints@2.73.0':
     resolution: {integrity: sha512-mzgwW3MqP0LyF+kwbTQUZUiEm7q6kUmwy+Zecyom/ORvUdvNEKYTtbWUQ3fr6QGdBYpNgsEkg1I+uP87Pvxj0g==}
 
+  '@osdk/foundry.checkpoints@2.75.0':
+    resolution: {integrity: sha512-32igKvro8f/5WWak1m87dFZlX+8uLNkbZyUVDviKOTh5fwwFRf5HaRFMNqGHSTbSBoQ/YtGX+0THH7a6PRCYtQ==}
+
   '@osdk/foundry.connectivity@2.73.0':
     resolution: {integrity: sha512-6t537UwFIzkOWbKjzRrdZZr/1rb4PYgDrKpiQo0C3jCswnpeO0g77QqCpGbNN0Fjtz5YT2mXR4tVSsUM+P/3Ag==}
+
+  '@osdk/foundry.connectivity@2.75.0':
+    resolution: {integrity: sha512-CYsVGQEtLo/Spp2y/lGHJzSS81vKmXPCilulJ8zfTrl5CRGCeP0Fs5jsfLZe3FEVzPWOyTBKZX6QMuwABbmf7A==}
 
   '@osdk/foundry.core@2.44.0':
     resolution: {integrity: sha512-fdDAm2pdf67DWo32sXBcfwujAxb7YOKI4iUQ99C1JW92SQRqNBbQZQlM10RJYQ7LMq6S9P1Gz6Gx7KRV7I5Zpw==}
@@ -9021,8 +9036,14 @@ packages:
   '@osdk/foundry.core@2.73.0':
     resolution: {integrity: sha512-wqgDfR+CnuuxeZc1CXcH2cfghkqA0jGOh2Wf7V363GK0kRb1QM+xoGmfbCB4Q9ebc8FEfSrD0k/r1PsFLyxDbw==}
 
+  '@osdk/foundry.core@2.75.0':
+    resolution: {integrity: sha512-I1Vs037q7q03gM0Gvi3lIuqPrmL0OiBCSA70aLDbTBChKIc4/cS8ehT+ovHfU/BMIuqoXhn3Wzb8yTiQS+esAA==}
+
   '@osdk/foundry.datahealth@2.73.0':
     resolution: {integrity: sha512-CAhWjDBh1N4cCVdzgIIoG7h43LDldvZwmpetWAVnCLpmHmkbIk062xkZMPeqi2F58l32EG4E2Z8YhfYnrbb0cg==}
+
+  '@osdk/foundry.datahealth@2.75.0':
+    resolution: {integrity: sha512-x6UF5065V7fKmlPQGfNDu++P7Db8H1vOy3Xk6zwtt6ewzkMXQXy9xu82JL6FpPJ5KeGb+6sG3isARFCn4t7FhA==}
 
   '@osdk/foundry.datasets@2.5.0':
     resolution: {integrity: sha512-W82xleLQgQFUTVnAQS54n26xUFEALayotl1f3LGeRLN6r+2G1dNp+UgRU7/IHc/xzOqgulEOGwwr6ENFcsNP2A==}
@@ -9030,14 +9051,23 @@ packages:
   '@osdk/foundry.datasets@2.73.0':
     resolution: {integrity: sha512-dCtezCUDmkDb/friCTgkHa14zTH2z5q0XBiPvSYWXbVzBS0SoWfGxnDxrWELhoxzKdT3eTOARh+E1kgK816KUg==}
 
+  '@osdk/foundry.datasets@2.75.0':
+    resolution: {integrity: sha512-wYaZmabfbSubDZfYLbtTjjU+f8wVDUPOVubo1xeMElXyjpjBxETtLRJwVqMEllmtNDR/O3fBe2GYvPciE7MITg==}
+
   '@osdk/foundry.filesystem@2.5.0':
     resolution: {integrity: sha512-SJKZSfBc7CroyoIVW3D2SpVyaCCnhv8onzIwHcJWOnufFgSbQ3kqyWoqNiStGlymmnoSbniK3rfUFFYeUbxhDQ==}
 
   '@osdk/foundry.filesystem@2.73.0':
     resolution: {integrity: sha512-bGm6UtfiA0KlxZbP5gdZ70HtfMZ5VcJtabnfoCxTorA1zX4YPP0WOyTJ+J/e19JF1IUaSLgw07ea2ZH+uv2rCw==}
 
+  '@osdk/foundry.filesystem@2.75.0':
+    resolution: {integrity: sha512-IFctl2hzaBFm/mAHJNNL9UAcXXo4vwxlzW+3GEHstrgMef3zvcn7UIFBEgXmLhvCLoVzwAlySuce+Xhnvb6xpg==}
+
   '@osdk/foundry.functions@2.73.0':
     resolution: {integrity: sha512-gp8Tk4mgQAYp5uW0vNNq9V/ICTog55iqJhGddssSuu1wAwTQs62FbVXOeqSI1p4qMfAxsdWuQSJ+3uYZCq6Jpg==}
+
+  '@osdk/foundry.functions@2.75.0':
+    resolution: {integrity: sha512-WNLVx+uCVmAVCiUkbQwln6rijrW7S3Uae8IOd0nJk8lDJZWu2wxpYbwJhvDKmi6YKZEpEoEVijm8ikx5oL2eMw==}
 
   '@osdk/foundry.geo@2.44.0':
     resolution: {integrity: sha512-eXiBR2YAesPJe5amQy6G/pz0i4kmgJXiCAocMSYsgVKm/8kuMaqDUn5UJIFYo7EdjLVJueiMAFyCdN0wpK3SZA==}
@@ -9048,11 +9078,20 @@ packages:
   '@osdk/foundry.geo@2.73.0':
     resolution: {integrity: sha512-map1LI7ic4s93u16mian0hj1QTads3M/nEa+sgJBh2u6rAdal56hK3YKblgvc9NvE7Bg5urAKIohly+f5RAC6g==}
 
+  '@osdk/foundry.geo@2.75.0':
+    resolution: {integrity: sha512-iLAd0ZAFMujM77MAMGO/AvkIgDuGVT15huDX81Lw56UeLOwZyVsrL/KX0v8LTsfgnCXRaoYHwDJ4AGNmpSkARg==}
+
   '@osdk/foundry.geojson@2.73.0':
     resolution: {integrity: sha512-huWeBypQ3H4RpkPiuhw7mX5kCaDb3KZupUi4IQmb0T1U6Shv+GZsT590lRLqFOoffXvlTXS221vU47hbMG46BA==}
 
+  '@osdk/foundry.geojson@2.75.0':
+    resolution: {integrity: sha512-Uf4pXFSNwoGhgfHMD5+0OsarG3v4Fd7p94vEH23vL7Oa+u44kKJmRzZLoQQ23K0ySu5lCXy8HmqFcxxAQ9ADbw==}
+
   '@osdk/foundry.languagemodels@2.73.0':
     resolution: {integrity: sha512-HPOQSmfrzMPUS4M0fWr5lH9pT1/fXhRM0e2IpkcmT/gK/48UibK0sp9jl2ZXuw9pjqNg7YP/rPMU6vGx9TyBqA==}
+
+  '@osdk/foundry.languagemodels@2.75.0':
+    resolution: {integrity: sha512-tz0vi/SVuORFZHg42dm43+GlLeT2ZA3WCFGS79sNytGlQ8mlNx0gyMJbS/RZu/MJHtcbL282udH6Qxplu+MeiQ==}
 
   '@osdk/foundry.mediasets@2.44.0':
     resolution: {integrity: sha512-l378lxKUdIMmb1txFs/hOKyPO3bc10OWU4BvaP/LMZjXLbUZPNI/DYAmKrzKTeSMGBnZ2luhqEyfPfZYMGmrhw==}
@@ -9060,11 +9099,20 @@ packages:
   '@osdk/foundry.mediasets@2.73.0':
     resolution: {integrity: sha512-ztLsK3QQsSvnkUkzMApZLsf8h38Q4fNFY9pS2Bap/feMHx4vsi+SxMRdcZSgJ9DYuAwNWfYsPcgf7aZNU61C1Q==}
 
+  '@osdk/foundry.mediasets@2.75.0':
+    resolution: {integrity: sha512-1kZqBwiz8r7ETkNLkEfwUfovVEl7/B/DWK6j3TdGJ4eGLXVwcV1rGR2oAmX/gl3pDRlnjqbGEy3GRHNiSwz9/w==}
+
   '@osdk/foundry.models@2.73.0':
     resolution: {integrity: sha512-q69O4yr7sJNTo0UCHMAkHgwEa+QKPuqsahF9tCGXVNcYPm8rFxznuP/bjMbwVFmfOJfUR5M3opvwo+qnWSg0fg==}
 
+  '@osdk/foundry.models@2.75.0':
+    resolution: {integrity: sha512-wM3G+KQabbkvL+Vu64ZjOXlfXfFFBTR71d3ck9ww6nUnDGJypAmMkOA15VN12Ag5/RyysguKt/W6BbyDTQKKXg==}
+
   '@osdk/foundry.notepad@2.73.0':
     resolution: {integrity: sha512-+M4/sTtdKxOfNS3tAPZougw8QFCwW1p7dHztpwYX9dGFdM/he4SzQtuZFv3EgJdsAa+H/PNnuKaMAvgE0MY2bA==}
+
+  '@osdk/foundry.notepad@2.75.0':
+    resolution: {integrity: sha512-SWSYOaDbbCpOzQFDxLSD3fM4qYU+J7hElE8eX01Ters0DJLkVJ0uOv8rCfufjJrSJ/07ox4lZDrfG0SxyxSa+Q==}
 
   '@osdk/foundry.ontologies@2.44.0':
     resolution: {integrity: sha512-A74NrG3tDiLNC5VW+plchrrMDf5gLekavrdyVnmVqQAkcBc6Z8/Jl+92rJbQ/v6TJnXWpCwuCkc+QQXaYlhHKQ==}
@@ -9072,32 +9120,62 @@ packages:
   '@osdk/foundry.ontologies@2.73.0':
     resolution: {integrity: sha512-eoViI7iiR1PRRpS88/rIkYAIbVMKnVCHDa7TFYtxc6lQbEGVazkHL5OZ8eqnX4n5fPK/KIAk1mGgi4wUVOhHcA==}
 
+  '@osdk/foundry.ontologies@2.75.0':
+    resolution: {integrity: sha512-5FLjpxBLez0wFBqEf0iH3lgxFpWhM+CSNZbfAhWy7//3Pse+tsnWaRGh3beOZUAt90FGC0mxPowTl5FD+JIyLQ==}
+
   '@osdk/foundry.operations@2.73.0':
     resolution: {integrity: sha512-B99kU3E/l1eIFcEDzbtsFSIAHAAeTI7rkAwkzCeGqDm61zzw4k87fFzlRrFbPScbmuHngHvA8QMFfS9JK5qpFg==}
+
+  '@osdk/foundry.operations@2.75.0':
+    resolution: {integrity: sha512-gBpIjw5O3GDCPqwzAPfVmN0rmJ/4w/niRrozVLo24dYI9LonPL4QtDdbasqFxsRqldcICujP/ObbC5mN382ncA==}
 
   '@osdk/foundry.orchestration@2.73.0':
     resolution: {integrity: sha512-a91+YtbyLsnWMOG2EfcastBxf9kF6ZFseth/EuC99P1A1/TTS0ovkGXlK6HNQFHF+R8xK8gYMdtfY3zgjoWeBQ==}
 
+  '@osdk/foundry.orchestration@2.75.0':
+    resolution: {integrity: sha512-feW4kGEO6pu/0iCsHAOv6MPwxaItnLnO5swccB3j1SIOz38yFKSBG2F4YlWk01E3CIUgZgrMPZB53Ggh8qnsyg==}
+
   '@osdk/foundry.pack@2.73.0':
     resolution: {integrity: sha512-CPt0RX8ai/UQc8GqPV8AzqtxfmG66Yo84KUZGWpvsQRAfcvJ70X/jDD1FncRqLCetlY1q3tK8j11/5SRt9v1eQ==}
+
+  '@osdk/foundry.pack@2.75.0':
+    resolution: {integrity: sha512-bGFRqUrgWzKJZCZ6+UEX+6vUV9RcjphIJlhfFN3q5e+Sn4tY0Fz3qGt4KXUs1/1JZfx5VpbSmGNXo4GyHPrtqA==}
 
   '@osdk/foundry.publicapis@2.73.0':
     resolution: {integrity: sha512-SjMCayouoNFVeHFcMrFsmts/17ADZ59t1TWzJBn6ZKTlwJ6p66ozdnWQC14YY/+3TMXKZEckHuoLp6wYndDdvQ==}
 
+  '@osdk/foundry.publicapis@2.75.0':
+    resolution: {integrity: sha512-aud3UK4hC5JKTAnxJH/Vkf4/CH9JbB+feyWbMMEvWLt82+tX7aatFbbm5Zr+4bMf7v2dJZHU55qX8TWhtwwWZg==}
+
   '@osdk/foundry.sqlqueries@2.73.0':
     resolution: {integrity: sha512-xFI95P5gF0nM/3VVtL5kDkczaLeDnA/KmvZ4hjQLrjZRqgdgnXvzmA1KEe1aDWQyDSVezSlKp77BYo8SVeMFWw==}
+
+  '@osdk/foundry.sqlqueries@2.75.0':
+    resolution: {integrity: sha512-gk3wOzxJj5QJMs9gdpf1hV0yd8gnOrDRlPLd5xdU1wASbjwkBmiq8OVzR2+eSU5m29Qdfr8CopCVU7o6LWwRLQ==}
 
   '@osdk/foundry.streams@2.73.0':
     resolution: {integrity: sha512-gWqAkt2ydzKdkP4bSQR9U1RIfArwmi8bxYQolVEuF7vQ6s5ufqp5H04URoKHspBppgc2+vgmq+qZj5QJC7GMUw==}
 
+  '@osdk/foundry.streams@2.75.0':
+    resolution: {integrity: sha512-eGH8AQsb2A09/aONRcG2aSFYONJfgjO9cZNF2fKVxdTTTPwTsAJG5QxDY/0LNrr180IaMysbeu9+hh9r/wDyIg==}
+
   '@osdk/foundry.thirdpartyapplications@2.73.0':
     resolution: {integrity: sha512-fLb16QgG17gIWFI8ZdQiyUEfZXQN2Kpm/IMEcFOFmUI+s9FjP9lF2UWfljYRFUgdj5STL07LRHPy9DgKDRtEGg==}
+
+  '@osdk/foundry.thirdpartyapplications@2.75.0':
+    resolution: {integrity: sha512-gKnvhloG31GX3UomVjCwEQ89/LLdl18ELWf5+Pof7/RAiTmfWq0IM06EjJD7Rngc6O1bnIu7F9wNPfa0rL2nvw==}
 
   '@osdk/foundry.widgets@2.73.0':
     resolution: {integrity: sha512-tGhg4+F5/0Fs8leKKkB4jGr9z5jZ777yu1tVx/9tJByMYQG7ghkeqG6TJDEYWIBYwUVlwg1/geX0dOrsdWthVA==}
 
+  '@osdk/foundry.widgets@2.75.0':
+    resolution: {integrity: sha512-djsdxCHpPGUwwfzEVGVK+UeU46ieP2D/pLdgPuCALt9JZjOiODwTPft+tNWR1+23Nmr2DEIzUFjxyocg8IqgKw==}
+
   '@osdk/foundry@2.73.0':
     resolution: {integrity: sha512-RzZ4mjo66llOQasGnOyHIMNIQAU0imyiWhpGrnMLLQQFyCB1sbSc5wWk1mLDYeda7rHKXGrjqtzdVCfwZO3w9w==}
+
+  '@osdk/foundry@2.75.0':
+    resolution: {integrity: sha512-ZsWmrQxPddnD5j0y+pjshsAoMsPqkClEooWynFjnpAsXlX/LtXpn3Wr8gWe20WA/senvcd6U6XtAyxQzaDhDqA==}
 
   '@osdk/gateway@2.4.2':
     resolution: {integrity: sha512-A2WmRHxzCiZKyviYKAQEq9KZwL5DEkhXADLt36lMn2tGixO5qOTU7rLsE+OAA4va+evmd44TfzipJs8ieffP6g==}
@@ -9105,17 +9183,17 @@ packages:
   '@osdk/generator-converters@2.7.5':
     resolution: {integrity: sha512-dtvqVN3ufdwgsz2BlQwoTpCHuftnAQMbjAqDA/cT1wnW5wCWeo8ctxhl0ArCfM4jbGhiz9OcspHajuDC07IStw==}
 
-  '@osdk/internal.foundry.core@2.73.0':
-    resolution: {integrity: sha512-AEEbCI9e/VkqgalPvDF+/XIDgvGWWM8Zd4pXG6LW+lUnRDiHtJ645uRDjhcsbrR2rvz2E8SJPpdZvp3I/H8JFQ==}
+  '@osdk/internal.foundry.core@2.75.0':
+    resolution: {integrity: sha512-sNUGtMzdii2WWeLi/lhPHfw1qrBlJo3w6esUqN4PDSGF1IfHpKAFjaMj9dTeDWP80IK5gNxGxNEXCgmr/AwdbA==}
 
-  '@osdk/internal.foundry.datasets@2.73.0':
-    resolution: {integrity: sha512-5wunpMzmvasLLeiE9CE47IbKSMPwNFcDCnAFvdMZBw2C9WnzqKOGT4kY1M151rY9JXyfXDq3449qNIxi+wORbw==}
+  '@osdk/internal.foundry.datasets@2.75.0':
+    resolution: {integrity: sha512-ePK+aGEiKC3cqrn6nk8rPNfqQhVbPgp928AaRRkKlqScqlzJQoNWuUBYGcCoWwD4DeGM9yBLY+7vo4x3BT9/RQ==}
 
-  '@osdk/internal.foundry.geo@2.73.0':
-    resolution: {integrity: sha512-xH844lIibnwBB6WjfI4QQ9US6kPSYOjvAi5tbRtjmdgH1ynd5n2kHeVhovOemaTnv+VJocz004XS1MQYlRBpnQ==}
+  '@osdk/internal.foundry.geo@2.75.0':
+    resolution: {integrity: sha512-FYTtyjNBqKjvcmtqPiMJgHKgsaHdayGm/0I0qTPa1ObdOt+x+k4Raisc4PmR/Zk/SlPnHFc2s+bBBmsBVU+Ocg==}
 
-  '@osdk/internal.foundry.ontologies@2.73.0':
-    resolution: {integrity: sha512-6A5rQDjTEoW/GfiQq85g5yY0PWuh9Cx+pbzBMnXmrX+Kxbj7PglxzusL5xj34CG5FkVxKp+Bj+ewMmdORDxqBA==}
+  '@osdk/internal.foundry.ontologies@2.75.0':
+    resolution: {integrity: sha512-H6YH/excjt6vwdxWxV5ajyEQ405BWJjqBd36jY9dtO+umYdieRZOyglJtALywaBhk13j5KyrT+Q4SiqHA8EDJA==}
 
   '@osdk/legacy-client@2.5.6':
     resolution: {integrity: sha512-QPeCcuqCv+s6toIxWMRArKJx35bzvcpoKAqsQ6YYiFEiGn43vLoQQGbeMlnqcGYfdbljyzeOoDxZtgVIn6a8HA==}
@@ -9158,6 +9236,9 @@ packages:
 
   '@osdk/shared.net.platformapi@1.7.0':
     resolution: {integrity: sha512-11pbEVkQ5fbNcYOXfRDcVcbu5UVAHYp612a0WzGwUDV7IoHo5P4vFH8HtzvzfElyejrvXfO/MJHHb5WXbnk2sw==}
+
+  '@osdk/shared.net.platformapi@1.8.0':
+    resolution: {integrity: sha512-u9kqyKxRpffVSiJOo7O7pFQbL6JlbcbOM4b6Gpvjt2WRlTgyX+K/Ssr399xu2iSTPOC/7QPygUGyiSHzVApAEA==}
 
   '@osdk/shared.net@1.12.3':
     resolution: {integrity: sha512-LjUKKNMzfzqM6m9WdxpW+51GhEcMPYZ/KBlwuCf2P8leJ9R4vbZgGiSoKubc0r90icwbgoEp22D72CE1dwEeJg==}
@@ -14688,6 +14769,10 @@ packages:
 
   eventsource-parser@3.0.8:
     resolution: {integrity: sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==}
+    engines: {node: '>=18.0.0'}
+
+  eventsource-parser@3.1.1:
+    resolution: {integrity: sha512-EKN1vKAMcZ8MlYMpaNuxN6R9yakzH6uajHcHVTqWJzvu5pWw9DyhbP35HH8MVBQ+dZjAfDxk+A8NiR9KWaXiyQ==}
     engines: {node: '>=18.0.0'}
 
   exec-async@2.2.0:
@@ -26309,6 +26394,13 @@ snapshots:
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.7.0
 
+  '@osdk/foundry.admin@2.75.0':
+    dependencies:
+      '@osdk/foundry.core': 2.75.0
+      '@osdk/shared.client': 1.0.1
+      '@osdk/shared.client2': 1.0.0
+      '@osdk/shared.net.platformapi': 1.8.0
+
   '@osdk/foundry.aipagents@2.73.0':
     dependencies:
       '@osdk/foundry.core': 2.73.0
@@ -26318,12 +26410,28 @@ snapshots:
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.7.0
 
+  '@osdk/foundry.aipagents@2.75.0':
+    dependencies:
+      '@osdk/foundry.core': 2.75.0
+      '@osdk/foundry.functions': 2.75.0
+      '@osdk/foundry.ontologies': 2.75.0
+      '@osdk/shared.client': 1.0.1
+      '@osdk/shared.client2': 1.0.0
+      '@osdk/shared.net.platformapi': 1.8.0
+
   '@osdk/foundry.audit@2.73.0':
     dependencies:
       '@osdk/foundry.core': 2.73.0
       '@osdk/shared.client': 1.0.1
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.7.0
+
+  '@osdk/foundry.audit@2.75.0':
+    dependencies:
+      '@osdk/foundry.core': 2.75.0
+      '@osdk/shared.client': 1.0.1
+      '@osdk/shared.client2': 1.0.0
+      '@osdk/shared.net.platformapi': 1.8.0
 
   '@osdk/foundry.checkpoints@2.73.0':
     dependencies:
@@ -26332,6 +26440,13 @@ snapshots:
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.7.0
 
+  '@osdk/foundry.checkpoints@2.75.0':
+    dependencies:
+      '@osdk/foundry.core': 2.75.0
+      '@osdk/shared.client': 1.0.1
+      '@osdk/shared.client2': 1.0.0
+      '@osdk/shared.net.platformapi': 1.8.0
+
   '@osdk/foundry.connectivity@2.73.0':
     dependencies:
       '@osdk/foundry.core': 2.73.0
@@ -26339,6 +26454,14 @@ snapshots:
       '@osdk/shared.client': 1.0.1
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.7.0
+
+  '@osdk/foundry.connectivity@2.75.0':
+    dependencies:
+      '@osdk/foundry.core': 2.75.0
+      '@osdk/foundry.filesystem': 2.75.0
+      '@osdk/shared.client': 1.0.1
+      '@osdk/shared.client2': 1.0.0
+      '@osdk/shared.net.platformapi': 1.8.0
 
   '@osdk/foundry.core@2.44.0':
     dependencies:
@@ -26361,12 +26484,26 @@ snapshots:
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.7.0
 
+  '@osdk/foundry.core@2.75.0':
+    dependencies:
+      '@osdk/foundry.geo': 2.75.0
+      '@osdk/shared.client': 1.0.1
+      '@osdk/shared.client2': 1.0.0
+      '@osdk/shared.net.platformapi': 1.8.0
+
   '@osdk/foundry.datahealth@2.73.0':
     dependencies:
       '@osdk/foundry.core': 2.73.0
       '@osdk/shared.client': 1.0.1
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.7.0
+
+  '@osdk/foundry.datahealth@2.75.0':
+    dependencies:
+      '@osdk/foundry.core': 2.75.0
+      '@osdk/shared.client': 1.0.1
+      '@osdk/shared.client2': 1.0.0
+      '@osdk/shared.net.platformapi': 1.8.0
 
   '@osdk/foundry.datasets@2.5.0':
     dependencies:
@@ -26385,6 +26522,15 @@ snapshots:
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.7.0
 
+  '@osdk/foundry.datasets@2.75.0':
+    dependencies:
+      '@osdk/foundry.core': 2.75.0
+      '@osdk/foundry.datahealth': 2.75.0
+      '@osdk/foundry.filesystem': 2.75.0
+      '@osdk/shared.client': 1.0.1
+      '@osdk/shared.client2': 1.0.0
+      '@osdk/shared.net.platformapi': 1.8.0
+
   '@osdk/foundry.filesystem@2.5.0':
     dependencies:
       '@osdk/foundry.core': 2.5.0
@@ -26399,6 +26545,13 @@ snapshots:
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.7.0
 
+  '@osdk/foundry.filesystem@2.75.0':
+    dependencies:
+      '@osdk/foundry.core': 2.75.0
+      '@osdk/shared.client': 1.0.1
+      '@osdk/shared.client2': 1.0.0
+      '@osdk/shared.net.platformapi': 1.8.0
+
   '@osdk/foundry.functions@2.73.0':
     dependencies:
       '@osdk/foundry.core': 2.73.0
@@ -26406,6 +26559,14 @@ snapshots:
       '@osdk/shared.client': 1.0.1
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.7.0
+
+  '@osdk/foundry.functions@2.75.0':
+    dependencies:
+      '@osdk/foundry.core': 2.75.0
+      '@osdk/foundry.ontologies': 2.75.0
+      '@osdk/shared.client': 1.0.1
+      '@osdk/shared.client2': 1.0.0
+      '@osdk/shared.net.platformapi': 1.8.0
 
   '@osdk/foundry.geo@2.44.0':
     dependencies:
@@ -26425,11 +26586,23 @@ snapshots:
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.7.0
 
+  '@osdk/foundry.geo@2.75.0':
+    dependencies:
+      '@osdk/shared.client': 1.0.1
+      '@osdk/shared.client2': 1.0.0
+      '@osdk/shared.net.platformapi': 1.8.0
+
   '@osdk/foundry.geojson@2.73.0':
     dependencies:
       '@osdk/shared.client': 1.0.1
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.7.0
+
+  '@osdk/foundry.geojson@2.75.0':
+    dependencies:
+      '@osdk/shared.client': 1.0.1
+      '@osdk/shared.client2': 1.0.0
+      '@osdk/shared.net.platformapi': 1.8.0
 
   '@osdk/foundry.languagemodels@2.73.0':
     dependencies:
@@ -26437,6 +26610,13 @@ snapshots:
       '@osdk/shared.client': 1.0.1
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.7.0
+
+  '@osdk/foundry.languagemodels@2.75.0':
+    dependencies:
+      '@osdk/foundry.core': 2.75.0
+      '@osdk/shared.client': 1.0.1
+      '@osdk/shared.client2': 1.0.0
+      '@osdk/shared.net.platformapi': 1.8.0
 
   '@osdk/foundry.mediasets@2.44.0':
     dependencies:
@@ -26452,6 +26632,13 @@ snapshots:
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.7.0
 
+  '@osdk/foundry.mediasets@2.75.0':
+    dependencies:
+      '@osdk/foundry.core': 2.75.0
+      '@osdk/shared.client': 1.0.1
+      '@osdk/shared.client2': 1.0.0
+      '@osdk/shared.net.platformapi': 1.8.0
+
   '@osdk/foundry.models@2.73.0':
     dependencies:
       '@osdk/foundry.core': 2.73.0
@@ -26462,6 +26649,16 @@ snapshots:
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.7.0
 
+  '@osdk/foundry.models@2.75.0':
+    dependencies:
+      '@osdk/foundry.core': 2.75.0
+      '@osdk/foundry.filesystem': 2.75.0
+      '@osdk/foundry.ontologies': 2.75.0
+      '@osdk/foundry.orchestration': 2.75.0
+      '@osdk/shared.client': 1.0.1
+      '@osdk/shared.client2': 1.0.0
+      '@osdk/shared.net.platformapi': 1.8.0
+
   '@osdk/foundry.notepad@2.73.0':
     dependencies:
       '@osdk/foundry.core': 2.73.0
@@ -26470,6 +26667,15 @@ snapshots:
       '@osdk/shared.client': 1.0.1
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.7.0
+
+  '@osdk/foundry.notepad@2.75.0':
+    dependencies:
+      '@osdk/foundry.core': 2.75.0
+      '@osdk/foundry.filesystem': 2.75.0
+      '@osdk/foundry.ontologies': 2.75.0
+      '@osdk/shared.client': 1.0.1
+      '@osdk/shared.client2': 1.0.0
+      '@osdk/shared.net.platformapi': 1.8.0
 
   '@osdk/foundry.ontologies@2.44.0':
     dependencies:
@@ -26488,6 +26694,15 @@ snapshots:
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.7.0
 
+  '@osdk/foundry.ontologies@2.75.0':
+    dependencies:
+      '@osdk/foundry.core': 2.75.0
+      '@osdk/foundry.datasets': 2.75.0
+      '@osdk/foundry.geo': 2.75.0
+      '@osdk/shared.client': 1.0.1
+      '@osdk/shared.client2': 1.0.0
+      '@osdk/shared.net.platformapi': 1.8.0
+
   '@osdk/foundry.operations@2.73.0':
     dependencies:
       '@osdk/foundry.core': 2.73.0
@@ -26495,6 +26710,14 @@ snapshots:
       '@osdk/shared.client': 1.0.1
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.7.0
+
+  '@osdk/foundry.operations@2.75.0':
+    dependencies:
+      '@osdk/foundry.core': 2.75.0
+      '@osdk/foundry.ontologies': 2.75.0
+      '@osdk/shared.client': 1.0.1
+      '@osdk/shared.client2': 1.0.0
+      '@osdk/shared.net.platformapi': 1.8.0
 
   '@osdk/foundry.orchestration@2.73.0':
     dependencies:
@@ -26505,6 +26728,15 @@ snapshots:
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.7.0
 
+  '@osdk/foundry.orchestration@2.75.0':
+    dependencies:
+      '@osdk/foundry.core': 2.75.0
+      '@osdk/foundry.datasets': 2.75.0
+      '@osdk/foundry.filesystem': 2.75.0
+      '@osdk/shared.client': 1.0.1
+      '@osdk/shared.client2': 1.0.0
+      '@osdk/shared.net.platformapi': 1.8.0
+
   '@osdk/foundry.pack@2.73.0':
     dependencies:
       '@osdk/foundry.core': 2.73.0
@@ -26513,12 +26745,27 @@ snapshots:
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.7.0
 
+  '@osdk/foundry.pack@2.75.0':
+    dependencies:
+      '@osdk/foundry.core': 2.75.0
+      '@osdk/foundry.filesystem': 2.75.0
+      '@osdk/shared.client': 1.0.1
+      '@osdk/shared.client2': 1.0.0
+      '@osdk/shared.net.platformapi': 1.8.0
+
   '@osdk/foundry.publicapis@2.73.0':
     dependencies:
       '@osdk/foundry.core': 2.73.0
       '@osdk/shared.client': 1.0.1
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.7.0
+
+  '@osdk/foundry.publicapis@2.75.0':
+    dependencies:
+      '@osdk/foundry.core': 2.75.0
+      '@osdk/shared.client': 1.0.1
+      '@osdk/shared.client2': 1.0.0
+      '@osdk/shared.net.platformapi': 1.8.0
 
   '@osdk/foundry.sqlqueries@2.73.0':
     dependencies:
@@ -26529,6 +26776,15 @@ snapshots:
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.7.0
 
+  '@osdk/foundry.sqlqueries@2.75.0':
+    dependencies:
+      '@osdk/foundry.core': 2.75.0
+      '@osdk/foundry.datasets': 2.75.0
+      '@osdk/foundry.ontologies': 2.75.0
+      '@osdk/shared.client': 1.0.1
+      '@osdk/shared.client2': 1.0.0
+      '@osdk/shared.net.platformapi': 1.8.0
+
   '@osdk/foundry.streams@2.73.0':
     dependencies:
       '@osdk/foundry.core': 2.73.0
@@ -26538,6 +26794,15 @@ snapshots:
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.7.0
 
+  '@osdk/foundry.streams@2.75.0':
+    dependencies:
+      '@osdk/foundry.core': 2.75.0
+      '@osdk/foundry.datasets': 2.75.0
+      '@osdk/foundry.filesystem': 2.75.0
+      '@osdk/shared.client': 1.0.1
+      '@osdk/shared.client2': 1.0.0
+      '@osdk/shared.net.platformapi': 1.8.0
+
   '@osdk/foundry.thirdpartyapplications@2.73.0':
     dependencies:
       '@osdk/foundry.core': 2.73.0
@@ -26545,12 +26810,26 @@ snapshots:
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.7.0
 
+  '@osdk/foundry.thirdpartyapplications@2.75.0':
+    dependencies:
+      '@osdk/foundry.core': 2.75.0
+      '@osdk/shared.client': 1.0.1
+      '@osdk/shared.client2': 1.0.0
+      '@osdk/shared.net.platformapi': 1.8.0
+
   '@osdk/foundry.widgets@2.73.0':
     dependencies:
       '@osdk/foundry.core': 2.73.0
       '@osdk/shared.client': 1.0.1
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.7.0
+
+  '@osdk/foundry.widgets@2.75.0':
+    dependencies:
+      '@osdk/foundry.core': 2.75.0
+      '@osdk/shared.client': 1.0.1
+      '@osdk/shared.client2': 1.0.0
+      '@osdk/shared.net.platformapi': 1.8.0
 
   '@osdk/foundry@2.73.0':
     dependencies:
@@ -26583,6 +26862,37 @@ snapshots:
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.platformapi': 1.7.0
 
+  '@osdk/foundry@2.75.0':
+    dependencies:
+      '@osdk/foundry.admin': 2.75.0
+      '@osdk/foundry.aipagents': 2.75.0
+      '@osdk/foundry.audit': 2.75.0
+      '@osdk/foundry.checkpoints': 2.75.0
+      '@osdk/foundry.connectivity': 2.75.0
+      '@osdk/foundry.core': 2.75.0
+      '@osdk/foundry.datahealth': 2.75.0
+      '@osdk/foundry.datasets': 2.75.0
+      '@osdk/foundry.filesystem': 2.75.0
+      '@osdk/foundry.functions': 2.75.0
+      '@osdk/foundry.geo': 2.75.0
+      '@osdk/foundry.geojson': 2.75.0
+      '@osdk/foundry.languagemodels': 2.75.0
+      '@osdk/foundry.mediasets': 2.75.0
+      '@osdk/foundry.models': 2.75.0
+      '@osdk/foundry.notepad': 2.75.0
+      '@osdk/foundry.ontologies': 2.75.0
+      '@osdk/foundry.operations': 2.75.0
+      '@osdk/foundry.orchestration': 2.75.0
+      '@osdk/foundry.pack': 2.75.0
+      '@osdk/foundry.publicapis': 2.75.0
+      '@osdk/foundry.sqlqueries': 2.75.0
+      '@osdk/foundry.streams': 2.75.0
+      '@osdk/foundry.thirdpartyapplications': 2.75.0
+      '@osdk/foundry.widgets': 2.75.0
+      '@osdk/shared.client': 1.0.1
+      '@osdk/shared.client2': 1.0.0
+      '@osdk/shared.net.platformapi': 1.8.0
+
   '@osdk/gateway@2.4.2':
     dependencies:
       fetch-retry: 6.0.0
@@ -26593,34 +26903,34 @@ snapshots:
       '@osdk/api': 2.7.5
       '@osdk/foundry.ontologies': 2.44.0
 
-  '@osdk/internal.foundry.core@2.73.0':
+  '@osdk/internal.foundry.core@2.75.0':
     dependencies:
-      '@osdk/internal.foundry.geo': 2.73.0
+      '@osdk/internal.foundry.geo': 2.75.0
       '@osdk/shared.client': 1.0.1
       '@osdk/shared.client2': 1.0.0
-      '@osdk/shared.net.platformapi': 1.7.0
+      '@osdk/shared.net.platformapi': 1.8.0
 
-  '@osdk/internal.foundry.datasets@2.73.0':
+  '@osdk/internal.foundry.datasets@2.75.0':
     dependencies:
-      '@osdk/internal.foundry.core': 2.73.0
+      '@osdk/internal.foundry.core': 2.75.0
       '@osdk/shared.client': 1.0.1
       '@osdk/shared.client2': 1.0.0
-      '@osdk/shared.net.platformapi': 1.7.0
+      '@osdk/shared.net.platformapi': 1.8.0
 
-  '@osdk/internal.foundry.geo@2.73.0':
+  '@osdk/internal.foundry.geo@2.75.0':
     dependencies:
       '@osdk/shared.client': 1.0.1
       '@osdk/shared.client2': 1.0.0
-      '@osdk/shared.net.platformapi': 1.7.0
+      '@osdk/shared.net.platformapi': 1.8.0
 
-  '@osdk/internal.foundry.ontologies@2.73.0':
+  '@osdk/internal.foundry.ontologies@2.75.0':
     dependencies:
-      '@osdk/internal.foundry.core': 2.73.0
-      '@osdk/internal.foundry.datasets': 2.73.0
-      '@osdk/internal.foundry.geo': 2.73.0
+      '@osdk/internal.foundry.core': 2.75.0
+      '@osdk/internal.foundry.datasets': 2.75.0
+      '@osdk/internal.foundry.geo': 2.75.0
       '@osdk/shared.client': 1.0.1
       '@osdk/shared.client2': 1.0.0
-      '@osdk/shared.net.platformapi': 1.7.0
+      '@osdk/shared.net.platformapi': 1.8.0
 
   '@osdk/legacy-client@2.5.6':
     dependencies:
@@ -26684,6 +26994,13 @@ snapshots:
       '@osdk/shared.client': 1.0.1
       '@osdk/shared.client2': 1.0.0
       '@osdk/shared.net.errors': 2.5.0-beta.2
+
+  '@osdk/shared.net.platformapi@1.8.0':
+    dependencies:
+      '@osdk/shared.client': 1.0.1
+      '@osdk/shared.client2': 1.0.0
+      '@osdk/shared.net.errors': 2.5.0-beta.2
+      eventsource-parser: 3.1.1
 
   '@osdk/shared.net@1.12.3':
     dependencies:
@@ -33185,6 +33502,8 @@ snapshots:
   events@3.3.0: {}
 
   eventsource-parser@3.0.8: {}
+
+  eventsource-parser@3.1.1: {}
 
   exec-async@2.2.0: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -22,13 +22,13 @@ catalogs:
   foundry-platform-typescript:
     "@osdk/docs-spec-core": 0.6.0
     "@osdk/docs-spec-sdk": 0.17.0
-    "@osdk/foundry": 2.73.0
-    "@osdk/foundry.core": 2.73.0
+    "@osdk/foundry": 2.75.0
+    "@osdk/foundry.core": 2.75.0
     "@osdk/foundry.datasets": ~2.5.0
-    "@osdk/foundry.functions": 2.73.0
-    "@osdk/foundry.geo": 2.73.0
-    "@osdk/foundry.admin": 2.73.0
-    "@osdk/foundry.mediasets": 2.73.0
-    "@osdk/foundry.ontologies": 2.73.0
-    "@osdk/foundry.thirdpartyapplications": 2.73.0
-    "@osdk/internal.foundry.ontologies": 2.73.0
+    "@osdk/foundry.functions": 2.75.0
+    "@osdk/foundry.geo": 2.75.0
+    "@osdk/foundry.admin": 2.75.0
+    "@osdk/foundry.mediasets": 2.75.0
+    "@osdk/foundry.ontologies": 2.75.0
+    "@osdk/foundry.thirdpartyapplications": 2.75.0
+    "@osdk/internal.foundry.ontologies": 2.75.0


### PR DESCRIPTION
This PR reimplements support for queries with streamed responses, which were previously implemented in #3105 and removed in #3750. This new reimplementation uses an SSE stream rather than NDJSON as it was previously. The platform SDK versions were bumped as well to get the support added in the TS platform SDK.

Unit tests were added in the same way they were before, just swapped out NDJSON for SSE. I also tested end-to-end locally with the executeStreamingFunction method and it returned correctly.