### PR TITLE
Templates depend on @osdk/foundry with caret range

### DIFF
--- a/.changeset/easy-snakes-unite.md
+++ b/.changeset/easy-snakes-unite.md
@@ -1,0 +1,7 @@
+---
+"@osdk/create-app.template.react.beta": patch
+"@osdk/create-app.template.expo.v2": patch
+"@osdk/create-app.template.vue.v2": patch
+---
+
+Templates depend on @osdk/foundry with caret range

--- a/examples/example-expo-sdk-2.x-no-osdk/package.json
+++ b/examples/example-expo-sdk-2.x-no-osdk/package.json
@@ -21,7 +21,7 @@
     "@babel/runtime": "^7.28.4",
     "@expo/vector-icons": "^14.1.0",
     "@osdk/client": "workspace:*",
-    "@osdk/foundry": "latest",
+    "@osdk/foundry": "^2.75.0",
     "@osdk/oauth": "workspace:*",
     "@osdk/react": "workspace:*",
     "@react-navigation/bottom-tabs": "^7.4.7",

--- a/examples/example-expo-sdk-2.x/package.json
+++ b/examples/example-expo-sdk-2.x/package.json
@@ -22,7 +22,7 @@
     "@expo/vector-icons": "^14.1.0",
     "@osdk/client": "workspace:*",
     "@osdk/e2e.generated.catchall": "workspace:*",
-    "@osdk/foundry": "latest",
+    "@osdk/foundry": "^2.75.0",
     "@osdk/oauth": "workspace:*",
     "@osdk/react": "workspace:*",
     "@react-navigation/bottom-tabs": "^7.4.7",

--- a/examples/example-react-sdk-2.x-no-osdk/package.json
+++ b/examples/example-react-sdk-2.x-no-osdk/package.json
@@ -21,7 +21,7 @@
     "@blueprintjs/core": "^6.10.0",
     "@blueprintjs/icons": "^6.7.0",
     "@osdk/client": "workspace:*",
-    "@osdk/foundry": "latest",
+    "@osdk/foundry": "^2.75.0",
     "@osdk/oauth": "workspace:*",
     "@osdk/react": "workspace:*",
     "normalize.css": "^8.0.1",

--- a/examples/example-react-sdk-2.x/package.json
+++ b/examples/example-react-sdk-2.x/package.json
@@ -22,7 +22,7 @@
     "@blueprintjs/icons": "^6.7.0",
     "@osdk/client": "workspace:*",
     "@osdk/e2e.generated.catchall": "workspace:*",
-    "@osdk/foundry": "latest",
+    "@osdk/foundry": "^2.75.0",
     "@osdk/oauth": "workspace:*",
     "@osdk/react": "workspace:*",
     "normalize.css": "^8.0.1",

--- a/examples/example-vue-sdk-2.x-no-osdk/package.json
+++ b/examples/example-vue-sdk-2.x-no-osdk/package.json
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@osdk/client": "workspace:*",
-    "@osdk/foundry": "latest",
+    "@osdk/foundry": "^2.75.0",
     "@osdk/oauth": "workspace:*",
     "vue": "^3.5.21",
     "vue-router": "^4.5.1"

--- a/examples/example-vue-sdk-2.x/package.json
+++ b/examples/example-vue-sdk-2.x/package.json
@@ -16,7 +16,7 @@
   "dependencies": {
     "@osdk/client": "workspace:*",
     "@osdk/e2e.generated.catchall": "workspace:*",
-    "@osdk/foundry": "latest",
+    "@osdk/foundry": "^2.75.0",
     "@osdk/oauth": "workspace:*",
     "vue": "^3.5.21",
     "vue-router": "^4.5.1"

--- a/packages/create-app.template.expo.v2/templates/package.json.osdk.hbs
+++ b/packages/create-app.template.expo.v2/templates/package.json.osdk.hbs
@@ -16,7 +16,7 @@
   "dependencies": {
     "{{osdkPackage}}": "latest",
     "@osdk/client": "{{clientVersion}}",
-    "@osdk/foundry": "latest",
+    "@osdk/foundry": "^2.75.0",
     "@osdk/oauth": "^1.1.0",
     "@osdk/react": "^0.7.0",
     "@babel/runtime": "^7.26.0",

--- a/packages/create-app.template.expo.v2/templates/package.json.psdk.hbs
+++ b/packages/create-app.template.expo.v2/templates/package.json.psdk.hbs
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@osdk/client": "{{clientVersion}}",
-    "@osdk/foundry": "latest",
+    "@osdk/foundry": "^2.75.0",
     "@osdk/oauth": "^1.1.0",
     "@osdk/react": "^0.7.0",
     "@babel/runtime": "^7.26.0",

--- a/packages/create-app.template.react.beta/templates/package.json.osdk.hbs
+++ b/packages/create-app.template.react.beta/templates/package.json.osdk.hbs
@@ -16,7 +16,7 @@
   "dependencies": {
     "{{osdkPackage}}": "latest",
     "@osdk/client": "{{clientVersion}}",
-    "@osdk/foundry": "latest",
+    "@osdk/foundry": "^2.75.0",
     "@osdk/oauth": "^1.1.0",
     "@osdk/react": "{{clientVersion}}",
     "@blueprintjs/core": "^6.8.1",

--- a/packages/create-app.template.react.beta/templates/package.json.psdk.hbs
+++ b/packages/create-app.template.react.beta/templates/package.json.psdk.hbs
@@ -15,7 +15,7 @@
   },
   "dependencies": {
     "@osdk/client": "{{clientVersion}}",
-    "@osdk/foundry": "latest",
+    "@osdk/foundry": "^2.75.0",
     "@osdk/oauth": "^1.1.0",
     "@osdk/react": "{{clientVersion}}",
     "@blueprintjs/core": "^6.8.1",

--- a/packages/create-app.template.vue.v2/templates/package.json.osdk.hbs
+++ b/packages/create-app.template.vue.v2/templates/package.json.osdk.hbs
@@ -12,7 +12,7 @@
   "dependencies": {
     "{{osdkPackage}}": "latest",
     "@osdk/client": "{{clientVersion}}",
-    "@osdk/foundry": "latest",
+    "@osdk/foundry": "^2.75.0",
     "@osdk/oauth": "^1.1.0"
   }
 }

--- a/packages/create-app.template.vue.v2/templates/package.json.psdk.hbs
+++ b/packages/create-app.template.vue.v2/templates/package.json.psdk.hbs
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@osdk/client": "{{clientVersion}}",
-    "@osdk/foundry": "latest",
+    "@osdk/foundry": "^2.75.0",
     "@osdk/oauth": "^1.1.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -428,8 +428,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/e2e.generated.catchall
       '@osdk/foundry':
-        specifier: latest
-        version: 2.73.0
+        specifier: ^2.75.0
+        version: 2.75.0
       '@osdk/oauth':
         specifier: workspace:*
         version: link:../../packages/oauth
@@ -618,8 +618,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/client
       '@osdk/foundry':
-        specifier: latest
-        version: 2.73.0
+        specifier: ^2.75.0
+        version: 2.75.0
       '@osdk/oauth':
         specifier: workspace:*
         version: link:../../packages/oauth
@@ -881,8 +881,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/e2e.generated.catchall
       '@osdk/foundry':
-        specifier: latest
-        version: 2.73.0
+        specifier: ^2.75.0
+        version: 2.75.0
       '@osdk/oauth':
         specifier: workspace:*
         version: link:../../packages/oauth
@@ -984,8 +984,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/client
       '@osdk/foundry':
-        specifier: latest
-        version: 2.73.0
+        specifier: ^2.75.0
+        version: 2.75.0
       '@osdk/oauth':
         specifier: workspace:*
         version: link:../../packages/oauth
@@ -1428,8 +1428,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/e2e.generated.catchall
       '@osdk/foundry':
-        specifier: latest
-        version: 2.73.0
+        specifier: ^2.75.0
+        version: 2.75.0
       '@osdk/oauth':
         specifier: workspace:*
         version: link:../../packages/oauth
@@ -1465,8 +1465,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/client
       '@osdk/foundry':
-        specifier: latest
-        version: 2.73.0
+        specifier: ^2.75.0
+        version: 2.75.0
       '@osdk/oauth':
         specifier: workspace:*
         version: link:../../packages/oauth


### PR DESCRIPTION
Currently templates depend on @osdk/foundry at latest which means that `npm ci` from a lockfile will never be clean if a new version gets published