### PR TITLE
Default OTDP flag to None

### DIFF
--- a/.changeset/forty-cities-dream.md
+++ b/.changeset/forty-cities-dream.md
@@ -9,4 +9,4 @@
 "@osdk/api": patch
 ---
 
-Bump platform SDKs and add loadOntologyDefinedDerivedProperties flag, which defaults to true
+Bump platform SDKs and add the optional loadOntologyDefinedDerivedProperties flag, which defaults to true

--- a/.changeset/forty-cities-dream.md
+++ b/.changeset/forty-cities-dream.md
@@ -9,4 +9,4 @@
 "@osdk/api": patch
 ---
 
-Bump platform SDKs and add the optional loadOntologyDefinedDerivedProperties flag, which defaults to true
+Bump platform SDKs and add loadOntologyDefinedDerivedProperties flag, which defaults to true

--- a/.changeset/six-sloths-battle.md
+++ b/.changeset/six-sloths-battle.md
@@ -1,0 +1,5 @@
+---
+"@osdk/client": patch
+---
+
+Default the loadOntologyDefinedDerivedProperties flag to None

--- a/packages/client/src/object/fetchPage.ts
+++ b/packages/client/src/object/fetchPage.ts
@@ -673,8 +673,10 @@ async function applyFetchArgs<
     body.loadPropertySecurities = true;
   }
 
-  body.loadOntologyDefinedDerivedProperties =
-    args?.$UNSTABLE_loadOntologyDefinedDerivedProperties ?? true;
+  if (args?.$UNSTABLE_loadOntologyDefinedDerivedProperties != null) {
+    body.loadOntologyDefinedDerivedProperties =
+      args.$UNSTABLE_loadOntologyDefinedDerivedProperties;
+  }
 
   const orderBy = args?.$orderBy;
   if (orderBy) {


### PR DESCRIPTION
Previously in #3852 , we defaulted the flag to `True`. However, we want to keep a single source of truth and allow API gateway to determine what the default behavior should be, so it now defaults to `None`