### PR TITLE
Stop generating input shapes for SPT backed interface props

### DIFF
--- a/.changeset/sixty-lamps-win.md
+++ b/.changeset/sixty-lamps-win.md
@@ -1,0 +1,5 @@
+---
+"@osdk/maker-experimental": patch
+---
+
+Stop generating input shapes for spt-backed interface props

--- a/packages/maker-experimental/src/api/overall.test.ts
+++ b/packages/maker-experimental/src/api/overall.test.ts
@@ -1255,29 +1255,29 @@ describe("Experimental Test Suite", () => {
           interfaceApiName,
           sptApiName,
         );
+      const sptReadableId = ReadableIdGenerator.getForSpt(sptApiName);
       const interfaceShape = result.shapes.inputShapes.get(interfaceReadableId);
       const interfacePropertyShape = result.shapes.inputShapes.get(
         interfacePropertyReadableId,
       );
+      const sptShape = result.shapes.inputShapes.get(sptReadableId);
       expect(interfaceShape).toMatchObject({
         type: "interfaceType",
         interfaceType: {
           properties: [expect.any(String)],
-          propertiesV2: [expect.any(String)],
+          propertiesV2: [],
         },
       });
-      expect(interfacePropertyShape).toMatchObject({
-        type: "interfacePropertyType",
-        interfacePropertyType: {
+      expect(interfacePropertyShape).toBeUndefined();
+      expect(sptShape).toMatchObject({
+        type: "sharedPropertyType",
+        sharedPropertyType: {
           about: { fallbackTitle: sptApiName },
-          interfaceType: expect.any(String),
-          sharedPropertyType: expect.any(String),
-          requireImplementation: true,
         },
       });
-      expect(
-        result.importedInputPresets.get(interfacePropertyReadableId),
-      ).toEqual(apiNamePreset(sptApiName));
+      expect(result.importedInputPresets.get(sptReadableId)).toEqual(
+        apiNamePreset(sptApiName),
+      );
     });
   });
 

--- a/packages/maker-experimental/src/conversion/toMarketplace/shapeExtractors/ImportedShapeExtractor.ts
+++ b/packages/maker-experimental/src/conversion/toMarketplace/shapeExtractors/ImportedShapeExtractor.ts
@@ -359,20 +359,14 @@ function extractImportedInterfaceTypes(
     for (const [propertyRid, property] of Object.entries(
       interfaceType.propertiesV3 ?? {},
     )) {
-      const propReadableId =
-        property.type === "sharedPropertyBasedPropertyType"
-          ? ReadableIdGenerator.getForSptBackedInterfaceProperty(
-              interfaceType.apiName,
-              property.sharedPropertyBasedPropertyType.sharedPropertyType
-                .apiName,
-            )
-          : ridGenerator
-              .getInterfacePropertyTypeRids()
-              .inverse()
-              .get(propertyRid);
+      if (property.type !== "interfaceDefinedPropertyType") continue;
+      const propReadableId = ridGenerator
+        .getInterfacePropertyTypeRids()
+        .inverse()
+        .get(propertyRid);
       if (!propReadableId) {
         throw new Error(
-          `Missing readable ID for interface property RID ${propertyRid} on interface ${interfaceType.apiName}`,
+          `Missing readable ID for interface-defined property RID ${propertyRid} on interface ${interfaceType.apiName}`,
         );
       }
       propertiesV2.push(ridGenerator.toBlockInternalId(propReadableId));
@@ -442,71 +436,47 @@ function extractImportedInterfaceTypes(
       });
     }
 
-    // Generate interface property type input shapes
+    // Generate interface-defined property type input shapes. SPT-backed
+    // properties are represented by their shared property type input shapes.
     for (const [propertyRid, property] of Object.entries(
       interfaceType.propertiesV3 ?? {},
     )) {
-      let propReadableId: ReadableId;
-      let propApiName: string;
-      let propInputShape: InterfacePropertyTypeInputShape;
-      if (property.type === "interfaceDefinedPropertyType") {
-        const registeredReadableId = ridGenerator
-          .getInterfacePropertyTypeRids()
-          .inverse()
-          .get(propertyRid);
-        if (!registeredReadableId) {
-          throw new Error(
-            `Missing readable ID for interface-defined property RID ${propertyRid} on interface ${interfaceType.apiName}`,
-          );
-        }
-        propReadableId = registeredReadableId;
-        propApiName = property.interfaceDefinedPropertyType.apiName;
-        propInputShape = {
-          about: createLocalizedAbout(
-            property.interfaceDefinedPropertyType.displayMetadata.displayName,
-            property.interfaceDefinedPropertyType.displayMetadata.description ??
-              "",
-          ),
-          type: {
-            type: "objectPropertyType",
-            objectPropertyType: typeToMarketplaceObjectPropertyType(
-              property.interfaceDefinedPropertyType.type,
-            ),
-          },
-          interfaceType: ridGenerator.toBlockInternalId(interfaceReadableId),
-          requireImplementation:
-            property.interfaceDefinedPropertyType.constraints
-              .requireImplementation,
-        };
-      } else {
-        const spt = property.sharedPropertyBasedPropertyType.sharedPropertyType;
-        propReadableId = ReadableIdGenerator.getForSptBackedInterfaceProperty(
-          interfaceType.apiName,
-          spt.apiName,
+      if (property.type !== "interfaceDefinedPropertyType") continue;
+      const propReadableId = ridGenerator
+        .getInterfacePropertyTypeRids()
+        .inverse()
+        .get(propertyRid);
+      if (!propReadableId) {
+        throw new Error(
+          `Missing readable ID for interface-defined property RID ${propertyRid} on interface ${interfaceType.apiName}`,
         );
-        propApiName = spt.apiName;
-        propInputShape = {
-          about: createLocalizedAbout(
-            spt.displayMetadata.displayName,
-            spt.displayMetadata.description ?? "",
-          ),
-          type: {
-            type: "objectPropertyType",
-            objectPropertyType: typeToMarketplaceObjectPropertyType(spt.type),
-          },
-          interfaceType: ridGenerator.toBlockInternalId(interfaceReadableId),
-          requireImplementation:
-            property.sharedPropertyBasedPropertyType.requireImplementation,
-          sharedPropertyType: ridGenerator.toBlockInternalId(
-            ReadableIdGenerator.getForSpt(spt.apiName),
-          ),
-        };
       }
+      const propInputShape: InterfacePropertyTypeInputShape = {
+        about: createLocalizedAbout(
+          property.interfaceDefinedPropertyType.displayMetadata.displayName,
+          property.interfaceDefinedPropertyType.displayMetadata.description ??
+            "",
+        ),
+        type: {
+          type: "objectPropertyType",
+          objectPropertyType: typeToMarketplaceObjectPropertyType(
+            property.interfaceDefinedPropertyType.type,
+          ),
+        },
+        interfaceType: ridGenerator.toBlockInternalId(interfaceReadableId),
+        requireImplementation:
+          property.interfaceDefinedPropertyType.constraints
+            .requireImplementation,
+      };
       blockShapes.inputShapes.set(propReadableId, {
         type: "interfacePropertyType",
         interfacePropertyType: propInputShape,
       });
-      addApiNamePreset(blockShapes, propReadableId, propApiName);
+      addApiNamePreset(
+        blockShapes,
+        propReadableId,
+        property.interfaceDefinedPropertyType.apiName,
+      );
     }
 
     // Generate interface link type input shapes


### PR DESCRIPTION
https://github.com/palantir/osdk-ts/pull/3826 overeagerly generated input shapes for spt backed interface props. Our java implementation intentionally doesn't do this since we don't have a good way of determining the upstream readable id due to the custom logic we introduced for them. We don't need these input shapes at the moment