### PR TITLE
Version Packages

### DIFF
--- a/.changeset/sixty-lamps-win.md
+++ b/.changeset/sixty-lamps-win.md
@@ -1,5 +1,0 @@
----
-"@osdk/maker-experimental": patch
----
-
-Stop generating input shapes for spt-backed interface props

--- a/packages/maker-experimental/CHANGELOG.md
+++ b/packages/maker-experimental/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/maker-experimental
 
+## 0.53.0
+
+### Minor Changes
+
+- 32cd3f8: Stop generating input shapes for spt-backed interface props
+
 ## 0.52.0
 
 ### Minor Changes

--- a/packages/maker-experimental/package.json
+++ b/packages/maker-experimental/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/maker-experimental",
-  "version": "0.52.0",
+  "version": "0.53.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR was opened by automation. When you're ready to do a release, you can merge this and publish to npm yourself.
     If you're not ready to do a release yet, that's fine, whenever you re-run the release script in main, this PR will be updated.


# Releases
## @osdk/maker-experimental@0.53.0

### Minor Changes

-   32cd3f8: Stop generating input shapes for spt-backed interface props
