### PR TITLE
Move @arethetypeswrong/cli to devDependencies

### DIFF
--- a/.changeset/attw-dev-dependency.md
+++ b/.changeset/attw-dev-dependency.md
@@ -1,0 +1,6 @@
+---
+"@osdk/cli.cmd.typescript": patch
+"@osdk/cli": patch
+---
+
+Move @arethetypeswrong/cli to devDependencies so installing the CLI no longer pulls in a check-only tool

--- a/packages/cli.cmd.typescript/package.json
+++ b/packages/cli.cmd.typescript/package.json
@@ -34,7 +34,6 @@
     "typecheck": "tsc --noEmit --emitDeclarationOnly false"
   },
   "dependencies": {
-    "@arethetypeswrong/cli": "^0.17.4",
     "@osdk/cli.common": "workspace:~",
     "@osdk/foundry.ontologies": "catalog:foundry-platform-typescript",
     "@osdk/generator": "workspace:~",
@@ -46,6 +45,7 @@
     "yargs": "^17.7.2"
   },
   "devDependencies": {
+    "@arethetypeswrong/cli": "^0.17.4",
     "@osdk/monorepo.api-extractor": "workspace:~",
     "@osdk/monorepo.tsconfig": "workspace:~",
     "@types/node": "^18.19.124",

--- a/packages/cli.cmd.typescript/src/generate/handleGenerate.mts
+++ b/packages/cli.cmd.typescript/src/generate/handleGenerate.mts
@@ -322,7 +322,7 @@ export async function getDependencyVersions(): Promise<{
   const typescriptVersion = ourPackageJson.devDependencies.typescript;
   const tslibVersion = ourPackageJson.dependencies.tslib;
   const areTheTypesWrongVersion =
-    ourPackageJson.dependencies["@arethetypeswrong/cli"];
+    ourPackageJson.devDependencies["@arethetypeswrong/cli"];
   const osdkClientVersion = `^${process.env.PACKAGE_CLIENT_VERSION}`;
   const osdkApiVersion = `^${process.env.PACKAGE_API_VERSION}`;
   const osdkLegacyClientVersion = `^${process.env.PACKAGE_LEGACY_CLIENT_VERSION}`;

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -38,7 +38,6 @@
     "typecheck": "tsc --noEmit --emitDeclarationOnly false"
   },
   "dependencies": {
-    "@arethetypeswrong/cli": "0.17.3",
     "@osdk/foundry-config-json": "workspace:*",
     "@osdk/shared.net.errors": "workspace:*",
     "@osdk/shared.net.fetch": "workspace:*",
@@ -56,6 +55,7 @@
     "yargs": "17.7.2"
   },
   "devDependencies": {
+    "@arethetypeswrong/cli": "0.17.3",
     "@osdk/cli.cmd.typescript": "workspace:~",
     "@osdk/cli.common": "workspace:~",
     "@osdk/monorepo.api-extractor": "workspace:~",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1794,9 +1794,6 @@ importers:
 
   packages/cli:
     dependencies:
-      '@arethetypeswrong/cli':
-        specifier: 0.17.3
-        version: 0.17.3
       '@osdk/foundry-config-json':
         specifier: workspace:*
         version: link:../foundry-config-json
@@ -1843,6 +1840,9 @@ importers:
         specifier: 17.7.2
         version: 17.7.2
     devDependencies:
+      '@arethetypeswrong/cli':
+        specifier: 0.17.3
+        version: 0.17.3
       '@osdk/cli.cmd.typescript':
         specifier: workspace:~
         version: link:../cli.cmd.typescript
@@ -1882,9 +1882,6 @@ importers:
 
   packages/cli.cmd.typescript:
     dependencies:
-      '@arethetypeswrong/cli':
-        specifier: ^0.17.4
-        version: 0.17.4
       '@osdk/cli.common':
         specifier: workspace:~
         version: link:../cli.common
@@ -1913,6 +1910,9 @@ importers:
         specifier: ^17.7.2
         version: 17.7.2
     devDependencies:
+      '@arethetypeswrong/cli':
+        specifier: ^0.17.4
+        version: 0.17.4
       '@osdk/monorepo.api-extractor':
         specifier: workspace:~
         version: link:../monorepo.api-extractor


### PR DESCRIPTION
`@arethetypeswrong/cli` was listed in the runtime `dependencies` of both `@osdk/cli` and `@osdk/cli.cmd.typescript`, which meant every consumer installing the CLI also pulled down a package that is only ever used as a build-time check — attw packs a package as npm would and verifies its shipped type declarations resolve correctly for consumers, and it is invoked solely through the per-package `check-attw` script that monorepolint generates and `turbo` runs in CI. 

It is safe to drop from `dependencies` because nothing imports or executes it at runtime; the only reason it lived there was that `getDependencyVersions()` in `handleGenerate.mts` read `ourPackageJson.dependencies["@arethetypeswrong/cli"]` purely as a version-string lookup, so that generating a standalone SDK with `--asPackage` could stamp a matching attw pin into the generated package's own `devDependencies` (alongside its `check-attw` script) — the field was being used as a lookup table. I don't think anyone is usinf --asPackage