### PR TITLE
Fix RDP Object Set loading states when combined with other query loads

### DIFF
--- a/.changeset/tidy-cats-load.md
+++ b/.changeset/tidy-cats-load.md
@@ -1,0 +1,5 @@
+---
+"@osdk/client": patch
+---
+
+Keep observable object set queries loading until objects for their exact derived-property configuration are available.

--- a/packages/client/src/observable/internal/object/ObjectsHelper.test.ts
+++ b/packages/client/src/observable/internal/object/ObjectsHelper.test.ts
@@ -269,6 +269,49 @@ describe("ObjectsHelper.propagateWrite RDP merge", () => {
     store.cacheKeys.release(queryWithRdp.cacheKey);
   });
 
+  it("loads an object with no RDPs from an RDP write without derived fields", () => {
+    const rdpConfig = createFakeRdpConfig("derivedAddress");
+    const queryWithRdp = store.objects.getQuery(
+      {
+        apiName: Employee,
+        pk: 1,
+      },
+      rdpConfig,
+    );
+    const queryNoRdp = store.objects.getQuery({
+      apiName: Employee,
+      pk: 1,
+    });
+    store.cacheKeys.retain(queryNoRdp.cacheKey);
+    const subscription = store.subjects
+      .get(queryNoRdp.cacheKey)
+      .subscribe(() => {});
+    store.batch({}, (batch) => {
+      queryNoRdp.writeToStore(emp as any, "loading", batch);
+    });
+    const rdpValue = emp.$clone({
+      fullName: "Bob",
+      derivedAddress: "123 Main St",
+    } as any);
+
+    store.batch({}, (batch) => {
+      queryWithRdp.writeToStore(rdpValue as any, "loaded", batch);
+    });
+
+    expect(store.getValue(queryNoRdp.cacheKey)).toMatchObject({
+      status: "loaded",
+      value: {
+        $primaryKey: 1,
+        fullName: "Bob",
+      },
+    });
+    expect(
+      (store.getValue(queryNoRdp.cacheKey)?.value as any)?.derivedAddress,
+    ).toBeUndefined();
+    subscription.unsubscribe();
+    store.cacheKeys.release(queryNoRdp.cacheKey);
+  });
+
   it("keeps the recomputed derived value on a $select refetch", () => {
     const rdpConfig = createFakeRdpConfig("derivedAddress");
     const queryB = store.objects.getQuery(

--- a/packages/client/src/observable/internal/objectset/ObjectSetQuery.test.ts
+++ b/packages/client/src/observable/internal/objectset/ObjectSetQuery.test.ts
@@ -1,0 +1,193 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { ObjectSet } from "@osdk/api";
+import { Employee } from "@osdk/client.test.ontology";
+import { FauxFoundry, ontologies, startNodeApiServer } from "@osdk/shared.test";
+import { beforeAll, beforeEach, describe, expect, it, vitest } from "vitest";
+
+import type { Client } from "../../../Client.js";
+import { createClient } from "../../../createClient.js";
+import type { ObjectHolder } from "../../../object/convertWireToOsdkObjects/ObjectHolder.js";
+import { createChangedObjects } from "../Changes.js";
+import { createOptimisticId } from "../OptimisticId.js";
+import { Store } from "../Store.js";
+
+describe("ObjectSetQuery cache reconciliation", () => {
+  let client: Client;
+  let store: Store;
+
+  beforeAll(() => {
+    const testSetup = startNodeApiServer(
+      new FauxFoundry("https://stack.palantir.com/"),
+      createClient,
+    );
+    client = testSetup.client;
+
+    const fauxOntology = testSetup.fauxFoundry.getDefaultOntology();
+    ontologies.addEmployeeOntology(fauxOntology);
+
+    return () => {
+      testSetup.apiServer.close();
+    };
+  });
+
+  beforeEach(() => {
+    store = new Store(client);
+  });
+
+  function getRdpQuery() {
+    return store.objectSets.getQuery({
+      baseObjectSet: client(Employee) as ObjectSet<typeof Employee>,
+      withProperties: {
+        derivedName: (base) => base.pivotTo("lead").selectProperty("fullName"),
+      },
+      mode: "offline",
+    });
+  }
+
+  function createEmployee(): ObjectHolder {
+    return {
+      $apiName: Employee.apiName,
+      $objectType: Employee.apiName,
+      $primaryKey: 1,
+    } as unknown as ObjectHolder;
+  }
+
+  function createChanges(employee: ObjectHolder, isNew: boolean = true) {
+    const sourceQuery = store.objects.getQuery({
+      apiName: Employee,
+      pk: employee.$primaryKey,
+    });
+    const changes = createChangedObjects();
+    changes.registerObject(sourceQuery.cacheKey, employee, isNew);
+    return changes;
+  }
+
+  it.each([
+    ["adds", true],
+    ["modifies", false],
+  ])(
+    "keeps an RDP query loading when a sibling %s an unavailable cache variant",
+    (_change, isNew) => {
+      const query = getRdpQuery();
+      store.batch({}, (batch) =>
+        query.writeToStore({ data: [] }, "loading", batch),
+      );
+      const revalidate = vitest.spyOn(query, "revalidate").mockResolvedValue();
+
+      query.maybeUpdateAndRevalidate(
+        createChanges(createEmployee(), isNew),
+        undefined,
+      );
+
+      expect(revalidate).toHaveBeenCalledWith(true);
+      expect(store.getValue(query.cacheKey)).toMatchObject({
+        status: "loading",
+        value: { data: [] },
+      });
+    },
+  );
+
+  it("locally adds an object when the exact RDP cache variant is available", () => {
+    const query = getRdpQuery();
+    const employee = createEmployee();
+    const targetObjectQuery = store.objects.getQuery(
+      { apiName: Employee, pk: employee.$primaryKey },
+      query.rdpConfig,
+    );
+    store.batch({}, (batch) => {
+      batch.write(targetObjectQuery.cacheKey, employee, "loaded");
+      batch.write(query.cacheKey, { data: [] }, "loaded");
+    });
+    const revalidate = vitest.spyOn(query, "revalidate").mockResolvedValue();
+
+    query.maybeUpdateAndRevalidate(createChanges(employee), undefined);
+
+    expect(revalidate).not.toHaveBeenCalled();
+    expect(store.getValue(query.cacheKey)).toMatchObject({
+      status: "loaded",
+      value: { data: [targetObjectQuery.cacheKey] },
+    });
+  });
+
+  it("keeps an RDP query loading while its own fetch is pending", () => {
+    const query = getRdpQuery();
+    const employee = createEmployee();
+    const targetObjectQuery = store.objects.getQuery(
+      { apiName: Employee, pk: employee.$primaryKey },
+      query.rdpConfig,
+    );
+    store.batch({}, (batch) => {
+      batch.write(targetObjectQuery.cacheKey, employee, "loaded");
+      batch.write(query.cacheKey, { data: [] }, "loading");
+    });
+    query.pendingFetch = Promise.resolve();
+    const revalidate = vitest.spyOn(query, "revalidate").mockResolvedValue();
+
+    query.maybeUpdateAndRevalidate(createChanges(employee), undefined);
+
+    expect(revalidate).not.toHaveBeenCalled();
+    expect(store.getValue(query.cacheKey)).toMatchObject({
+      status: "loading",
+      value: { data: [targetObjectQuery.cacheKey] },
+    });
+    query.pendingFetch = undefined;
+  });
+
+  it("does not restore loading after a pending fetch has written its result", () => {
+    const query = getRdpQuery();
+    const employee = createEmployee();
+    const targetObjectQuery = store.objects.getQuery(
+      { apiName: Employee, pk: employee.$primaryKey },
+      query.rdpConfig,
+    );
+    store.batch({}, (batch) => {
+      batch.write(targetObjectQuery.cacheKey, employee, "loaded");
+      batch.write(query.cacheKey, { data: [] }, "loaded");
+    });
+    query.pendingFetch = Promise.resolve();
+    const revalidate = vitest.spyOn(query, "revalidate").mockResolvedValue();
+
+    query.maybeUpdateAndRevalidate(createChanges(employee), undefined);
+
+    expect(revalidate).not.toHaveBeenCalled();
+    expect(store.getValue(query.cacheKey)).toMatchObject({
+      status: "loaded",
+      value: { data: [targetObjectQuery.cacheKey] },
+    });
+    query.pendingFetch = undefined;
+  });
+
+  it("does not revalidate a missing RDP cache variant during an optimistic update", () => {
+    const query = getRdpQuery();
+    store.batch({}, (batch) =>
+      query.writeToStore({ data: [] }, "loaded", batch),
+    );
+    const revalidate = vitest.spyOn(query, "revalidate").mockResolvedValue();
+
+    query.maybeUpdateAndRevalidate(
+      createChanges(createEmployee()),
+      createOptimisticId(),
+    );
+
+    expect(revalidate).not.toHaveBeenCalled();
+    expect(store.getValue(query.cacheKey)).toMatchObject({
+      status: "loading",
+      value: { data: [] },
+    });
+  });
+});

--- a/packages/client/src/observable/internal/objectset/ObjectSetQuery.test.ts
+++ b/packages/client/src/observable/internal/objectset/ObjectSetQuery.test.ts
@@ -23,6 +23,7 @@ import type { Client } from "../../../Client.js";
 import { createClient } from "../../../createClient.js";
 import type { ObjectHolder } from "../../../object/convertWireToOsdkObjects/ObjectHolder.js";
 import { createChangedObjects } from "../Changes.js";
+import type { ObjectCacheKey } from "../object/ObjectCacheKey.js";
 import { createOptimisticId } from "../OptimisticId.js";
 import { Store } from "../Store.js";
 
@@ -84,17 +85,32 @@ describe("ObjectSetQuery cache reconciliation", () => {
     "keeps an RDP query loading when a sibling %s an unavailable cache variant",
     (_change, isNew) => {
       const query = getRdpQuery();
+      const employee = createEmployee();
       store.batch({}, (batch) =>
         query.writeToStore({ data: [] }, "loading", batch),
       );
       const revalidate = vitest.spyOn(query, "revalidate").mockResolvedValue();
 
-      query.maybeUpdateAndRevalidate(
-        createChanges(createEmployee(), isNew),
-        undefined,
-      );
+      expect(
+        store.cacheKeys.peek<ObjectCacheKey>(
+          "object",
+          Employee.apiName,
+          employee.$primaryKey,
+          query.rdpConfig,
+        ),
+      ).toBeUndefined();
+
+      query.maybeUpdateAndRevalidate(createChanges(employee, isNew), undefined);
 
       expect(revalidate).toHaveBeenCalledWith(true);
+      expect(
+        store.cacheKeys.peek<ObjectCacheKey>(
+          "object",
+          Employee.apiName,
+          employee.$primaryKey,
+          query.rdpConfig,
+        ),
+      ).toBeUndefined();
       expect(store.getValue(query.cacheKey)).toMatchObject({
         status: "loading",
         value: { data: [] },

--- a/packages/client/src/observable/internal/objectset/ObjectSetQuery.ts
+++ b/packages/client/src/observable/internal/objectset/ObjectSetQuery.ts
@@ -405,17 +405,11 @@ export class ObjectSetQuery extends BaseListQuery<
       effectiveWhere,
     );
 
-    const status =
-      optimisticId ||
-      addedMatches.uncertain.size > 0 ||
-      modifiedMatches.uncertain.size > 0
-        ? "loading"
-        : "loaded";
-
     const { retVal: needsRevalidation } = this.store.batch(
       { optimisticId, changes },
       (batch) => {
-        const existingKeys = new Set(batch.read(this.cacheKey)?.value?.data);
+        const existingEntry = batch.read(this.cacheKey);
+        const existingKeys = new Set(existingEntry?.value?.data);
 
         const { newList, needsRevalidation } = reconcileListChanges(
           existingKeys,
@@ -425,9 +419,22 @@ export class ObjectSetQuery extends BaseListQuery<
           changes.deleted,
           batch.optimisticWrite,
           (obj) => this.#getObjectCacheKey(obj),
+          (key) => {
+            const value = batch.read(key)?.value;
+            return value != null && typeof value === "object";
+          },
         );
 
-        const existingTotalCount = batch.read(this.cacheKey)?.value?.totalCount;
+        const status =
+          (this.pendingFetch != null && existingEntry?.status === "loading") ||
+          needsRevalidation ||
+          optimisticId ||
+          addedMatches.uncertain.size > 0 ||
+          modifiedMatches.uncertain.size > 0
+            ? "loading"
+            : "loaded";
+
+        const existingTotalCount = existingEntry?.value?.totalCount;
         this._updateList(
           newList,
           status,
@@ -440,7 +447,7 @@ export class ObjectSetQuery extends BaseListQuery<
       },
     );
 
-    if (needsRevalidation) {
+    if (needsRevalidation && !optimisticId) {
       return this.revalidate(true);
     }
     return undefined;
@@ -543,18 +550,30 @@ function reconcileListChanges(
   deleted: ReadonlySet<CacheKey>,
   isOptimistic: boolean,
   getObjectCacheKey: (obj: ObjectHolder | InterfaceHolder) => ObjectCacheKey,
+  hasCachedObject: (key: ObjectCacheKey) => boolean,
 ): { newList: ObjectCacheKey[]; needsRevalidation: boolean } {
-  const objectsToInsert = new Set<ObjectHolder | InterfaceHolder>(
-    addedDefiniteMatches,
-  );
+  const objectsToInsert = new Set<ObjectHolder | InterfaceHolder>();
   const keysToRemove = new Set<CacheKey>(deleted);
 
   let needsRevalidation = false;
+  const addIfAvailable = (obj: ObjectHolder | InterfaceHolder): void => {
+    const key = getObjectCacheKey(obj);
+    if (existingKeys.has(key)) {
+      return;
+    }
+    if (hasCachedObject(key)) {
+      objectsToInsert.add(obj);
+    } else {
+      needsRevalidation = true;
+    }
+  };
+
+  for (const obj of addedDefiniteMatches) {
+    addIfAvailable(obj);
+  }
   for (const obj of modifiedObjects) {
     if (modifiedMatches.definite.has(obj)) {
-      if (!existingKeys.has(getObjectCacheKey(obj))) {
-        objectsToInsert.add(obj);
-      }
+      addIfAvailable(obj);
     } else if (!isOptimistic) {
       keysToRemove.add(getObjectCacheKey(obj));
       if (modifiedMatches.uncertain.has(obj)) {

--- a/packages/client/src/observable/internal/objectset/ObjectSetQuery.ts
+++ b/packages/client/src/observable/internal/objectset/ObjectSetQuery.ts
@@ -419,9 +419,13 @@ export class ObjectSetQuery extends BaseListQuery<
           changes.deleted,
           batch.optimisticWrite,
           (obj) => this.#getObjectCacheKey(obj),
-          (key) => {
+          (obj) => {
+            const key = this.#peekObjectCacheKey(obj);
+            if (key == null) {
+              return undefined;
+            }
             const value = batch.read(key)?.value;
-            return value != null && typeof value === "object";
+            return value != null && typeof value === "object" ? key : undefined;
           },
         );
 
@@ -503,6 +507,18 @@ export class ObjectSetQuery extends BaseListQuery<
     );
   }
 
+  #peekObjectCacheKey(obj: {
+    $objectType: string;
+    $primaryKey: string | number;
+  }): ObjectCacheKey | undefined {
+    return this.cacheKeys.peek<ObjectCacheKey>(
+      "object",
+      obj.$objectType,
+      obj.$primaryKey,
+      this.rdpConfig ?? undefined,
+    );
+  }
+
   // TODO(oxc type-aware): the type-aware typescript/require-await rule does not flag this (it returns a Promise); remove this disable once type-aware linting is enabled.
   // oxlint-disable-next-line require-await -- intentionally async: returns a Promise to satisfy its declared/contract type; no await needed
   invalidateObjectType = async (
@@ -550,22 +566,24 @@ function reconcileListChanges(
   deleted: ReadonlySet<CacheKey>,
   isOptimistic: boolean,
   getObjectCacheKey: (obj: ObjectHolder | InterfaceHolder) => ObjectCacheKey,
-  hasCachedObject: (key: ObjectCacheKey) => boolean,
+  getCachedObjectKey: (
+    obj: ObjectHolder | InterfaceHolder,
+  ) => ObjectCacheKey | undefined,
 ): { newList: ObjectCacheKey[]; needsRevalidation: boolean } {
   const objectsToInsert = new Set<ObjectHolder | InterfaceHolder>();
   const keysToRemove = new Set<CacheKey>(deleted);
 
   let needsRevalidation = false;
   const addIfAvailable = (obj: ObjectHolder | InterfaceHolder): void => {
-    const key = getObjectCacheKey(obj);
+    const key = getCachedObjectKey(obj);
+    if (key == null) {
+      needsRevalidation = true;
+      return;
+    }
     if (existingKeys.has(key)) {
       return;
     }
-    if (hasCachedObject(key)) {
-      objectsToInsert.add(obj);
-    } else {
-      needsRevalidation = true;
-    }
+    objectsToInsert.add(obj);
   };
 
   for (const obj of addedDefiniteMatches) {

--- a/packages/client/src/observable/internal/objectset/ObjectSetQuery.ts
+++ b/packages/client/src/observable/internal/objectset/ObjectSetQuery.ts
@@ -411,15 +411,15 @@ export class ObjectSetQuery extends BaseListQuery<
         const existingEntry = batch.read(this.cacheKey);
         const existingKeys = new Set(existingEntry?.value?.data);
 
-        const { newList, needsRevalidation } = reconcileListChanges(
+        const reconciliationPlan = getListReconciliationPlan({
           existingKeys,
-          addedMatches.definite,
-          relevant.modifiedObjects,
+          addedDefiniteMatches: addedMatches.definite,
+          modifiedObjects: relevant.modifiedObjects,
           modifiedMatches,
-          changes.deleted,
-          batch.optimisticWrite,
-          (obj) => this.#getObjectCacheKey(obj),
-          (obj) => {
+          deleted: changes.deleted,
+          isOptimistic: batch.optimisticWrite,
+          getObjectCacheKey: (obj) => this.#getObjectCacheKey(obj),
+          getCachedObjectKey: (obj) => {
             const key = this.#peekObjectCacheKey(obj);
             if (key == null) {
               return undefined;
@@ -427,16 +427,20 @@ export class ObjectSetQuery extends BaseListQuery<
             const value = batch.read(key)?.value;
             return value != null && typeof value === "object" ? key : undefined;
           },
-        );
+        });
+        const { needsRevalidation } = reconciliationPlan;
+        const newList = reconcileListChanges(existingKeys, reconciliationPlan);
 
-        const status =
-          (this.pendingFetch != null && existingEntry?.status === "loading") ||
+        const isPendingFetchLoading =
+          this.pendingFetch != null && existingEntry?.status === "loading";
+        const hasUncertainMatches =
+          addedMatches.uncertain.size > 0 || modifiedMatches.uncertain.size > 0;
+        const shouldBeLoading =
+          isPendingFetchLoading ||
           needsRevalidation ||
-          optimisticId ||
-          addedMatches.uncertain.size > 0 ||
-          modifiedMatches.uncertain.size > 0
-            ? "loading"
-            : "loaded";
+          optimisticId != null ||
+          hasUncertainMatches;
+        const status = shouldBeLoading ? "loading" : "loaded";
 
         const existingTotalCount = existingEntry?.value?.totalCount;
         this._updateList(
@@ -557,20 +561,51 @@ export class ObjectSetQuery extends BaseListQuery<
 
 function reconcileListChanges(
   existingKeys: ReadonlySet<ObjectCacheKey>,
-  addedDefiniteMatches: ReadonlySet<ObjectHolder | InterfaceHolder>,
-  modifiedObjects: ReadonlyArray<ObjectHolder>,
+  plan: {
+    keysToInsert: ReadonlySet<ObjectCacheKey>;
+    keysToRemove: ReadonlySet<CacheKey>;
+  },
+): ObjectCacheKey[] {
+  const newList: ObjectCacheKey[] = [];
+  for (const key of existingKeys) {
+    if (!plan.keysToRemove.has(key)) {
+      newList.push(key);
+    }
+  }
+  newList.push(...plan.keysToInsert);
+
+  return newList;
+}
+
+function getListReconciliationPlan({
+  existingKeys,
+  addedDefiniteMatches,
+  modifiedObjects,
+  modifiedMatches,
+  deleted,
+  isOptimistic,
+  getObjectCacheKey,
+  getCachedObjectKey,
+}: {
+  existingKeys: ReadonlySet<ObjectCacheKey>;
+  addedDefiniteMatches: ReadonlySet<ObjectHolder | InterfaceHolder>;
+  modifiedObjects: ReadonlyArray<ObjectHolder>;
   modifiedMatches: {
     definite: ReadonlySet<ObjectHolder | InterfaceHolder>;
     uncertain: ReadonlySet<ObjectHolder | InterfaceHolder>;
-  },
-  deleted: ReadonlySet<CacheKey>,
-  isOptimistic: boolean,
-  getObjectCacheKey: (obj: ObjectHolder | InterfaceHolder) => ObjectCacheKey,
+  };
+  deleted: ReadonlySet<CacheKey>;
+  isOptimistic: boolean;
+  getObjectCacheKey: (obj: ObjectHolder | InterfaceHolder) => ObjectCacheKey;
   getCachedObjectKey: (
     obj: ObjectHolder | InterfaceHolder,
-  ) => ObjectCacheKey | undefined,
-): { newList: ObjectCacheKey[]; needsRevalidation: boolean } {
-  const objectsToInsert = new Set<ObjectHolder | InterfaceHolder>();
+  ) => ObjectCacheKey | undefined;
+}): {
+  keysToInsert: ReadonlySet<ObjectCacheKey>;
+  keysToRemove: ReadonlySet<CacheKey>;
+  needsRevalidation: boolean;
+} {
+  const keysToInsert = new Set<ObjectCacheKey>();
   const keysToRemove = new Set<CacheKey>(deleted);
 
   let needsRevalidation = false;
@@ -583,7 +618,7 @@ function reconcileListChanges(
     if (existingKeys.has(key)) {
       return;
     }
-    objectsToInsert.add(obj);
+    keysToInsert.add(key);
   };
 
   for (const obj of addedDefiniteMatches) {
@@ -600,15 +635,5 @@ function reconcileListChanges(
     }
   }
 
-  const newList: ObjectCacheKey[] = [];
-  for (const key of existingKeys) {
-    if (!keysToRemove.has(key)) {
-      newList.push(key);
-    }
-  }
-  for (const obj of objectsToInsert) {
-    newList.push(getObjectCacheKey(obj));
-  }
-
-  return { newList, needsRevalidation };
+  return { keysToInsert, keysToRemove, needsRevalidation };
 }


### PR DESCRIPTION
Users were running into issues where RDP-backed object-set queries would set their state as loaded even though the RDP load hadn't finished.

```typescript
const { data: oneData, isLoading: oneLoading, error: oneError } = useObjectSet(oneObjectSet);
    const {
        data: twoData,
        isLoading: twoLoading,
        error: twoError,
    } = useObjectSet(twoObjectSet, {
        withProperties: {
            purposeIds: base => base.pivotTo("purposes").aggregate("purposeId:collectList"),
        },
    });
```

What would happen here is that the second use object set would return a list of undefined.

There are two different stages:

  1. A cache update tells the object-set query: “Object Document/123 was added and definitely matches your filter.”
  2. The object-set result later resolves its stored keys by reading each exact cache entry.

With the example given, the first non-RDP query finished and wrote Document/123 to the shared cache. That write notified the second object-set query because it watches the same object type. That update flows to "#handleLocalUpdate". That then evaluated Document/123 against its filter and determined that it belonged in its result set, which it said "yes it did". This is because the only check it performs for the object being in the object set is based on the object set filter.

At stage 2, even though the object did belong to the object set, when we went to perform the lookup with the RDP key, we saw undefined and returned it. This is because the object itself is resolved via a different cache key.

The behavior to check "is this part of my object set" is still correct. However, we should also check that the cache key we resolve to actually exists, which is what this PR adds a check for.

you may ask, whats the point of checking object set scope and cache availability in two separate checks? 
 The checks answer different questions. The membership check tells us whether the object should appear in the result, while the cache check tells us whether we can return its requested RDP representation yet.

If the object belongs but its RDP variant is unavailable, omitting it would make the result look complete when it is not. Instead, we omit it temporarily, keep the query loading, and revalidate so the missing data is fetched. Once the exact cache variant is available, the object can safely be added to the result.
