### PR TITLE
Add inherited function scope authorization

### DIFF
--- a/packages/functions/src/scope/types.ts
+++ b/packages/functions/src/scope/types.ts
@@ -79,6 +79,11 @@ export interface ScopeReadWriteAuthorization extends ScopeReadAuthorization {
  */
 export namespace ScopeAuthorization {
   /**
+   * Sentinel value: the generated function inherits authorization from its caller.
+   */
+  export const inherit: unique symbol = Symbol("ScopeAuthorization.inherit");
+
+  /**
    * Sentinel value: discovery uses `defaultAuthorization.read` declared in functions.json.
    */
   export const defaultRead: unique symbol = Symbol(
@@ -95,5 +100,6 @@ export interface Scope {
   authorization:
     | ScopeReadAuthorization
     | ScopeReadWriteAuthorization
+    | typeof ScopeAuthorization.inherit
     | typeof ScopeAuthorization.defaultRead;
 }


### PR DESCRIPTION
Generated agent functions need a way to inherit authorization from their caller.

Added `ScopeAuthorization.inherit` for follow-up changes to use.
