### PR TITLE
Fix complex interface response mapping materialization

### DIFF
--- a/.changeset/fix-complex-interface-response-mappings.md
+++ b/.changeset/fix-complex-interface-response-mappings.md
@@ -1,0 +1,5 @@
+---
+"@osdk/client": patch
+---
+
+Materialize complex interface implementations from object-set response mappings.

--- a/packages/client/src/object/convertWireToOsdkObjects.test.ts
+++ b/packages/client/src/object/convertWireToOsdkObjects.test.ts
@@ -33,7 +33,11 @@ import type {
   PropertySecurities,
 } from "@osdk/foundry.ontologies";
 import { createSharedClientContext } from "@osdk/shared.client.impl";
-import { LegacyFauxFoundry, startNodeApiServer } from "@osdk/shared.test";
+import {
+  LegacyFauxFoundry,
+  startNodeApiServer,
+  stubData,
+} from "@osdk/shared.test";
 import { beforeAll, describe, expect, expectTypeOf, it } from "vitest";
 
 import { additionalContext, type Client } from "../Client.js";
@@ -701,6 +705,54 @@ describe("convertWireToOsdkObjects", () => {
     );
 
     expect(result.length).toBe(1);
+  });
+
+  it("materializes complex interface implementations from response mappings", async () => {
+    const objectDef = await client[
+      additionalContext
+    ].ontologyProvider.getObjectDefinition("ComplexImplementationObject");
+    const legacyObjectDef = {
+      ...objectDef,
+      interfaceImplementations: undefined,
+    };
+    const propertiesV2 =
+      stubData.complexImplementationObjectTypeWithLinkTypes
+        .implementsInterfaces2!.ComplexImplementationInterface.propertiesV2!;
+
+    const [result] = await convertWireToOsdkObjects(
+      client[additionalContext],
+      [
+        {
+          __apiName: "ComplexImplementationObject",
+          __primaryKey: "k1",
+          id: "k1",
+          localValue: "hello",
+          nestedStruct: { label: "nested-label", count: 7 },
+          multiStruct: { alpha: "a-val", beta: 42, gamma: "ignored" },
+          arrayValue: [1, 2, 3],
+        },
+      ],
+      "ComplexImplementationInterface",
+      {},
+      undefined,
+      false,
+      undefined,
+      false,
+      {},
+      {
+        ComplexImplementationInterface: {
+          ComplexImplementationObject: propertiesV2,
+        },
+      },
+      { ComplexImplementationObject: legacyObjectDef },
+    );
+
+    expect(result).toMatchObject({
+      iLocal: "hello",
+      iStructField: "nested-label",
+      iStruct: { theAlpha: "a-val", theBeta: 42 },
+      iReduced: [1, 2, 3],
+    });
   });
 
   describe("$metadata", () => {

--- a/packages/client/src/object/convertWireToOsdkObjects.ts
+++ b/packages/client/src/object/convertWireToOsdkObjects.ts
@@ -20,7 +20,6 @@ import type {
   ObjectMetadata,
 } from "@osdk/api";
 import type {
-  InterfacePropertyLocalPropertyImplementation,
   InterfaceToObjectTypeMappings,
   InterfaceToObjectTypeMappingsV2,
   InterfaceTypeApiName,
@@ -134,15 +133,9 @@ export async function convertWireToOsdkObjects(
 ): Promise<Array<ObjectHolder | InterfaceHolder>> {
   fixObjectPropertiesInPlace(objects, forceRemoveRid);
 
-  // prefer V2 mappings if non-empty, otherwise fall back to V1
-  const effectiveMappings =
-    Object.keys(interfaceToObjectTypeMappingsV2).length > 0
-      ? convertInterfaceToObjectTypeMappingsV2ToV1(
-          interfaceToObjectTypeMappingsV2,
-        )
-      : interfaceToObjectTypeMappings;
-
-  const isInterfaceScoped = Object.keys(effectiveMappings).length > 0;
+  const isInterfaceScoped =
+    Object.keys(interfaceToObjectTypeMappingsV2).length > 0 ||
+    Object.keys(interfaceToObjectTypeMappings).length > 0;
   const ret = [];
   for (const rawObj of objects) {
     // If caller supplied object definitions, use them exclusively instead of
@@ -156,24 +149,47 @@ export async function convertWireToOsdkObjects(
     ) as FetchedObjectTypeDefinition;
     invariant(objectDef, `Missing definition for '${rawObj.$apiName}'`);
 
-    const interfaceToObjMapping =
-      interfaceApiName && isInterfaceScoped
-        ? effectiveMappings[interfaceApiName as InterfaceTypeApiName][
-            rawObj.$apiName
-          ]
-        : undefined;
+    const interfaceToObjMappingV2 = interfaceApiName
+      ? interfaceToObjectTypeMappingsV2[
+          interfaceApiName as InterfaceTypeApiName
+        ]?.[rawObj.$apiName]
+      : undefined;
+    const interfaceToObjMapping = interfaceApiName
+      ? interfaceToObjectTypeMappings[
+          interfaceApiName as InterfaceTypeApiName
+        ]?.[rawObj.$apiName]
+      : undefined;
 
     const ifaceSelected =
-      interfaceApiName && interfaceToObjMapping
+      interfaceApiName && interfaceToObjMappingV2
         ? selectedProps
-          ? Object.keys(interfaceToObjMapping).filter((val) => {
-              selectedProps?.includes(interfaceToObjMapping[val]);
-            })
+          ? getReferencedObjectProperties(
+              interfaceToObjMappingV2,
+              selectedProps,
+            )
           : [
-              ...Object.values(interfaceToObjMapping),
+              ...getReferencedObjectProperties(interfaceToObjMappingV2),
               objectDef.primaryKeyApiName,
             ]
-        : undefined;
+        : interfaceApiName && interfaceToObjMapping
+          ? selectedProps
+            ? Object.keys(interfaceToObjMapping).filter((val) => {
+                selectedProps.includes(interfaceToObjMapping[val]);
+              })
+            : [
+                ...Object.values(interfaceToObjMapping),
+                objectDef.primaryKeyApiName,
+              ]
+          : undefined;
+
+    const objectDefWithResponseImplementations =
+      interfaceApiName && interfaceToObjMappingV2
+        ? addResponseInterfaceImplementations(
+            objectDef,
+            interfaceApiName,
+            interfaceToObjMappingV2,
+          )
+        : objectDef;
 
     // default value for when we are checking an object
     let objProps;
@@ -199,7 +215,7 @@ export async function convertWireToOsdkObjects(
 
     let osdkObject: ObjectHolder | InterfaceHolder = createOsdkObject(
       client,
-      objectDef,
+      objectDefWithResponseImplementations,
       rawObj,
       derivedPropertyTypeByName,
       propertySecurities,
@@ -299,36 +315,127 @@ function fixObjectPropertiesInPlace(
 }
 
 /**
- * Converts interfaceToObjectTypeMappingsV2 format to the V1 format.
- * V2 format: { interfaceProp: { type: "localPropertyImplementation", propertyApiName: "objectProp" } }
- * V1 format: { interfaceProp: "objectProp" }
+ * Returns every local object property required to materialize the selected
+ * interface properties from a V2 response mapping.
  */
-function convertInterfaceToObjectTypeMappingsV2ToV1(
-  mappingsV2: Record<InterfaceTypeApiName, InterfaceToObjectTypeMappingsV2>,
-): Record<InterfaceTypeApiName, InterfaceToObjectTypeMappings> {
-  return Object.fromEntries(
-    Object.entries(mappingsV2).map(
-      ([interfaceApiName, objectTypeMappingsV2]) => [
-        interfaceApiName,
-        Object.fromEntries(
-          Object.entries(objectTypeMappingsV2).map(
-            ([objectTypeName, propertyMappings]) => [
-              objectTypeName,
-              Object.fromEntries(
-                Object.entries(propertyMappings)
-                  .filter(
-                    ([, impl]) => impl.type === "localPropertyImplementation",
-                  )
-                  .map(([interfaceProp, impl]) => [
-                    interfaceProp,
-                    (impl as InterfacePropertyLocalPropertyImplementation)
-                      .propertyApiName,
-                  ]),
-              ),
-            ],
-          ),
-        ),
-      ],
-    ),
+function getReferencedObjectProperties(
+  mappings: InterfaceToObjectTypeMappingsV2[string],
+  selectedProps?: ReadonlyArray<string>,
+): string[] {
+  const referencedProperties = new Set<string>();
+  for (const [interfaceProp, implementation] of Object.entries(mappings)) {
+    if (selectedProps != null && !selectedProps.includes(interfaceProp))
+      continue;
+    addReferencedObjectProperties(referencedProperties, implementation);
+  }
+  return [...referencedProperties];
+}
+
+type WireInterfacePropertyImplementation =
+  InterfaceToObjectTypeMappingsV2[string][string];
+
+function addReferencedObjectProperties(
+  properties: Set<string>,
+  implementation: WireInterfacePropertyImplementation,
+): void {
+  switch (implementation.type) {
+    case "localPropertyImplementation":
+      properties.add(implementation.propertyApiName);
+      break;
+    case "structFieldImplementation":
+      properties.add(implementation.structFieldOfProperty.propertyApiName);
+      break;
+    case "structImplementation":
+      for (const entry of Object.values(implementation.mapping)) {
+        properties.add(entry.propertyApiName);
+      }
+      break;
+    case "reducedPropertyImplementation":
+      addReferencedObjectProperties(properties, implementation.implementation);
+      break;
+  }
+}
+
+function addResponseInterfaceImplementations(
+  objectDef: FetchedObjectTypeDefinition,
+  interfaceApiName: string,
+  mappings: InterfaceToObjectTypeMappingsV2[string],
+): FetchedObjectTypeDefinition {
+  const responseImplementations = Object.fromEntries(
+    Object.entries(mappings).map(([interfaceProp, implementation]) => [
+      interfaceProp,
+      convertResponseInterfaceImplementation(implementation),
+    ]),
   );
+  return {
+    ...objectDef,
+    interfaceImplementations: {
+      ...objectDef.interfaceImplementations,
+      [interfaceApiName]: {
+        ...objectDef.interfaceImplementations?.[interfaceApiName],
+        ...responseImplementations,
+      },
+    },
+  };
+}
+
+function convertResponseInterfaceImplementation(
+  implementation: WireInterfacePropertyImplementation,
+): ObjectMetadata.InterfacePropertyImplementation {
+  switch (implementation.type) {
+    case "localPropertyImplementation":
+      return {
+        type: "localProperty",
+        propertyApiName: implementation.propertyApiName,
+      };
+    case "structFieldImplementation":
+      return {
+        type: "structField",
+        propertyApiName: implementation.structFieldOfProperty.propertyApiName,
+        structFieldApiName:
+          implementation.structFieldOfProperty.structFieldApiName,
+      };
+    case "structImplementation":
+      return {
+        type: "struct",
+        mapping: Object.fromEntries(
+          Object.entries(implementation.mapping).map(([fieldName, entry]) => [
+            fieldName,
+            entry.type === "structFieldOfProperty"
+              ? {
+                  type: "structFieldOfProperty" as const,
+                  propertyApiName: entry.propertyApiName,
+                  structFieldApiName: entry.structFieldApiName,
+                }
+              : {
+                  type: "property" as const,
+                  propertyApiName: entry.propertyApiName,
+                },
+          ]),
+        ),
+      };
+    case "reducedPropertyImplementation":
+      return {
+        type: "reduced",
+        implementation: convertNestedResponseInterfaceImplementation(
+          implementation.implementation,
+        ),
+      };
+  }
+}
+
+type WireNestedInterfacePropertyImplementation = Extract<
+  WireInterfacePropertyImplementation,
+  { type: "reducedPropertyImplementation" }
+>["implementation"];
+
+function convertNestedResponseInterfaceImplementation(
+  implementation: WireNestedInterfacePropertyImplementation,
+): Exclude<
+  ObjectMetadata.InterfacePropertyImplementation,
+  ObjectMetadata.InterfacePropertyReducedImplementation
+> {
+  const converted = convertResponseInterfaceImplementation(implementation);
+  invariant(converted.type !== "reduced");
+  return converted;
 }


### PR DESCRIPTION
## Summary

- Materialize all V2 interface property implementation variants returned by object set responses.
- Support local property, struct field, struct, and reduced property implementations without relying on separately generated implementation metadata.
- Preserve the existing V1 mapping fallback.

## Testing

- Added a regression test that removes generated interface implementation metadata and verifies that complex properties are materialized from the response mappings.
- Ran `pnpm --dir packages/client exec vitest run src/object/convertWireToOsdkObjects.test.ts`.