### PR TITLE
Fix formatted date timezone

### DIFF
--- a/.changeset/common-carrots-appear.md
+++ b/.changeset/common-carrots-appear.md
@@ -1,0 +1,6 @@
+---
+"@osdk/client": minor
+"@osdk/faux": minor
+---
+
+Fix date-only properties shifting by a day in some timezones

--- a/packages/client/src/object/formatting/applyPropertyFormatter.test.ts
+++ b/packages/client/src/object/formatting/applyPropertyFormatter.test.ts
@@ -27,6 +27,10 @@ describe("getFormattedValue", () => {
   const EN_US = { locale: "en-US" };
   const DE_DE = { locale: "de-DE" };
   const FR_FR = { locale: "fr-FR" };
+  const EN_US_LOS_ANGELES = {
+    locale: "en-US",
+    timezoneId: "America/Los_Angeles",
+  };
   const EN_US_TOKYO = { locale: "en-US", timezoneId: "Asia/Tokyo" };
 
   // Single object definition with properties for testing
@@ -659,6 +663,19 @@ describe("getFormattedValue", () => {
         );
 
       expect(formatted).toBe("Mi., 15. Jan. 2025");
+    });
+
+    it("does not shift a date to the previous day in a negative UTC offset", () => {
+      const obj = getObject({
+        createdDate: "2025-01-15T00:00:00.000Z",
+      });
+      const formatted =
+        obj.$__EXPERIMENTAL__NOT_SUPPORTED_YET__getFormattedValue(
+          "createdDate",
+          EN_US_LOS_ANGELES,
+        );
+
+      expect(formatted).toBe("Wed, Jan 15, 2025");
     });
 
     it("formats timestamp with static timezone (America/New_York)", () => {

--- a/packages/client/src/object/formatting/applyPropertyFormatter.ts
+++ b/packages/client/src/object/formatting/applyPropertyFormatter.ts
@@ -97,7 +97,7 @@ function formatPropertyValue(
         rule.type === "timestamp" ? rule.displayTimezone : undefined,
         objectData,
         options.locale ?? getBrowserLocale(),
-        options.timezoneId,
+        rule.type === "date" ? "UTC" : options.timezoneId,
       );
     default:
       return undefined;

--- a/packages/faux/package.json
+++ b/packages/faux/package.json
@@ -42,6 +42,7 @@
     "typecheck": "tsc --noEmit --emitDeclarationOnly false"
   },
   "dependencies": {
+    "@date-fns/utc": "^2.1.1",
     "@osdk/api": "workspace:~",
     "@osdk/foundry.admin": "catalog:foundry-platform-typescript",
     "@osdk/foundry.core": "catalog:foundry-platform-typescript",

--- a/packages/faux/src/FauxFoundry/aggregateObjects.ts
+++ b/packages/faux/src/FauxFoundry/aggregateObjects.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import { UTCDate } from "@date-fns/utc";
 import type {
   AggregateObjectsResponseV2,
   AggregationGroupByV2,
@@ -41,7 +42,7 @@ interface GroupBucket {
   objects: BaseServerObject[];
 }
 
-const DURATION_START_FNS: Record<string, (date: Date) => Date> = {
+const DURATION_START_FNS: Record<string, (date: UTCDate) => Date> = {
   SECONDS: startOfSecond,
   MINUTES: startOfMinute,
   HOURS: startOfHour,
@@ -256,7 +257,7 @@ function computeDurationBucketStart(date: Date, unit: string): string {
   if (fn == null) {
     throw new Error(`FauxFoundry: unsupported duration unit: ${unit}`);
   }
-  return fn(date).toISOString();
+  return fn(new UTCDate(date)).toISOString();
 }
 
 function numericAgg(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3844,6 +3844,9 @@ importers:
 
   packages/faux:
     dependencies:
+      '@date-fns/utc':
+        specifier: ^2.1.1
+        version: 2.1.1
       '@osdk/api':
         specifier: workspace:~
         version: link:../api
@@ -7725,6 +7728,9 @@ packages:
     engines: {node: '>=20.19.0'}
     peerDependencies:
       postcss: ^8.4
+
+  '@date-fns/utc@2.1.1':
+    resolution: {integrity: sha512-SlJDfG6RPeEX8wEVv6ZB3kak4MmbtyiI2qX/5zuKdordbrhB/iaJ58GVMZgJ6P1sJaM1gMgENFYYeg1JWrCFrA==}
 
   '@discoveryjs/json-ext@0.5.7':
     resolution: {integrity: sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==}
@@ -24063,6 +24069,8 @@ snapshots:
   '@csstools/utilities@3.0.0(postcss@8.5.6)':
     dependencies:
       postcss: 8.5.6
+
+  '@date-fns/utc@2.1.1': {}
 
   '@discoveryjs/json-ext@0.5.7': {}
 


### PR DESCRIPTION
Fix **date** properties shifting by a day in some timezones by formatting them in UTC instead of local time