### PR TITLE
Version Packages

### DIFF
--- a/.changeset/calm-scopes-inherit.md
+++ b/.changeset/calm-scopes-inherit.md
@@ -1,5 +1,0 @@
----
-"@osdk/functions": minor
----
-
-Added support for inheriting function scope authorization from the caller

--- a/.changeset/empty-media-sets.md
+++ b/.changeset/empty-media-sets.md
@@ -1,6 +1,0 @@
----
-"@osdk/maker": patch
-"@osdk/maker-experimental": patch
----
-
-Add opt-in generation of empty backing Media Sets for media reference properties.

--- a/.changeset/mighty-pets-press.md
+++ b/.changeset/mighty-pets-press.md
@@ -1,6 +1,0 @@
----
-"@osdk/maker": minor
-"@osdk/maker-experimental": minor
----
-
-Add vector property support

--- a/packages/functions/CHANGELOG.md
+++ b/packages/functions/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @osdk/functions
 
+## 1.22.0
+
+### Minor Changes
+
+- 311ff2a: Added support for inheriting function scope authorization from the caller
+
 ## 1.21.0
 
 ### Minor Changes

--- a/packages/functions/package.json
+++ b/packages/functions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/functions",
-  "version": "1.21.0",
+  "version": "1.22.0",
   "description": "",
   "access": "public",
   "license": "Apache-2.0",

--- a/packages/maker-experimental/CHANGELOG.md
+++ b/packages/maker-experimental/CHANGELOG.md
@@ -1,5 +1,18 @@
 # @osdk/maker-experimental
 
+## 0.57.0
+
+### Minor Changes
+
+- ab7c384: Add opt-in generation of empty backing Media Sets for media reference properties.
+- d316359: Add vector property support
+
+### Patch Changes
+
+- Updated dependencies [ab7c384]
+- Updated dependencies [d316359]
+  - @osdk/maker@0.63.0
+
 ## 0.56.0
 
 ### Minor Changes

--- a/packages/maker-experimental/package.json
+++ b/packages/maker-experimental/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/maker-experimental",
-  "version": "0.56.0",
+  "version": "0.57.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/maker-import/CHANGELOG.md
+++ b/packages/maker-import/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @osdk/maker-import
 
+## 0.33.0
+
+### Patch Changes
+
+- Updated dependencies [ab7c384]
+- Updated dependencies [d316359]
+  - @osdk/maker@0.63.0
+
 ## 0.32.0
 
 ### Patch Changes

--- a/packages/maker-import/package.json
+++ b/packages/maker-import/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/maker-import",
-  "version": "0.32.0",
+  "version": "0.33.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",

--- a/packages/maker/CHANGELOG.md
+++ b/packages/maker/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @osdk/maker
 
+## 0.63.0
+
+### Minor Changes
+
+- ab7c384: Add opt-in generation of empty backing Media Sets for media reference properties.
+- d316359: Add vector property support
+
 ## 0.62.0
 
 ### Minor Changes

--- a/packages/maker/package.json
+++ b/packages/maker/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@osdk/maker",
-  "version": "0.62.0",
+  "version": "0.63.0",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR was opened by automation. When you're ready to do a release, you can merge this and publish to npm yourself.
     If you're not ready to do a release yet, that's fine, whenever you re-run the release script in main, this PR will be updated.


# Releases
## @osdk/functions@1.22.0

### Minor Changes

-   311ff2a: Added support for inheriting function scope authorization from the caller

## @osdk/maker@0.63.0

### Minor Changes

-   ab7c384: Add opt-in generation of empty backing Media Sets for media reference properties.
-   d316359: Add vector property support

## @osdk/maker-experimental@0.57.0

### Minor Changes

-   ab7c384: Add opt-in generation of empty backing Media Sets for media reference properties.
-   d316359: Add vector property support

### Patch Changes

-   Updated dependencies [ab7c384]
-   Updated dependencies [d316359]
    -   @osdk/maker@0.63.0

## @osdk/maker-import@0.33.0

### Patch Changes

-   Updated dependencies [ab7c384]
-   Updated dependencies [d316359]
    -   @osdk/maker@0.63.0
