### PR TITLE
Add new branch-aware changes to unstable features

### DIFF
--- a/.changeset/happy-masks-begin.md
+++ b/.changeset/happy-masks-begin.md
@@ -1,9 +1,0 @@
----
-"@osdk/create-app.template.tutorial-todo-aip-app.beta": major
-"@osdk/create-app.template.tutorial-todo-app.beta": major
-"@osdk/create-app.template.react.beta": major
-"@osdk/create-app.template.vue.v2": major
-"@osdk/create-app": major
----
-
-Add new branch-aware changes to unstable features

--- a/.changeset/happy-masks-begin.md
+++ b/.changeset/happy-masks-begin.md
@@ -1,0 +1,9 @@
+---
+"@osdk/create-app.template.tutorial-todo-aip-app.beta": major
+"@osdk/create-app.template.tutorial-todo-app.beta": major
+"@osdk/create-app.template.react.beta": major
+"@osdk/create-app.template.vue.v2": major
+"@osdk/create-app": major
+---
+
+Add new branch-aware changes to unstable features

--- a/.changeset/major-clouds-open.md
+++ b/.changeset/major-clouds-open.md
@@ -1,0 +1,9 @@
+---
+"@osdk/create-app.template.tutorial-todo-aip-app.beta": minor
+"@osdk/create-app.template.tutorial-todo-app.beta": minor
+"@osdk/create-app.template.react.beta": minor
+"@osdk/create-app.template.vue.v2": minor
+"@osdk/create-app": minor
+---
+
+Add new branch-aware changes to unstable features

--- a/packages/create-app.template.react.beta/templates/src/client.ts.hbs
+++ b/packages/create-app.template.react.beta/templates/src/client.ts.hbs
@@ -1,8 +1,5 @@
 {{#if osdkPackage}}
 import { createClient, type Client } from "@osdk/client";
-{{#if unstableFeatures}}
-import { $branch } from "{{osdkPackage}}";
-{{/if}}
 {{else}}
 import { createPlatformClient, type PlatformClient } from "@osdk/client";
 {{/if}}
@@ -54,9 +51,7 @@ export const auth: PublicOauthClient = createPublicOauthClient(
 /**
  * Initialize the client to interact with the Ontology and Platform SDKs
  */
-export const client: Client = createClient(foundryUrl, ontologyRid, auth{{#if unstableFeatures}}, {
-  UNSTABLE_DO_NOT_USE_BRANCH: $branch,
-}{{/if}});
+export const client: Client = createClient(foundryUrl, ontologyRid, auth);
 {{else}}
 /**
  * Initialize the client to interact with the Platform SDK

--- a/packages/create-app.template.react.beta/templates/vite.config.ts.hbs
+++ b/packages/create-app.template.react.beta/templates/vite.config.ts.hbs
@@ -1,11 +1,16 @@
 import path from "node:path";
+{{#if osdkPackage}}
+{{#if unstableFeatures}}
+import { branchPlugin } from "@osdk/vite-plugin-branch";
+{{/if}}
+{{/if}}
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => {
   return {
-    plugins: [react()],
+    plugins: [react(){{#if osdkPackage}}{{#if unstableFeatures}}, branchPlugin(){{/if}}{{/if}}],
     resolve: {
       alias: {
         "@": path.resolve(__dirname, "./src"),

--- a/packages/create-app.template.tutorial-todo-aip-app.beta/templates/src/client.ts.hbs
+++ b/packages/create-app.template.tutorial-todo-aip-app.beta/templates/src/client.ts.hbs
@@ -1,8 +1,5 @@
 import { createClient, type Client } from "@osdk/client";
 import { createPublicOauthClient, type PublicOauthClient } from "@osdk/oauth";
-{{#if unstableFeatures}}
-import { $branch } from "{{osdkPackage}}";
-{{/if}}
 
 function getMetaTagContent(tagName: string): string {
   const elements = document.querySelectorAll(`meta[name="${tagName}"]`);
@@ -47,8 +44,6 @@ export const auth: PublicOauthClient = createPublicOauthClient(
 /**
  * Initialize the client to interact with the Ontology and Platform SDKs
  */
-const client: Client = createClient(foundryUrl, ontologyRid, auth{{#if unstableFeatures}}, {
-  UNSTABLE_DO_NOT_USE_BRANCH: $branch,
-}{{/if}});
+const client: Client = createClient(foundryUrl, ontologyRid, auth);
 
 export default client;

--- a/packages/create-app.template.tutorial-todo-aip-app.beta/templates/vite.config.ts.hbs
+++ b/packages/create-app.template.tutorial-todo-aip-app.beta/templates/vite.config.ts.hbs
@@ -1,9 +1,12 @@
+{{#if unstableFeatures}}
+import { branchPlugin } from "@osdk/vite-plugin-branch";
+{{/if}}
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [react()],
+  plugins: [react(){{#if unstableFeatures}}, branchPlugin(){{/if}}],
   server: {
     port: 8080,
     {{#if corsProxy}}

--- a/packages/create-app.template.tutorial-todo-app.beta/templates/src/client.ts.hbs
+++ b/packages/create-app.template.tutorial-todo-app.beta/templates/src/client.ts.hbs
@@ -1,8 +1,5 @@
 import { createClient, type Client } from "@osdk/client";
 import { createPublicOauthClient, type PublicOauthClient } from "@osdk/oauth";
-{{#if unstableFeatures}}
-import { $branch } from "{{osdkPackage}}";
-{{/if}}
 
 function getMetaTagContent(tagName: string): string {
   const elements = document.querySelectorAll(`meta[name="${tagName}"]`);
@@ -47,8 +44,6 @@ export const auth: PublicOauthClient = createPublicOauthClient(
 /**
  * Initialize the client to interact with the Ontology and Platform SDKs
  */
-const client: Client = createClient(foundryUrl, ontologyRid, auth{{#if unstableFeatures}}, {
-  UNSTABLE_DO_NOT_USE_BRANCH: $branch,
-}{{/if}});
+const client: Client = createClient(foundryUrl, ontologyRid, auth);
 
 export default client;

--- a/packages/create-app.template.tutorial-todo-app.beta/templates/vite.config.ts.hbs
+++ b/packages/create-app.template.tutorial-todo-app.beta/templates/vite.config.ts.hbs
@@ -1,9 +1,12 @@
+{{#if unstableFeatures}}
+import { branchPlugin } from "@osdk/vite-plugin-branch";
+{{/if}}
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  plugins: [react()],
+  plugins: [react(){{#if unstableFeatures}}, branchPlugin(){{/if}}],
   server: {
     port: 8080,
     {{#if corsProxy}}

--- a/packages/create-app.template.vue.v2/templates/src/client.ts.hbs
+++ b/packages/create-app.template.vue.v2/templates/src/client.ts.hbs
@@ -1,8 +1,5 @@
 {{#if osdkPackage}}
 import { createClient, type Client } from "@osdk/client";
-{{#if unstableFeatures}}
-import { $branch } from "{{osdkPackage}}";
-{{/if}}
 {{else}}
 import { createPlatformClient, type PlatformClient } from "@osdk/client";
 {{/if}}
@@ -54,9 +51,7 @@ export const auth: PublicOauthClient = createPublicOauthClient(
 /**
  * Initialize the client to interact with the Ontology and Platform SDKs
  */
-export const client: Client = createClient(foundryUrl, ontologyRid, auth{{#if unstableFeatures}}, {
-  UNSTABLE_DO_NOT_USE_BRANCH: $branch,
-}{{/if}});
+export const client: Client = createClient(foundryUrl, ontologyRid, auth);
 {{else}}
 /**
  * Initialize the client to interact with the Platform SDK

--- a/packages/create-app.template.vue.v2/templates/vite.config.ts.hbs
+++ b/packages/create-app.template.vue.v2/templates/vite.config.ts.hbs
@@ -1,10 +1,15 @@
+{{#if osdkPackage}}
+{{#if unstableFeatures}}
+import { branchPlugin } from "@osdk/vite-plugin-branch";
+{{/if}}
+{{/if}}
 import vue from "@vitejs/plugin-vue";
 import { defineConfig } from "vite";
 
 // https://vitejs.dev/config/
 export default defineConfig(({ mode }) => {  
   return {
-    plugins: [vue()],
+    plugins: [vue(){{#if osdkPackage}}{{#if unstableFeatures}}, branchPlugin(){{/if}}{{/if}}],
     server: {
       port: 8080,
       {{#if corsProxy}}

--- a/packages/create-app/src/cli.test.ts
+++ b/packages/create-app/src/cli.test.ts
@@ -214,13 +214,17 @@ async function runTest({
 }
 
 describe("--unstableFeatures flag", () => {
-  const argsFor = (project: string, extra: string[]): string[] => [
+  const argsFor = (
+    project: string,
+    extra: string[],
+    template = "template-react",
+  ): string[] => [
     "npx",
     "@osdk/create-app",
     project,
     "--overwrite",
     "--template",
-    "template-react",
+    template,
     "--foundryUrl",
     "https://example.palantirfoundry.com",
     "--applicationUrl",
@@ -247,33 +251,66 @@ describe("--unstableFeatures flag", () => {
   const readProject = (project: string) => {
     const root = path.join(process.cwd(), project);
     const pkgPath = path.join(root, "package.json");
-    const clientPath = path.join(root, "src", "client.ts");
+    const viteConfigPath = path.join(root, "vite.config.ts");
     return {
       packageJson: JSON.parse(fs.readFileSync(pkgPath, "utf-8")),
-      clientTs: fs.readFileSync(clientPath, "utf-8"),
+      viteConfigTs: fs.readFileSync(viteConfigPath, "utf-8"),
     };
   };
 
   test("wires Foundry branch support when enabled", async () => {
     const project = "expected-unstable-on";
     await cli(argsFor(project, ["--unstableFeatures", "true"]));
-    const { packageJson, clientTs } = readProject(project);
+    const { packageJson, viteConfigTs } = readProject(project);
 
     const postinstall = "./node_modules/.bin/osdk unstable branch sync";
     expect(packageJson.scripts.postinstall).toBe(postinstall);
     expect(packageJson.devDependencies["@osdk/cli"]).toBe("latest");
-    expect(clientTs).toContain('import { $branch } from "@fake/sdk";');
-    expect(clientTs).toContain("UNSTABLE_DO_NOT_USE_BRANCH: $branch");
+    expect(packageJson.dependencies["@osdk/vite-plugin-branch"]).toBe(
+      `^${createAppVersion}`,
+    );
+    expect(viteConfigTs).toContain(
+      'import { branchPlugin } from "@osdk/vite-plugin-branch";',
+    );
+    expect(viteConfigTs).toContain("plugins: [react(), branchPlugin()]");
   });
 
   test("omits Foundry branch support by default", async () => {
     const project = "expected-unstable-off";
     await cli(argsFor(project, []));
-    const { packageJson, clientTs } = readProject(project);
+    const { packageJson, viteConfigTs } = readProject(project);
 
     expect(packageJson.scripts.postinstall).toBeUndefined();
     expect(packageJson.devDependencies?.["@osdk/cli"]).toBeUndefined();
-    expect(clientTs).not.toContain("UNSTABLE_DO_NOT_USE_BRANCH");
-    expect(clientTs).not.toContain("$branch");
+    expect(
+      packageJson.dependencies["@osdk/vite-plugin-branch"],
+    ).toBeUndefined();
+    expect(viteConfigTs).not.toContain("branchPlugin");
+  });
+
+  test("passes the generated branch explicitly for Expo", async () => {
+    const project = "expected-unstable-expo";
+    await cli(
+      argsFor(project, ["--unstableFeatures", "true"], "template-expo"),
+    );
+
+    const root = path.join(process.cwd(), project);
+    const packageJson = JSON.parse(
+      fs.readFileSync(path.join(root, "package.json"), "utf-8"),
+    );
+    const clientTs = fs.readFileSync(
+      path.join(root, "foundry", "client.ts"),
+      "utf-8",
+    );
+
+    expect(packageJson.scripts.postinstall).toBe(
+      "./node_modules/.bin/osdk unstable branch sync",
+    );
+    expect(packageJson.devDependencies["@osdk/cli"]).toBe("latest");
+    expect(
+      packageJson.dependencies["@osdk/vite-plugin-branch"],
+    ).toBeUndefined();
+    expect(clientTs).toContain('import { $branch } from "@fake/sdk";');
+    expect(clientTs).toContain("UNSTABLE_DO_NOT_USE_BRANCH: $branch");
   });
 });

--- a/packages/create-app/src/run.ts
+++ b/packages/create-app/src/run.ts
@@ -196,6 +196,12 @@ export async function run({
       "@osdk/cli": "latest",
       ...packageJson.devDependencies,
     };
+    if (fs.existsSync(path.join(root, "vite.config.ts"))) {
+      packageJson.dependencies = {
+        "@osdk/vite-plugin-branch": changeVersionPrefix(clientVersion, "^"),
+        ...packageJson.dependencies,
+      };
+    }
     fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2));
   }
 


### PR DESCRIPTION
• Updates unstable create-app templates to use @osdk/vite-plugin-branch for Vite apps. Expo retains explicit branch configuration because it uses Metro. Removes explicit client branch wiring from other templates and adds test coverage.