### PR TITLE
[Maker Experimental] Fix backing Media Set reconciliation order

### DIFF
--- a/.changeset/bright-media-sets-wait.md
+++ b/.changeset/bright-media-sets-wait.md
@@ -1,0 +1,5 @@
+---
+"@osdk/maker-experimental": patch
+---
+
+Require generated backing Media Sets to exist before ontology reconciliation.

--- a/packages/maker-experimental/src/api/defineOntologyV2.ts
+++ b/packages/maker-experimental/src/api/defineOntologyV2.ts
@@ -36,7 +36,10 @@ import {
 } from "../conversion/toMarketplace/shapeExtractors/ImportedShapeExtractor.js";
 import { getShapes } from "../conversion/toMarketplace/shapeExtractors/IrShapeExtractor.js";
 import type { BlockShapes, ReadableId } from "../util/generateRid.js";
-import { OntologyRidGeneratorImpl } from "../util/generateRid.js";
+import {
+  OntologyRidGeneratorImpl,
+  ReadableIdGenerator,
+} from "../util/generateRid.js";
 
 export interface OntologyV2Result {
   ontologyIr: OntologyIrV2;
@@ -144,6 +147,17 @@ export async function defineOntologyV2(
       )
       .map(({ apiName }) => `${objectType.apiName}.${apiName}`);
   });
+
+  for (const mediaSetName of backingMediaSetNames) {
+    shapes.inputShapeMetadata.set(
+      ReadableIdGenerator.getForMediaSetView(mediaSetName),
+      {
+        isOptional: false,
+        isAccessedInReconcile: true,
+        reconcileAccessRequirements: "RESOURCE_EXISTENCE_REQUIRED",
+      },
+    );
+  }
 
   if (outputDir) {
     writeStaticObjects(outputDir);

--- a/packages/maker-experimental/src/api/overall.test.ts
+++ b/packages/maker-experimental/src/api/overall.test.ts
@@ -69,7 +69,7 @@ describe("Experimental Test Suite", () => {
   });
 
   describe("Empty backing Media Sets", () => {
-    it("collects opted-in properties without changing existing input metadata", async () => {
+    it("requires opted-in Media Sets to exist before reconciliation", async () => {
       const result = await defineOntologyV2("com.palantir.", () => {
         defineObject({
           apiName: "Document",
@@ -96,7 +96,11 @@ describe("Experimental Test Suite", () => {
       );
       expect(
         result.shapes.inputShapeMetadata.get(inputReadableId),
-      ).toBeUndefined();
+      ).toEqual({
+        isOptional: false,
+        isAccessedInReconcile: true,
+        reconcileAccessRequirements: "RESOURCE_EXISTENCE_REQUIRED",
+      });
     });
   });
 

--- a/packages/maker-experimental/src/api/overall.test.ts
+++ b/packages/maker-experimental/src/api/overall.test.ts
@@ -94,9 +94,7 @@ describe("Experimental Test Suite", () => {
       expect(result.shapes.inputShapes.get(inputReadableId)?.type).toBe(
         "filesDatasource",
       );
-      expect(
-        result.shapes.inputShapeMetadata.get(inputReadableId),
-      ).toEqual({
+      expect(result.shapes.inputShapeMetadata.get(inputReadableId)).toEqual({
         isOptional: false,
         isAccessedInReconcile: true,
         reconcileAccessRequirements: "RESOURCE_EXISTENCE_REQUIRED",


### PR DESCRIPTION
## Summary

- mark generated backing Media Set view inputs as accessed during reconciliation
- require the backing Media Set resource to exist before ontology reconciliation
