### PR TITLE
Fix behavior when multiple useOsdkObjects hooks were sharing max pageSize

### DIFF
--- a/.changeset/stale-bees-wonder.md
+++ b/.changeset/stale-bees-wonder.md
@@ -1,0 +1,5 @@
+---
+"@osdk/client": patch
+---
+
+Fix bug where empty page size parameter was behaving incorrectly

--- a/.changeset/stale-bees-wonder.md
+++ b/.changeset/stale-bees-wonder.md
@@ -2,4 +2,4 @@
 "@osdk/client": patch
 ---
 
-Fix bug where empty page size parameter was behaving incorrectly
+Fix multiple useOsdkObjects hooks that share the same query incorrectly sharing a page size. Each hook now respects its configured pageSize, or the default of 100, regardless of subscription order.

--- a/packages/client/src/observable/internal/AbstractHelper.ts
+++ b/packages/client/src/observable/internal/AbstractHelper.ts
@@ -102,6 +102,16 @@ export abstract class AbstractHelper<
     } else {
       this.store.cacheKeys.retain(query.cacheKey);
     }
+    // For queries that support views (list-like queries), wrap with ListQueryView
+    // to handle per-subscriber view data such as pageSize
+    const listOptions = options as ListObserveOptions;
+    const view = supportsViews<PAYLOAD & BaseListPayloadShape>(query)
+      ? new ListQueryView<PAYLOAD & BaseListPayloadShape>(
+          query,
+          listOptions.pageSize ?? 100,
+          listOptions.autoFetchMore,
+        )
+      : undefined;
 
     if (options.mode !== "offline") {
       query.revalidate(options.mode === "force").catch((e: unknown) => {
@@ -118,20 +128,8 @@ export abstract class AbstractHelper<
       });
     }
 
-    // For queries that support views (list-like queries), wrap with ListQueryView
-    // to handle per-subscriber view data such as pageSize
-    const listOptions = options as ListObserveOptions;
-    const useView =
-      supportsViews<PAYLOAD & BaseListPayloadShape>(query) &&
-      (listOptions.pageSize !== undefined ||
-        listOptions.autoFetchMore !== undefined);
-
-    const sub = useView
-      ? new ListQueryView<PAYLOAD & BaseListPayloadShape>(
-          query,
-          listOptions.pageSize ?? 100,
-          listOptions.autoFetchMore,
-        ).subscribe(subFn as Observer<PAYLOAD & BaseListPayloadShape>)
+    const sub = view
+      ? view.subscribe(subFn as Observer<PAYLOAD & BaseListPayloadShape>)
       : query.subscribe(subFn);
 
     const querySub = new QuerySubscription(query, sub);

--- a/packages/client/src/observable/internal/list/ListQuery.test.ts
+++ b/packages/client/src/observable/internal/list/ListQuery.test.ts
@@ -1401,4 +1401,106 @@ describe("ListQuery shared query autoFetchMore tests", () => {
     expect(lastPayload?.hasMore).toBe(false);
     expect(lastPayload?.status).toBe("loaded");
   });
+
+  it("shared query: smaller pageSize subscriber first, default pageSize subscriber second", async () => {
+    setupTodos(fauxFoundry, 150);
+
+    testStage("Subscribe A with pageSize: 20");
+    const subA = mockListSubCallback();
+    defer(
+      store.lists.observe(
+        {
+          type: Todo,
+          where: {},
+          orderBy: {},
+          pageSize: 20,
+        },
+        subA,
+      ),
+    );
+
+    testStage("Wait for A to load 20 items");
+    const payloadA = await waitForPayload(
+      subA,
+      (p) => p?.status === "loaded" && p?.resolvedList?.length === 20,
+    );
+    expect(payloadA?.hasMore).toBe(true);
+
+    testStage("Subscribe B with the default pageSize");
+    const subB = mockListSubCallback();
+    defer(
+      store.lists.observe(
+        {
+          type: Todo,
+          where: {},
+          orderBy: {},
+        },
+        subB,
+      ),
+    );
+
+    testStage("Wait for B to load the default 100 items");
+    const payloadB = await waitForPayload(
+      subB,
+      (p) => p?.status === "loaded" && p?.resolvedList?.length === 100,
+    );
+    expect(payloadB?.hasMore).toBe(true);
+
+    testStage("Verify A still shows 20 items");
+    const aCalls = subA.next.mock.calls;
+    expect(aCalls).not.toHaveLength(0);
+    const lastPayloadA = aCalls[aCalls.length - 1][0];
+    expect(lastPayloadA?.resolvedList?.length).toBe(20);
+  });
+
+  it("shared query: default pageSize subscriber first, smaller pageSize subscriber second", async () => {
+    setupTodos(fauxFoundry, 150);
+
+    testStage("Subscribe A with the default pageSize");
+    const subA = mockListSubCallback();
+    defer(
+      store.lists.observe(
+        {
+          type: Todo,
+          where: {},
+          orderBy: {},
+        },
+        subA,
+      ),
+    );
+
+    testStage("Wait for A to load the default 100 items");
+    const payloadA = await waitForPayload(
+      subA,
+      (p) => p?.status === "loaded" && p?.resolvedList?.length === 100,
+    );
+    expect(payloadA?.hasMore).toBe(true);
+
+    testStage("Subscribe B with pageSize: 20");
+    const subB = mockListSubCallback();
+    defer(
+      store.lists.observe(
+        {
+          type: Todo,
+          where: {},
+          orderBy: {},
+          pageSize: 20,
+        },
+        subB,
+      ),
+    );
+
+    testStage("Wait for B to load 20 items");
+    const payloadB = await waitForPayload(
+      subB,
+      (p) => p?.status === "loaded" && p?.resolvedList?.length === 20,
+    );
+    expect(payloadB?.hasMore).toBe(true);
+
+    testStage("Verify A still shows 100 items");
+    const aCalls = subA.next.mock.calls;
+    expect(aCalls).not.toHaveLength(0);
+    const lastPayloadA = aCalls[aCalls.length - 1][0];
+    expect(lastPayloadA?.resolvedList?.length).toBe(100);
+  });
 });


### PR DESCRIPTION
Previously, if I had two `useOsdkObjects` hooks making the same query, with one of them setting a `pageSize` of 20, and the other without `pageSize`, both would only fetch 20.

With my changes, the query without a `pageSize` will now default to 100, which was the expected behavior.