### PR TITLE
Materialize array-valued struct interface implementations

### DIFF
--- a/.changeset/tidy-bands-map.md
+++ b/.changeset/tidy-bands-map.md
@@ -1,0 +1,5 @@
+---
+"@osdk/client": patch
+---
+
+Materialize array-valued struct interface implementations as arrays

--- a/packages/client/src/object/convertWireToOsdkObjects/createOsdkInterface.ts
+++ b/packages/client/src/object/convertWireToOsdkObjects/createOsdkInterface.ts
@@ -19,6 +19,7 @@ import type {
   ObjectMetadata,
   PropertySecurity,
 } from "@osdk/api";
+import invariant from "tiny-invariant";
 
 import { extractNamespace } from "../../internal/conversions/extractNamespace.js";
 import type { FetchedObjectTypeDefinition } from "../../ontology/OntologyProvider.js";
@@ -38,36 +39,95 @@ type PropertySecuritiesMap = {
 function extractValueByImplementation(
   underlying: Record<string, unknown>,
   impl: ObjectMetadata.InterfacePropertyImplementation,
+  multiplicity: boolean,
 ): unknown {
   switch (impl.type) {
     case "localProperty":
       return underlying[impl.propertyApiName];
     case "structField": {
-      const struct = underlying[impl.propertyApiName] as
-        | Record<string, unknown>
-        | null
-        | undefined;
-      return struct == null ? undefined : struct[impl.structFieldApiName];
-    }
-    case "struct":
-      return Object.fromEntries(
-        Object.entries(impl.mapping).map(([fieldName, entry]) => {
-          if (entry.type === "structFieldOfProperty") {
-            const struct = underlying[entry.propertyApiName] as
-              | Record<string, unknown>
-              | null
-              | undefined;
-            return [
-              fieldName,
-              struct == null ? undefined : struct[entry.structFieldApiName],
-            ];
-          }
-          return [fieldName, underlying[entry.propertyApiName]];
-        }),
+      const struct = underlying[impl.propertyApiName];
+      if (struct == null) return undefined;
+      return getStructField(
+        struct,
+        impl.propertyApiName,
+        impl.structFieldApiName,
       );
+    }
+    case "struct": {
+      const fieldMappings = Object.entries(impl.mapping);
+      if (!multiplicity) {
+        return Object.fromEntries(
+          fieldMappings.map(([fieldName, fieldMapping]) => [
+            fieldName,
+            extractStructFieldValue(
+              underlying[fieldMapping.propertyApiName],
+              fieldMapping,
+            ),
+          ]),
+        );
+      }
+
+      const propertyApiName = fieldMappings[0]?.[1].propertyApiName;
+      invariant(
+        propertyApiName != null,
+        "Expected struct implementation to map at least one field",
+      );
+      invariant(
+        fieldMappings.every(
+          ([, fieldMapping]) =>
+            fieldMapping.propertyApiName === propertyApiName,
+        ),
+        "Expected array struct implementation fields to use the same backing property",
+      );
+      const property = underlying[propertyApiName];
+      if (property == null) return undefined;
+      invariant(
+        Array.isArray(property),
+        `Expected '${propertyApiName}' to be an array`,
+      );
+      return property.map((value) =>
+        Object.fromEntries(
+          fieldMappings.map(([fieldName, fieldMapping]) => [
+            fieldName,
+            extractStructFieldValue(value, fieldMapping),
+          ]),
+        ),
+      );
+    }
     case "reduced":
-      return extractValueByImplementation(underlying, impl.implementation);
+      return extractValueByImplementation(
+        underlying,
+        impl.implementation,
+        false,
+      );
   }
+}
+
+function extractStructFieldValue(
+  value: unknown,
+  fieldMapping: ObjectMetadata.InterfacePropertyStructImplementation["mapping"][string],
+): unknown {
+  return fieldMapping.type === "structFieldOfProperty"
+    ? getStructField(
+        value,
+        fieldMapping.propertyApiName,
+        fieldMapping.structFieldApiName,
+      )
+    : value;
+}
+
+function getStructField(
+  value: unknown,
+  propertyApiName: string,
+  structFieldApiName: string,
+): unknown {
+  if (value == null) return undefined;
+  invariant(isStruct(value), `Expected '${propertyApiName}' to be a struct`);
+  return value[structFieldApiName];
+}
+
+function isStruct(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value != null && !Array.isArray(value);
 }
 
 /** @internal */
@@ -77,6 +137,7 @@ export function createOsdkInterface<Q extends FetchedObjectTypeDefinition>(
 ): InterfaceHolder {
   const [objApiNamespace] = extractNamespace(interfaceDef.apiName);
   const objDef = underlying[ObjectDefRef];
+  const underlyingProperties = underlying as unknown as Record<string, unknown>;
 
   return Object.freeze(
     Object.defineProperties(
@@ -155,8 +216,9 @@ export function createOsdkInterface<Q extends FetchedObjectTypeDefinition>(
 
             if (impl != null) {
               const value = extractValueByImplementation(
-                underlying as unknown as Record<string, unknown>,
+                underlyingProperties,
                 impl,
+                interfaceDef.properties[p].multiplicity === true,
               );
               return [
                 exposedName,

--- a/packages/client/src/objectSet/InterfaceObjectSet.test.ts
+++ b/packages/client/src/objectSet/InterfaceObjectSet.test.ts
@@ -155,6 +155,10 @@ describe("ObjectSet", () => {
                     beta: 42,
                     gamma: "ignored",
                   },
+                  multiStructArray: [
+                    { alpha: "first", beta: 1, gamma: "ignored" },
+                    { alpha: "second", beta: 2, gamma: "ignored" },
+                  ],
                   arrayValue: [1, 2, 3],
                 },
               ],
@@ -172,12 +176,43 @@ describe("ObjectSet", () => {
         expect(ifaceObj.iLocal).toEqual("hello");
         expect(ifaceObj.iStructField).toEqual("nested-label");
         expect(ifaceObj.iStruct).toEqual({ theAlpha: "a-val", theBeta: 42 });
+        expect(ifaceObj.iStructArray).toEqual([
+          { theAlpha: "first", theBeta: 1 },
+          { theAlpha: "second", theBeta: 2 },
+        ]);
         expect(ifaceObj.iReduced).toEqual([1, 2, 3]);
 
         // @ts-expect-error
         expect(() => ifaceObj.$as(ComplexImplementationObject)).toThrowError(
           /has a non-local implementation/u,
         );
+      })();
+    });
+
+    it("rejects a scalar backing property for an array struct implementation", async () => {
+      await apiServer.boundary(async () => {
+        apiServer.use(
+          MockOntologiesV2.OntologyObjectSets.loadMultipleObjectTypes(
+            baseUrl,
+            () => ({
+              data: [
+                {
+                  __primaryKey: "k1",
+                  __apiName: "ComplexImplementationObject",
+                  id: "k1",
+                  multiStructArray: { alpha: "first", beta: 1 },
+                },
+              ],
+              ...wireMappings,
+              totalCount: "1",
+              propertySecurities: [],
+            }),
+          ),
+        );
+
+        await expect(
+          client(ComplexImplementationInterface).fetchPage(),
+        ).rejects.toThrowError("Expected 'multiStructArray' to be an array");
       })();
     });
   });

--- a/packages/e2e.generated.catchall/ontology.json
+++ b/packages/e2e.generated.catchall/ontology.json
@@ -1116,25 +1116,25 @@
           "rid": "ri.ontology.main.interface.ee112779-ed04-44c6-bf84-9543513eb80b",
           "properties": {},
           "propertiesV2": {
-            "stringFromNonMainValueOfStruct": {
+            "stringFromStruct": {
               "type": "structFieldImplementation",
               "structFieldOfProperty": {
                 "propertyApiName": "struct",
                 "structFieldApiName": "string"
               }
             },
-            "stringFromReducedMainValueStructArray": {
+            "integerFromReducedMainValueStructArray": {
               "type": "structFieldImplementation",
               "structFieldOfProperty": {
                 "propertyApiName": "struct",
                 "structFieldApiName": "integer"
               }
             },
-            "stringFromArrayFromAlreadyReduced": {
+            "stringArray": {
               "type": "localPropertyImplementation",
               "propertyApiName": "stringArray"
             },
-            "stringFromSingleMainValue": {
+            "stringFromReducedArray": {
               "type": "reducedPropertyImplementation",
               "implementation": {
                 "type": "structFieldImplementation",
@@ -1144,7 +1144,7 @@
                 }
               }
             },
-            "structFromMultipleMainValue": {
+            "structWithLessPropsThanOt": {
               "type": "structImplementation",
               "mapping": {
                 "string": {
@@ -6600,94 +6600,10 @@
       "properties": {},
       "allProperties": {},
       "propertiesV2": {
-        "stringFromNonMainValueOfStruct": {
-          "type": "interfaceDefinedPropertyType",
-          "rid": "ri.ontology.main.interface-property.f73ecda3-ffb0-47f0-b16f-0b894c9a7006",
-          "apiName": "stringFromNonMainValueOfStruct",
-          "displayName": "stringFromStruct",
-          "dataType": {
-            "type": "string"
-          },
-          "requireImplementation": true,
-          "typeClasses": [
-            {
-              "kind": "render_hint",
-              "name": "SELECTABLE"
-            },
-            {
-              "kind": "render_hint",
-              "name": "SORTABLE"
-            }
-          ]
-        },
-        "stringFromReducedMainValueStructArray": {
-          "type": "interfaceDefinedPropertyType",
-          "rid": "ri.ontology.main.interface-property.6410cf6b-c991-46bd-9085-799ef71cba2d",
-          "apiName": "stringFromReducedMainValueStructArray",
-          "displayName": "integerFromReducedMainValueStructArray",
-          "dataType": {
-            "type": "integer"
-          },
-          "requireImplementation": true,
-          "typeClasses": [
-            {
-              "kind": "render_hint",
-              "name": "SELECTABLE"
-            },
-            {
-              "kind": "render_hint",
-              "name": "SORTABLE"
-            }
-          ]
-        },
-        "stringFromArrayFromAlreadyReduced": {
-          "type": "interfaceDefinedPropertyType",
-          "rid": "ri.ontology.main.interface-property.524744e2-cac6-4fe9-a112-bdf25fe3ceaa",
-          "apiName": "stringFromArrayFromAlreadyReduced",
-          "displayName": "stringArray",
-          "dataType": {
-            "type": "array",
-            "subType": {
-              "type": "string"
-            },
-            "reducers": []
-          },
-          "requireImplementation": true,
-          "typeClasses": [
-            {
-              "kind": "render_hint",
-              "name": "SELECTABLE"
-            },
-            {
-              "kind": "render_hint",
-              "name": "SORTABLE"
-            }
-          ]
-        },
-        "stringFromSingleMainValue": {
-          "type": "interfaceDefinedPropertyType",
-          "rid": "ri.ontology.main.interface-property.62bf7924-5ebd-4413-821f-f85a17fa2d04",
-          "apiName": "stringFromSingleMainValue",
-          "displayName": "stringFromReducedArray",
-          "dataType": {
-            "type": "string"
-          },
-          "requireImplementation": true,
-          "typeClasses": [
-            {
-              "kind": "render_hint",
-              "name": "SELECTABLE"
-            },
-            {
-              "kind": "render_hint",
-              "name": "SORTABLE"
-            }
-          ]
-        },
-        "structFromMultipleMainValue": {
+        "structWithLessPropsThanOt": {
           "type": "interfaceDefinedPropertyType",
           "rid": "ri.ontology.main.interface-property.0c837cd3-91ab-42c2-927d-6c72c3cd817f",
-          "apiName": "structFromMultipleMainValue",
+          "apiName": "structWithLessPropsThanOt",
           "displayName": "structWithLessPropsThanOt",
           "dataType": {
             "type": "struct",
@@ -6726,30 +6642,31 @@
           },
           "requireImplementation": true,
           "typeClasses": []
-        }
-      },
-      "allPropertiesV2": {
-        "stringFromReducedMainValueStructArray": {
+        },
+        "integerFromReducedMainValueStructArray": {
+          "type": "interfaceDefinedPropertyType",
           "rid": "ri.ontology.main.interface-property.6410cf6b-c991-46bd-9085-799ef71cba2d",
-          "apiName": "stringFromReducedMainValueStructArray",
+          "apiName": "integerFromReducedMainValueStructArray",
           "displayName": "integerFromReducedMainValueStructArray",
           "dataType": {
             "type": "integer"
           },
-          "requireImplementation": true
+          "requireImplementation": true,
+          "typeClasses": [
+            {
+              "kind": "render_hint",
+              "name": "SELECTABLE"
+            },
+            {
+              "kind": "render_hint",
+              "name": "SORTABLE"
+            }
+          ]
         },
-        "stringFromNonMainValueOfStruct": {
-          "rid": "ri.ontology.main.interface-property.f73ecda3-ffb0-47f0-b16f-0b894c9a7006",
-          "apiName": "stringFromNonMainValueOfStruct",
-          "displayName": "stringFromStruct",
-          "dataType": {
-            "type": "string"
-          },
-          "requireImplementation": true
-        },
-        "stringFromArrayFromAlreadyReduced": {
+        "stringArray": {
+          "type": "interfaceDefinedPropertyType",
           "rid": "ri.ontology.main.interface-property.524744e2-cac6-4fe9-a112-bdf25fe3ceaa",
-          "apiName": "stringFromArrayFromAlreadyReduced",
+          "apiName": "stringArray",
           "displayName": "stringArray",
           "dataType": {
             "type": "array",
@@ -6758,20 +6675,63 @@
             },
             "reducers": []
           },
-          "requireImplementation": true
+          "requireImplementation": true,
+          "typeClasses": [
+            {
+              "kind": "render_hint",
+              "name": "SELECTABLE"
+            },
+            {
+              "kind": "render_hint",
+              "name": "SORTABLE"
+            }
+          ]
         },
-        "stringFromSingleMainValue": {
+        "stringFromStruct": {
+          "type": "interfaceDefinedPropertyType",
+          "rid": "ri.ontology.main.interface-property.f73ecda3-ffb0-47f0-b16f-0b894c9a7006",
+          "apiName": "stringFromStruct",
+          "displayName": "stringFromStruct",
+          "dataType": {
+            "type": "string"
+          },
+          "requireImplementation": true,
+          "typeClasses": [
+            {
+              "kind": "render_hint",
+              "name": "SELECTABLE"
+            },
+            {
+              "kind": "render_hint",
+              "name": "SORTABLE"
+            }
+          ]
+        },
+        "stringFromReducedArray": {
+          "type": "interfaceDefinedPropertyType",
           "rid": "ri.ontology.main.interface-property.62bf7924-5ebd-4413-821f-f85a17fa2d04",
-          "apiName": "stringFromSingleMainValue",
+          "apiName": "stringFromReducedArray",
           "displayName": "stringFromReducedArray",
           "dataType": {
             "type": "string"
           },
-          "requireImplementation": true
-        },
-        "structFromMultipleMainValue": {
+          "requireImplementation": true,
+          "typeClasses": [
+            {
+              "kind": "render_hint",
+              "name": "SELECTABLE"
+            },
+            {
+              "kind": "render_hint",
+              "name": "SORTABLE"
+            }
+          ]
+        }
+      },
+      "allPropertiesV2": {
+        "structWithLessPropsThanOt": {
           "rid": "ri.ontology.main.interface-property.0c837cd3-91ab-42c2-927d-6c72c3cd817f",
-          "apiName": "structFromMultipleMainValue",
+          "apiName": "structWithLessPropsThanOt",
           "displayName": "structWithLessPropsThanOt",
           "dataType": {
             "type": "struct",
@@ -6807,6 +6767,46 @@
                 ]
               }
             ]
+          },
+          "requireImplementation": true
+        },
+        "integerFromReducedMainValueStructArray": {
+          "rid": "ri.ontology.main.interface-property.6410cf6b-c991-46bd-9085-799ef71cba2d",
+          "apiName": "integerFromReducedMainValueStructArray",
+          "displayName": "integerFromReducedMainValueStructArray",
+          "dataType": {
+            "type": "integer"
+          },
+          "requireImplementation": true
+        },
+        "stringArray": {
+          "rid": "ri.ontology.main.interface-property.524744e2-cac6-4fe9-a112-bdf25fe3ceaa",
+          "apiName": "stringArray",
+          "displayName": "stringArray",
+          "dataType": {
+            "type": "array",
+            "subType": {
+              "type": "string"
+            },
+            "reducers": []
+          },
+          "requireImplementation": true
+        },
+        "stringFromStruct": {
+          "rid": "ri.ontology.main.interface-property.f73ecda3-ffb0-47f0-b16f-0b894c9a7006",
+          "apiName": "stringFromStruct",
+          "displayName": "stringFromStruct",
+          "dataType": {
+            "type": "string"
+          },
+          "requireImplementation": true
+        },
+        "stringFromReducedArray": {
+          "rid": "ri.ontology.main.interface-property.62bf7924-5ebd-4413-821f-f85a17fa2d04",
+          "apiName": "stringFromReducedArray",
+          "displayName": "stringFromReducedArray",
+          "dataType": {
+            "type": "string"
           },
           "requireImplementation": true
         }

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/experimental/ontology-metadata.json
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/experimental/ontology-metadata.json
@@ -1180,25 +1180,25 @@
                     "rid": "ri.ontology.main.interface.ee112779-ed04-44c6-bf84-9543513eb80b",
                     "properties": {},
                     "propertiesV2": {
-                        "stringFromNonMainValueOfStruct": {
+                        "stringFromStruct": {
                             "type": "structFieldImplementation",
                             "structFieldOfProperty": {
                                 "propertyApiName": "struct",
                                 "structFieldApiName": "string"
                             }
                         },
-                        "stringFromReducedMainValueStructArray": {
+                        "integerFromReducedMainValueStructArray": {
                             "type": "structFieldImplementation",
                             "structFieldOfProperty": {
                                 "propertyApiName": "struct",
                                 "structFieldApiName": "integer"
                             }
                         },
-                        "stringFromArrayFromAlreadyReduced": {
+                        "stringArray": {
                             "type": "localPropertyImplementation",
                             "propertyApiName": "stringArray"
                         },
-                        "stringFromSingleMainValue": {
+                        "stringFromReducedArray": {
                             "type": "reducedPropertyImplementation",
                             "implementation": {
                                 "type": "structFieldImplementation",
@@ -1208,7 +1208,7 @@
                                 }
                             }
                         },
-                        "structFromMultipleMainValue": {
+                        "structWithLessPropsThanOt": {
                             "type": "structImplementation",
                             "mapping": {
                                 "string": {
@@ -7226,94 +7226,10 @@
             "properties": {},
             "allProperties": {},
             "propertiesV2": {
-                "stringFromNonMainValueOfStruct": {
-                    "type": "interfaceDefinedPropertyType",
-                    "rid": "ri.ontology.main.interface-property.f73ecda3-ffb0-47f0-b16f-0b894c9a7006",
-                    "apiName": "stringFromNonMainValueOfStruct",
-                    "displayName": "stringFromStruct",
-                    "dataType": {
-                        "type": "string"
-                    },
-                    "requireImplementation": true,
-                    "typeClasses": [
-                        {
-                            "kind": "render_hint",
-                            "name": "SELECTABLE"
-                        },
-                        {
-                            "kind": "render_hint",
-                            "name": "SORTABLE"
-                        }
-                    ]
-                },
-                "stringFromReducedMainValueStructArray": {
-                    "type": "interfaceDefinedPropertyType",
-                    "rid": "ri.ontology.main.interface-property.6410cf6b-c991-46bd-9085-799ef71cba2d",
-                    "apiName": "stringFromReducedMainValueStructArray",
-                    "displayName": "integerFromReducedMainValueStructArray",
-                    "dataType": {
-                        "type": "integer"
-                    },
-                    "requireImplementation": true,
-                    "typeClasses": [
-                        {
-                            "kind": "render_hint",
-                            "name": "SELECTABLE"
-                        },
-                        {
-                            "kind": "render_hint",
-                            "name": "SORTABLE"
-                        }
-                    ]
-                },
-                "stringFromArrayFromAlreadyReduced": {
-                    "type": "interfaceDefinedPropertyType",
-                    "rid": "ri.ontology.main.interface-property.524744e2-cac6-4fe9-a112-bdf25fe3ceaa",
-                    "apiName": "stringFromArrayFromAlreadyReduced",
-                    "displayName": "stringArray",
-                    "dataType": {
-                        "type": "array",
-                        "subType": {
-                            "type": "string"
-                        },
-                        "reducers": []
-                    },
-                    "requireImplementation": true,
-                    "typeClasses": [
-                        {
-                            "kind": "render_hint",
-                            "name": "SELECTABLE"
-                        },
-                        {
-                            "kind": "render_hint",
-                            "name": "SORTABLE"
-                        }
-                    ]
-                },
-                "stringFromSingleMainValue": {
-                    "type": "interfaceDefinedPropertyType",
-                    "rid": "ri.ontology.main.interface-property.62bf7924-5ebd-4413-821f-f85a17fa2d04",
-                    "apiName": "stringFromSingleMainValue",
-                    "displayName": "stringFromReducedArray",
-                    "dataType": {
-                        "type": "string"
-                    },
-                    "requireImplementation": true,
-                    "typeClasses": [
-                        {
-                            "kind": "render_hint",
-                            "name": "SELECTABLE"
-                        },
-                        {
-                            "kind": "render_hint",
-                            "name": "SORTABLE"
-                        }
-                    ]
-                },
-                "structFromMultipleMainValue": {
+                "structWithLessPropsThanOt": {
                     "type": "interfaceDefinedPropertyType",
                     "rid": "ri.ontology.main.interface-property.0c837cd3-91ab-42c2-927d-6c72c3cd817f",
-                    "apiName": "structFromMultipleMainValue",
+                    "apiName": "structWithLessPropsThanOt",
                     "displayName": "structWithLessPropsThanOt",
                     "dataType": {
                         "type": "struct",
@@ -7352,30 +7268,31 @@
                     },
                     "requireImplementation": true,
                     "typeClasses": []
-                }
-            },
-            "allPropertiesV2": {
-                "stringFromReducedMainValueStructArray": {
+                },
+                "integerFromReducedMainValueStructArray": {
+                    "type": "interfaceDefinedPropertyType",
                     "rid": "ri.ontology.main.interface-property.6410cf6b-c991-46bd-9085-799ef71cba2d",
-                    "apiName": "stringFromReducedMainValueStructArray",
+                    "apiName": "integerFromReducedMainValueStructArray",
                     "displayName": "integerFromReducedMainValueStructArray",
                     "dataType": {
                         "type": "integer"
                     },
-                    "requireImplementation": true
+                    "requireImplementation": true,
+                    "typeClasses": [
+                        {
+                            "kind": "render_hint",
+                            "name": "SELECTABLE"
+                        },
+                        {
+                            "kind": "render_hint",
+                            "name": "SORTABLE"
+                        }
+                    ]
                 },
-                "stringFromNonMainValueOfStruct": {
-                    "rid": "ri.ontology.main.interface-property.f73ecda3-ffb0-47f0-b16f-0b894c9a7006",
-                    "apiName": "stringFromNonMainValueOfStruct",
-                    "displayName": "stringFromStruct",
-                    "dataType": {
-                        "type": "string"
-                    },
-                    "requireImplementation": true
-                },
-                "stringFromArrayFromAlreadyReduced": {
+                "stringArray": {
+                    "type": "interfaceDefinedPropertyType",
                     "rid": "ri.ontology.main.interface-property.524744e2-cac6-4fe9-a112-bdf25fe3ceaa",
-                    "apiName": "stringFromArrayFromAlreadyReduced",
+                    "apiName": "stringArray",
                     "displayName": "stringArray",
                     "dataType": {
                         "type": "array",
@@ -7384,20 +7301,63 @@
                         },
                         "reducers": []
                     },
-                    "requireImplementation": true
+                    "requireImplementation": true,
+                    "typeClasses": [
+                        {
+                            "kind": "render_hint",
+                            "name": "SELECTABLE"
+                        },
+                        {
+                            "kind": "render_hint",
+                            "name": "SORTABLE"
+                        }
+                    ]
                 },
-                "stringFromSingleMainValue": {
+                "stringFromStruct": {
+                    "type": "interfaceDefinedPropertyType",
+                    "rid": "ri.ontology.main.interface-property.f73ecda3-ffb0-47f0-b16f-0b894c9a7006",
+                    "apiName": "stringFromStruct",
+                    "displayName": "stringFromStruct",
+                    "dataType": {
+                        "type": "string"
+                    },
+                    "requireImplementation": true,
+                    "typeClasses": [
+                        {
+                            "kind": "render_hint",
+                            "name": "SELECTABLE"
+                        },
+                        {
+                            "kind": "render_hint",
+                            "name": "SORTABLE"
+                        }
+                    ]
+                },
+                "stringFromReducedArray": {
+                    "type": "interfaceDefinedPropertyType",
                     "rid": "ri.ontology.main.interface-property.62bf7924-5ebd-4413-821f-f85a17fa2d04",
-                    "apiName": "stringFromSingleMainValue",
+                    "apiName": "stringFromReducedArray",
                     "displayName": "stringFromReducedArray",
                     "dataType": {
                         "type": "string"
                     },
-                    "requireImplementation": true
-                },
-                "structFromMultipleMainValue": {
+                    "requireImplementation": true,
+                    "typeClasses": [
+                        {
+                            "kind": "render_hint",
+                            "name": "SELECTABLE"
+                        },
+                        {
+                            "kind": "render_hint",
+                            "name": "SORTABLE"
+                        }
+                    ]
+                }
+            },
+            "allPropertiesV2": {
+                "structWithLessPropsThanOt": {
                     "rid": "ri.ontology.main.interface-property.0c837cd3-91ab-42c2-927d-6c72c3cd817f",
-                    "apiName": "structFromMultipleMainValue",
+                    "apiName": "structWithLessPropsThanOt",
                     "displayName": "structWithLessPropsThanOt",
                     "dataType": {
                         "type": "struct",
@@ -7433,6 +7393,46 @@
                                 ]
                             }
                         ]
+                    },
+                    "requireImplementation": true
+                },
+                "integerFromReducedMainValueStructArray": {
+                    "rid": "ri.ontology.main.interface-property.6410cf6b-c991-46bd-9085-799ef71cba2d",
+                    "apiName": "integerFromReducedMainValueStructArray",
+                    "displayName": "integerFromReducedMainValueStructArray",
+                    "dataType": {
+                        "type": "integer"
+                    },
+                    "requireImplementation": true
+                },
+                "stringArray": {
+                    "rid": "ri.ontology.main.interface-property.524744e2-cac6-4fe9-a112-bdf25fe3ceaa",
+                    "apiName": "stringArray",
+                    "displayName": "stringArray",
+                    "dataType": {
+                        "type": "array",
+                        "subType": {
+                            "type": "string"
+                        },
+                        "reducers": []
+                    },
+                    "requireImplementation": true
+                },
+                "stringFromStruct": {
+                    "rid": "ri.ontology.main.interface-property.f73ecda3-ffb0-47f0-b16f-0b894c9a7006",
+                    "apiName": "stringFromStruct",
+                    "displayName": "stringFromStruct",
+                    "dataType": {
+                        "type": "string"
+                    },
+                    "requireImplementation": true
+                },
+                "stringFromReducedArray": {
+                    "rid": "ri.ontology.main.interface-property.62bf7924-5ebd-4413-821f-f85a17fa2d04",
+                    "apiName": "stringFromReducedArray",
+                    "displayName": "stringFromReducedArray",
+                    "dataType": {
+                        "type": "string"
                     },
                     "requireImplementation": true
                 }

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/interfaces/ReducerTestInterface.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/interfaces/ReducerTestInterface.ts
@@ -14,33 +14,33 @@ export type OsdkObjectLinks$ReducerTestInterface = {};
 
 export namespace ReducerTestInterface {
   export type PropertyKeys =
-    | 'stringFromArrayFromAlreadyReduced'
-    | 'stringFromNonMainValueOfStruct'
-    | 'stringFromReducedMainValueStructArray'
-    | 'stringFromSingleMainValue'
-    | 'structFromMultipleMainValue';
+    | 'integerFromReducedMainValueStructArray'
+    | 'stringArray'
+    | 'stringFromReducedArray'
+    | 'stringFromStruct'
+    | 'structWithLessPropsThanOt';
 
   export interface Props {
     /**
-     *   display name: 'stringArray'
+     * (no ontology metadata)
      */
-    readonly stringFromArrayFromAlreadyReduced: $PropType['string'][] | undefined;
+    readonly integerFromReducedMainValueStructArray: $PropType['integer'] | undefined;
     /**
-     *   display name: 'stringFromStruct'
+     * (no ontology metadata)
      */
-    readonly stringFromNonMainValueOfStruct: $PropType['string'] | undefined;
+    readonly stringArray: $PropType['string'][] | undefined;
     /**
-     *   display name: 'integerFromReducedMainValueStructArray'
+     * (no ontology metadata)
      */
-    readonly stringFromReducedMainValueStructArray: $PropType['integer'] | undefined;
+    readonly stringFromReducedArray: $PropType['string'] | undefined;
     /**
-     *   display name: 'stringFromReducedArray'
+     * (no ontology metadata)
      */
-    readonly stringFromSingleMainValue: $PropType['string'] | undefined;
+    readonly stringFromStruct: $PropType['string'] | undefined;
     /**
-     *   display name: 'structWithLessPropsThanOt'
+     * (no ontology metadata)
      */
-    readonly structFromMultipleMainValue:
+    readonly structWithLessPropsThanOt:
       | { integer: $PropType['integer'] | undefined; string: $PropType['string'] | undefined }
       | undefined;
   }
@@ -77,25 +77,25 @@ export interface ReducerTestInterface extends $InterfaceDefinition {
     links: {};
     properties: {
       /**
-       *   display name: 'stringArray'
+       * (no ontology metadata)
        */
-      stringFromArrayFromAlreadyReduced: $PropertyDef<'string', 'nullable', 'array'>;
+      integerFromReducedMainValueStructArray: $PropertyDef<'integer', 'nullable', 'single'>;
       /**
-       *   display name: 'stringFromStruct'
+       * (no ontology metadata)
        */
-      stringFromNonMainValueOfStruct: $PropertyDef<'string', 'nullable', 'single'>;
+      stringArray: $PropertyDef<'string', 'nullable', 'array'>;
       /**
-       *   display name: 'integerFromReducedMainValueStructArray'
+       * (no ontology metadata)
        */
-      stringFromReducedMainValueStructArray: $PropertyDef<'integer', 'nullable', 'single'>;
+      stringFromReducedArray: $PropertyDef<'string', 'nullable', 'single'>;
       /**
-       *   display name: 'stringFromReducedArray'
+       * (no ontology metadata)
        */
-      stringFromSingleMainValue: $PropertyDef<'string', 'nullable', 'single'>;
+      stringFromStruct: $PropertyDef<'string', 'nullable', 'single'>;
       /**
-       *   display name: 'structWithLessPropsThanOt'
+       * (no ontology metadata)
        */
-      structFromMultipleMainValue: $PropertyDef<{ string: 'string'; integer: 'integer' }, 'nullable', 'single'>;
+      structWithLessPropsThanOt: $PropertyDef<{ string: 'string'; integer: 'integer' }, 'nullable', 'single'>;
     };
     rid: 'ri.ontology.main.interface.ee112779-ed04-44c6-bf84-9543513eb80b';
     type: 'interface';

--- a/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/ReducerTest.ts
+++ b/packages/e2e.generated.catchall/src/generatedNoCheck/ontology/objects/ReducerTest.ts
@@ -117,21 +117,21 @@ export interface ReducerTest extends $ObjectTypeDefinition {
     implements: ['ReducerTestInterface'];
     interfaceImplementations: {
       ReducerTestInterface: {
-        stringFromNonMainValueOfStruct: {
+        stringFromStruct: {
           type: 'structField';
           propertyApiName: 'struct';
           structFieldApiName: 'string';
         };
-        stringFromReducedMainValueStructArray: {
+        integerFromReducedMainValueStructArray: {
           type: 'structField';
           propertyApiName: 'struct';
           structFieldApiName: 'integer';
         };
-        stringFromArrayFromAlreadyReduced: {
+        stringArray: {
           type: 'localProperty';
           propertyApiName: 'stringArray';
         };
-        stringFromSingleMainValue: {
+        stringFromReducedArray: {
           type: 'reduced';
           implementation: {
             type: 'structField';
@@ -139,7 +139,7 @@ export interface ReducerTest extends $ObjectTypeDefinition {
             structFieldApiName: 'integer';
           };
         };
-        structFromMultipleMainValue: {
+        structWithLessPropsThanOt: {
           type: 'struct';
           mapping: {
             string: {
@@ -158,12 +158,12 @@ export interface ReducerTest extends $ObjectTypeDefinition {
     };
     interfaceMap: {
       ReducerTestInterface: {
-        stringFromArrayFromAlreadyReduced: 'stringArray';
+        stringArray: 'stringArray';
       };
     };
     inverseInterfaceMap: {
       ReducerTestInterface: {
-        stringArray: 'stringFromArrayFromAlreadyReduced';
+        stringArray: 'stringArray';
       };
     };
     links: {};

--- a/packages/shared.test/src/stubs/complexImplementationTypes.ts
+++ b/packages/shared.test/src/stubs/complexImplementationTypes.ts
@@ -91,6 +91,37 @@ export const complexImplementationObjectType: ObjectTypeV2 = {
       rid: "rid",
       typeClasses: [],
     },
+    multiStructArray: {
+      dataType: {
+        type: "array",
+        subType: {
+          type: "struct",
+          structFieldTypes: [
+            {
+              apiName: "alpha",
+              dataType: { type: "string" },
+              rid: "ri.struct.array.alpha",
+              typeClasses: [],
+            },
+            {
+              apiName: "beta",
+              dataType: { type: "integer" },
+              rid: "ri.struct.array.beta",
+              typeClasses: [],
+            },
+            {
+              apiName: "gamma",
+              dataType: { type: "string" },
+              rid: "ri.struct.array.gamma",
+              typeClasses: [],
+            },
+          ],
+        },
+        reducers: [],
+      },
+      rid: "rid",
+      typeClasses: [],
+    },
     arrayValue: {
       dataType: {
         type: "array",
@@ -161,6 +192,35 @@ export const ComplexImplementationInterface: InterfaceType = {
       requireImplementation: true,
       typeClasses: [],
     },
+    iStructArray: {
+      type: "interfaceDefinedPropertyType",
+      rid: "ri.interfacePropertyType.main.iStructArray",
+      apiName: "iStructArray",
+      displayName: "i Struct Array",
+      dataType: {
+        type: "array",
+        subType: {
+          type: "struct",
+          structFieldTypes: [
+            {
+              apiName: "theAlpha",
+              dataType: { type: "string" },
+              rid: "ri.iface.array.struct.theAlpha",
+              typeClasses: [],
+            },
+            {
+              apiName: "theBeta",
+              dataType: { type: "integer" },
+              rid: "ri.iface.array.struct.theBeta",
+              typeClasses: [],
+            },
+          ],
+        },
+        reducers: [],
+      },
+      requireImplementation: true,
+      typeClasses: [],
+    },
     iReduced: {
       type: "interfaceDefinedPropertyType",
       rid: "ri.interfacePropertyType.main.iReduced",
@@ -209,6 +269,33 @@ export const ComplexImplementationInterface: InterfaceType = {
       },
       requireImplementation: true,
     },
+    iStructArray: {
+      rid: "ri.interfacePropertyType.main.iStructArray",
+      apiName: "iStructArray",
+      displayName: "i Struct Array",
+      dataType: {
+        type: "array",
+        subType: {
+          type: "struct",
+          structFieldTypes: [
+            {
+              apiName: "theAlpha",
+              dataType: { type: "string" },
+              rid: "ri.iface.array.struct.theAlpha",
+              typeClasses: [],
+            },
+            {
+              apiName: "theBeta",
+              dataType: { type: "integer" },
+              rid: "ri.iface.array.struct.theBeta",
+              typeClasses: [],
+            },
+          ],
+        },
+        reducers: [],
+      },
+      requireImplementation: true,
+    },
     iReduced: {
       rid: "ri.interfacePropertyType.main.iReduced",
       apiName: "iReduced",
@@ -250,6 +337,21 @@ export const complexImplementationObjectTypeWithLinkTypes: ObjectTypeFullMetadat
               theBeta: {
                 type: "structFieldOfProperty",
                 propertyApiName: "multiStruct",
+                structFieldApiName: "beta",
+              },
+            },
+          },
+          iStructArray: {
+            type: "structImplementation",
+            mapping: {
+              theAlpha: {
+                type: "structFieldOfProperty",
+                propertyApiName: "multiStructArray",
+                structFieldApiName: "alpha",
+              },
+              theBeta: {
+                type: "structFieldOfProperty",
+                propertyApiName: "multiStructArray",
                 structFieldApiName: "beta",
               },
             },


### PR DESCRIPTION
## Summary

Interface materialization treated every struct implementation as a non-array value, leaving array-valued struct properties unresolved. If we saw a struct array implementation backed by a struct array, we need to map the array correctly.

This PR:

- materialize array-valued struct implementations element-by-element
- validate the expected single array-valued backing property shape
- add regression coverage for valid arrays and malformed scalar values