### PR TITLE
Test Blueprint next tokens in React components

### DIFF
--- a/.changeset/bright-tokens-map.md
+++ b/.changeset/bright-tokens-map.md
@@ -1,0 +1,5 @@
+---
+"@osdk/react-components": patch
+---
+
+Map React component theme aliases to Blueprint next-token semantic roles.

--- a/packages/e2e.sandbox.peopleapp/src/index.css
+++ b/packages/e2e.sandbox.peopleapp/src/index.css
@@ -6,8 +6,7 @@
 /* OSDK styles (tokens + components) */
 @import "@osdk/react-components/styles.css" layer(osdk.components);
 
-/* Import theme overrides (e.g., change primary intent to green) */
-/* @import "./theme-overrides.css" layer(custom.theme); */
+@import "./theme-overrides.css" layer(custom.theme);
 
 /* Tailwind for utility classes */
 @import "tailwindcss" layer(tailwind);

--- a/packages/e2e.sandbox.peopleapp/src/theme-overrides.css
+++ b/packages/e2e.sandbox.peopleapp/src/theme-overrides.css
@@ -1,139 +1,236 @@
 :root {
-  --bp-palette-black: oklch(0.2827 0.019 238.86);
+  --bp-palette-grey-100: oklch(0.9809 0.0025 228.78);
+  --bp-palette-grey-200: oklch(0.9686 0.0039 228.8022);
+  --bp-palette-grey-300: oklch(0.9542 0.0057 228.7167);
+  --bp-palette-grey-400: oklch(0.9178 0.0101 227.89);
+  --bp-palette-grey-500: oklch(0.8562 0.0148 244.74);
+  --bp-palette-grey-600: oklch(0.7185 0.0211 243.9);
+  --bp-palette-grey-700: oklch(0.6564 0.0238 243.9267);
+  --bp-palette-grey-800: oklch(0.5946 0.0262 240.8333);
+  --bp-palette-grey-900: oklch(0.3631 0.0246 242.1433);
+  --bp-palette-grey-1000: oklch(0.2519 0.0152 244.29);
 
-  --bp-palette-white: oklch(1 0 89.88);
+  --bp-palette-blue-100: oklch(0.917 0.0248 254.68);
+  --bp-palette-blue-200: oklch(0.8239 0.0656 245.54);
+  --bp-palette-blue-300: oklch(0.7307 0.1063 236.4);
+  --bp-palette-blue-400: oklch(0.6204 0.1379 245.54);
+  --bp-palette-blue-500: oklch(0.51 0.1695 254.68);
+  --bp-palette-blue-600: oklch(0.5048 0.1666 254.77);
+  --bp-palette-blue-700: oklch(0.4996 0.1637 254.86);
+  --bp-palette-blue-800: oklch(0.4486 0.1601 257.0167);
+  --bp-palette-blue-900: oklch(0.3976 0.1566 259.1733);
+  --bp-palette-blue-1000: oklch(0.3466 0.153 261.33);
 
-  /* Gray scale: dark-gray (1-5), gray (1-5), light-gray (1-5) */
-  --bp-palette-dark-gray-1: oklch(0.2519 0.0152 244.29);
-  --bp-palette-dark-gray-2: oklch(0.312 0.0154 240.46);
-  --bp-palette-dark-gray-3: oklch(0.404 0.032 243.49);
-  --bp-palette-dark-gray-4: oklch(0.5926 0.0263 240.38);
-  --bp-palette-dark-gray-5: oklch(0.6109 0.0257 244.46);
-  --bp-palette-gray-1: oklch(0.6792 0.0229 243.66);
-  --bp-palette-gray-2: oklch(0.6792 0.0229 243.66);
-  --bp-palette-gray-3: oklch(0.8562 0.0148 244.74);
-  --bp-palette-gray-4: oklch(0.8562 0.0148 244.74);
-  --bp-palette-gray-5: oklch(0.9178 0.0101 227.89);
-  --bp-palette-light-gray-1: oklch(0.9178 0.0101 227.89);
-  --bp-palette-light-gray-2: oklch(0.9587 0.0051 228.82);
-  --bp-palette-light-gray-3: oklch(0.9587 0.0051 228.82);
-  --bp-palette-light-gray-4: oklch(0.9809 0.0025 228.78);
-  --bp-palette-light-gray-5: oklch(0.9809 0.0025 228.78);
+  --bp-palette-green-100: oklch(0.9272 0.0284 150.75);
+  --bp-palette-green-200: oklch(0.789 0.0856 152.46);
+  --bp-palette-green-300: oklch(0.6507 0.1428 154.17);
+  --bp-palette-green-400: oklch(0.5737 0.142 152.46);
+  --bp-palette-green-500: oklch(0.4967 0.1412 150.75);
+  --bp-palette-green-600: oklch(0.4842 0.1337 150.995);
+  --bp-palette-green-700: oklch(0.4717 0.1263 151.24);
+  --bp-palette-green-800: oklch(0.4372 0.1164 151.5467);
+  --bp-palette-green-900: oklch(0.4026 0.1064 151.8533);
+  --bp-palette-green-1000: oklch(0.3681 0.0965 152.16);
 
-  /* Blue scale */
-  --bp-palette-blue-1: oklch(0.3466 0.153 261.33);
-  --bp-palette-blue-2: oklch(0.4996 0.1637 254.86);
-  --bp-palette-blue-3: oklch(0.51 0.1695 254.68);
-  --bp-palette-blue-4: oklch(0.7307 0.1063 236.4);
-  --bp-palette-blue-5: oklch(0.917 0.0248 254.68);
+  --bp-palette-orange-100: oklch(0.9056 0.0455 61.84);
+  --bp-palette-orange-200: oklch(0.8293 0.0947 63.715);
+  --bp-palette-orange-300: oklch(0.753 0.1439 65.59);
+  --bp-palette-orange-400: oklch(0.676 0.1421 63.715);
+  --bp-palette-orange-500: oklch(0.599 0.1403 61.84);
+  --bp-palette-orange-600: oklch(0.5774 0.1306 62);
+  --bp-palette-orange-700: oklch(0.5558 0.1209 62.16);
+  --bp-palette-orange-800: oklch(0.5175 0.1121 62.18);
+  --bp-palette-orange-900: oklch(0.4792 0.1034 62.2);
+  --bp-palette-orange-1000: oklch(0.4409 0.0946 62.22);
 
-  /* Green scale */
-  --bp-palette-green-1: oklch(0.3681 0.0965 152.16);
-  --bp-palette-green-2: oklch(0.4717 0.1263 151.24);
-  --bp-palette-green-3: oklch(0.4967 0.1412 150.75);
-  --bp-palette-green-4: oklch(0.6507 0.1428 154.17);
-  --bp-palette-green-5: oklch(0.9272 0.0284 150.75);
+  --bp-palette-red-100: oklch(0.8913 0.0408 29.6);
+  --bp-palette-red-200: oklch(0.7733 0.1078 28.51);
+  --bp-palette-red-300: oklch(0.6553 0.1748 27.42);
+  --bp-palette-red-400: oklch(0.6033 0.1919 28.51);
+  --bp-palette-red-500: oklch(0.5513 0.2089 29.6);
+  --bp-palette-red-600: oklch(0.5446 0.2031 29.395);
+  --bp-palette-red-700: oklch(0.5378 0.1973 29.19);
+  --bp-palette-red-800: oklch(0.5123 0.1863 29.1933);
+  --bp-palette-red-900: oklch(0.4869 0.1753 29.1967);
+  --bp-palette-red-1000: oklch(0.4614 0.1643 29.2);
 
-  /* Orange scale */
-  --bp-palette-orange-1: oklch(0.4409 0.0946 62.22);
-  --bp-palette-orange-2: oklch(0.5558 0.1209 62.16);
-  --bp-palette-orange-3: oklch(0.599 0.1403 61.84);
-  --bp-palette-orange-4: oklch(0.753 0.1439 65.59);
-  --bp-palette-orange-5: oklch(0.9056 0.0455 61.84);
+  --bp-palette-cerulean-100: oklch(0.8872 0.0375 238.05);
+  --bp-palette-cerulean-200: oklch(0.7876 0.079 236.32);
+  --bp-palette-cerulean-300: oklch(0.688 0.1205 234.59);
+  --bp-palette-cerulean-400: oklch(0.6138 0.12 236.32);
+  --bp-palette-cerulean-500: oklch(0.5395 0.1195 238.05);
+  --bp-palette-cerulean-600: oklch(0.5275 0.1142 237.93);
+  --bp-palette-cerulean-700: oklch(0.5154 0.1088 237.81);
+  --bp-palette-cerulean-800: oklch(0.4814 0.1011 237.79);
+  --bp-palette-cerulean-900: oklch(0.4473 0.0935 237.77);
+  --bp-palette-cerulean-1000: oklch(0.4133 0.0858 237.75);
 
-  /* Red scale */
-  --bp-palette-red-1: oklch(0.4614 0.1643 29.2);
-  --bp-palette-red-2: oklch(0.5378 0.1973 29.19);
-  --bp-palette-red-3: oklch(0.5513 0.2089 29.6);
-  --bp-palette-red-4: oklch(0.6553 0.1748 27.42);
-  --bp-palette-red-5: oklch(0.8913 0.0408 29.6);
+  --bp-palette-forest-100: oklch(0.8947 0.0646 144.08);
+  --bp-palette-forest-200: oklch(0.8031 0.127 144.295);
+  --bp-palette-forest-300: oklch(0.7115 0.1894 144.51);
+  --bp-palette-forest-400: oklch(0.6613 0.188 144.295);
+  --bp-palette-forest-500: oklch(0.6111 0.1866 144.08);
+  --bp-palette-forest-600: oklch(0.5988 0.1788 144.095);
+  --bp-palette-forest-700: oklch(0.5864 0.1709 144.11);
+  --bp-palette-forest-800: oklch(0.5536 0.1605 144.12);
+  --bp-palette-forest-900: oklch(0.5209 0.1502 144.13);
+  --bp-palette-forest-1000: oklch(0.4881 0.1398 144.14);
 
-  /* Cerulean scale */
-  --bp-palette-cerulean-1: oklch(0.4133 0.0858 237.75);
-  --bp-palette-cerulean-2: oklch(0.5154 0.1088 237.81);
-  --bp-palette-cerulean-3: oklch(0.5395 0.1195 238.05);
-  --bp-palette-cerulean-4: oklch(0.688 0.1205 234.59);
-  --bp-palette-cerulean-5: oklch(0.8872 0.0375 238.05);
+  --bp-palette-gold-100: oklch(0.9278 0.0468 81.27);
+  --bp-palette-gold-200: oklch(0.869 0.1023 82.86);
+  --bp-palette-gold-300: oklch(0.8101 0.1577 84.45);
+  --bp-palette-gold-400: oklch(0.7299 0.1518 82.86);
+  --bp-palette-gold-500: oklch(0.6496 0.1458 81.27);
+  --bp-palette-gold-600: oklch(0.6165 0.1324 81.565);
+  --bp-palette-gold-700: oklch(0.5835 0.119 81.86);
+  --bp-palette-gold-800: oklch(0.523 0.1059 82.8067);
+  --bp-palette-gold-900: oklch(0.4625 0.0928 83.7533);
+  --bp-palette-gold-1000: oklch(0.402 0.0797 84.7);
 
-  /* Forest scale */
-  --bp-palette-forest-1: oklch(0.4881 0.1398 144.14);
-  --bp-palette-forest-2: oklch(0.5864 0.1709 144.11);
-  --bp-palette-forest-3: oklch(0.6111 0.1866 144.08);
-  --bp-palette-forest-4: oklch(0.7115 0.1894 144.51);
-  --bp-palette-forest-5: oklch(0.8947 0.0646 144.08);
+  --bp-palette-indigo-100: oklch(0.8799 0.0407 307.72);
+  --bp-palette-indigo-200: oklch(0.7838 0.0933 307.59);
+  --bp-palette-indigo-300: oklch(0.6877 0.1458 307.46);
+  --bp-palette-indigo-400: oklch(0.6445 0.1513 307.59);
+  --bp-palette-indigo-500: oklch(0.6013 0.1567 307.72);
+  --bp-palette-indigo-600: oklch(0.591 0.1558 308.675);
+  --bp-palette-indigo-700: oklch(0.5807 0.155 309.63);
+  --bp-palette-indigo-800: oklch(0.5503 0.1448 309.84);
+  --bp-palette-indigo-900: oklch(0.5199 0.1346 310.05);
+  --bp-palette-indigo-1000: oklch(0.4895 0.1244 310.26);
 
-  /* Gold scale */
-  --bp-palette-gold-1: oklch(0.402 0.0797 84.7);
-  --bp-palette-gold-2: oklch(0.5835 0.119 81.86);
-  --bp-palette-gold-3: oklch(0.6496 0.1458 81.27);
-  --bp-palette-gold-4: oklch(0.8101 0.1577 84.45);
-  --bp-palette-gold-5: oklch(0.9278 0.0468 81.27);
+  --bp-palette-lime-100: oklch(0.93 0.0507 123.35);
+  --bp-palette-lime-200: oklch(0.8816 0.1101 122.73);
+  --bp-palette-lime-300: oklch(0.8332 0.1694 122.11);
+  --bp-palette-lime-400: oklch(0.7382 0.1661 122.73);
+  --bp-palette-lime-500: oklch(0.6431 0.1627 123.35);
+  --bp-palette-lime-600: oklch(0.6099 0.1459 123.275);
+  --bp-palette-lime-700: oklch(0.5766 0.1291 123.2);
+  --bp-palette-lime-800: oklch(0.5202 0.112 122.66);
+  --bp-palette-lime-900: oklch(0.4638 0.095 122.12);
+  --bp-palette-lime-1000: oklch(0.4074 0.0779 121.58);
 
-  /* Indigo scale */
-  --bp-palette-indigo-1: oklch(0.4895 0.1244 310.26);
-  --bp-palette-indigo-2: oklch(0.5807 0.155 309.63);
-  --bp-palette-indigo-3: oklch(0.6013 0.1567 307.72);
-  --bp-palette-indigo-4: oklch(0.6877 0.1458 307.46);
-  --bp-palette-indigo-5: oklch(0.8799 0.0407 307.72);
+  --bp-palette-rose-100: oklch(0.8654 0.0677 4.14);
+  --bp-palette-rose-200: oklch(0.7659 0.1404 2.845);
+  --bp-palette-rose-300: oklch(0.6664 0.2131 1.55);
+  --bp-palette-rose-400: oklch(0.621 0.2125 2.845);
+  --bp-palette-rose-500: oklch(0.5756 0.2119 4.14);
+  --bp-palette-rose-600: oklch(0.5672 0.2055 4.125);
+  --bp-palette-rose-700: oklch(0.5588 0.199 4.11);
+  --bp-palette-rose-800: oklch(0.5354 0.19 4.0133);
+  --bp-palette-rose-900: oklch(0.5119 0.1809 3.9167);
+  --bp-palette-rose-1000: oklch(0.4885 0.1719 3.82);
 
-  /* Lime scale */
-  --bp-palette-lime-1: oklch(0.4074 0.0779 121.58);
-  --bp-palette-lime-2: oklch(0.5766 0.1291 123.2);
-  --bp-palette-lime-3: oklch(0.6431 0.1627 123.35);
-  --bp-palette-lime-4: oklch(0.8332 0.1694 122.11);
-  --bp-palette-lime-5: oklch(0.93 0.0507 123.35);
+  --bp-palette-sepia-100: oklch(0.8889 0.02 64.34);
+  --bp-palette-sepia-200: oklch(0.7681 0.049 65.355);
+  --bp-palette-sepia-300: oklch(0.6473 0.0781 66.37);
+  --bp-palette-sepia-400: oklch(0.5863 0.082 65.355);
+  --bp-palette-sepia-500: oklch(0.5254 0.0858 64.34);
+  --bp-palette-sepia-600: oklch(0.5137 0.0817 64.38);
+  --bp-palette-sepia-700: oklch(0.502 0.0776 64.42);
+  --bp-palette-sepia-800: oklch(0.4683 0.0717 64.8133);
+  --bp-palette-sepia-900: oklch(0.4345 0.0657 65.2067);
+  --bp-palette-sepia-1000: oklch(0.4008 0.0598 65.6);
 
-  /* Rose scale */
-  --bp-palette-rose-1: oklch(0.4885 0.1719 3.82);
-  --bp-palette-rose-2: oklch(0.5588 0.199 4.11);
-  --bp-palette-rose-3: oklch(0.5756 0.2119 4.14);
-  --bp-palette-rose-4: oklch(0.6664 0.2131 1.55);
-  --bp-palette-rose-5: oklch(0.8654 0.0677 4.14);
+  --bp-palette-turquoise-100: oklch(0.916 0.0341 184.92);
+  --bp-palette-turquoise-200: oklch(0.8344 0.0822 185.105);
+  --bp-palette-turquoise-300: oklch(0.7528 0.1303 185.29);
+  --bp-palette-turquoise-400: oklch(0.6726 0.1219 185.105);
+  --bp-palette-turquoise-500: oklch(0.5923 0.1134 184.92);
+  --bp-palette-turquoise-600: oklch(0.5668 0.1044 185.005);
+  --bp-palette-turquoise-700: oklch(0.5413 0.0953 185.09);
+  --bp-palette-turquoise-800: oklch(0.4868 0.0858 184.8833);
+  --bp-palette-turquoise-900: oklch(0.4322 0.0762 184.6767);
+  --bp-palette-turquoise-1000: oklch(0.3777 0.0667 184.47);
 
-  /* Sepia scale */
-  --bp-palette-sepia-1: oklch(0.4008 0.0598 65.6);
-  --bp-palette-sepia-2: oklch(0.502 0.0776 64.42);
-  --bp-palette-sepia-3: oklch(0.5254 0.0858 64.34);
-  --bp-palette-sepia-4: oklch(0.6473 0.0781 66.37);
-  --bp-palette-sepia-5: oklch(0.8889 0.02 64.34);
+  --bp-palette-vermilion-100: oklch(0.8913 0.0449 34.41);
+  --bp-palette-vermilion-200: oklch(0.7821 0.1073 34.85);
+  --bp-palette-vermilion-300: oklch(0.6728 0.1697 35.29);
+  --bp-palette-vermilion-400: oklch(0.6159 0.1811 34.85);
+  --bp-palette-vermilion-500: oklch(0.559 0.1926 34.41);
+  --bp-palette-vermilion-600: oklch(0.5493 0.187 34.305);
+  --bp-palette-vermilion-700: oklch(0.5396 0.1813 34.2);
+  --bp-palette-vermilion-800: oklch(0.5096 0.1706 34.3033);
+  --bp-palette-vermilion-900: oklch(0.4795 0.16 34.4067);
+  --bp-palette-vermilion-1000: oklch(0.4495 0.1493 34.51);
 
-  /* Turquoise scale */
-  --bp-palette-turquoise-1: oklch(0.3777 0.0667 184.47);
-  --bp-palette-turquoise-2: oklch(0.5413 0.0953 185.09);
-  --bp-palette-turquoise-3: oklch(0.5923 0.1134 184.92);
-  --bp-palette-turquoise-4: oklch(0.7528 0.1303 185.29);
-  --bp-palette-turquoise-5: oklch(0.916 0.0341 184.92);
+  --bp-palette-violet-100: oklch(0.8867 0.0342 327.64);
+  --bp-palette-violet-200: oklch(0.7675 0.0912 327.375);
+  --bp-palette-violet-300: oklch(0.6483 0.1481 327.11);
+  --bp-palette-violet-400: oklch(0.5759 0.1591 327.375);
+  --bp-palette-violet-500: oklch(0.5034 0.17 327.64);
+  --bp-palette-violet-600: oklch(0.4899 0.1601 327.625);
+  --bp-palette-violet-700: oklch(0.4763 0.1502 327.61);
+  --bp-palette-violet-800: oklch(0.4396 0.137 327.5867);
+  --bp-palette-violet-900: oklch(0.403 0.1237 327.5633);
+  --bp-palette-violet-1000: oklch(0.3663 0.1105 327.54);
 
-  /* Vermilion scale */
-  --bp-palette-vermilion-1: oklch(0.4495 0.1493 34.51);
-  --bp-palette-vermilion-2: oklch(0.5396 0.1813 34.2);
-  --bp-palette-vermilion-3: oklch(0.559 0.1926 34.41);
-  --bp-palette-vermilion-4: oklch(0.6728 0.1697 35.29);
-  --bp-palette-vermilion-5: oklch(0.8913 0.0449 34.41);
+  --bp-palette-white-100: oklch(1 0 89.88 / 0.06);
+  --bp-palette-white-200: oklch(1 0 89.88 / 0.12);
+  --bp-palette-white-300: oklch(1 0 89.88 / 0.2);
+  --bp-palette-white-400: oklch(1 0 89.88 / 0.3);
+  --bp-palette-white-500: oklch(1 0 89.88 / 0.5);
+  --bp-palette-white-600: oklch(1 0 89.88 / 0.8);
+  --bp-palette-white-700: oklch(1 0 89.88 / 0.85);
+  --bp-palette-white-800: oklch(1 0 89.88 / 0.9);
+  --bp-palette-white-900: oklch(1 0 89.88 / 0.95);
+  --bp-palette-white-1000: oklch(1 0 89.88 / 1);
 
-  /* Violet scale */
-  --bp-palette-violet-1: oklch(0.3663 0.1105 327.54);
-  --bp-palette-violet-2: oklch(0.4763 0.1502 327.61);
-  --bp-palette-violet-3: oklch(0.5034 0.17 327.64);
-  --bp-palette-violet-4: oklch(0.6483 0.1481 327.11);
-  --bp-palette-violet-5: oklch(0.8867 0.0342 327.64);
+  --bp-palette-black-100: oklch(0.2827 0.019 238.86 / 0.06);
+  --bp-palette-black-200: oklch(0.2827 0.019 238.86 / 0.12);
+  --bp-palette-black-300: oklch(0.2827 0.019 238.86 / 0.2);
+  --bp-palette-black-400: oklch(0.2827 0.019 238.86 / 0.3);
+  --bp-palette-black-500: oklch(0.2827 0.019 238.86 / 0.5);
+  --bp-palette-black-600: oklch(0.2827 0.019 238.86 / 0.8);
+  --bp-palette-black-700: oklch(0.2827 0.019 238.86 / 0.85);
+  --bp-palette-black-800: oklch(0.2827 0.019 238.86 / 0.9);
+  --bp-palette-black-900: oklch(0.2827 0.019 238.86 / 0.95);
+  --bp-palette-black-1000: oklch(0.2827 0.019 238.86 / 1);
 
-  /* OSDK tokens override */
-  --osdk-checkbox-border: var(--bp-surface-border-width) solid
-    var(--bp-surface-border-color-strong);
-  --osdk-checkbox-bg-hover: var(--bp-palette-gray-5);
-  --osdk-checkbox-bg-active: var(--bp-palette-gray-4);
-  --osdk-checkbox-bg-checked: var(--bp-palette-white);
-  --osdk-checkbox-bg-checked-hover: var(--bp-palette-light-gray-5);
-  --osdk-checkbox-bg-checked-active: var(--osdk-checkbox-bg-active);
-  --osdk-checkbox-checked-foreground: var(--bp-palette-dark-gray-1);
-
-  --osdk-table-header-color: var(--bp-typography-color-default-rest);
-  --osdk-table-row-bg-default: var(--bp-palette-white);
-  --osdk-table-row-bg-alternate: oklch(
-    from var(--bp-palette-light-gray-5) l c h / 0.5
+  --bp-surface-divider-color-default: oklch(
+    from var(--bp-palette-grey-700) l c h / 0.12
   );
-  --osdk-table-row-bg-hover: var(--bp-surface-background-color-default-hover);
-  --osdk-table-row-border-color-hover: var(--osdk-table-border-color);
-  --osdk-table-row-bg-active: var(--bp-palette-blue-5);
+  --bp-surface-divider-color-strong: oklch(
+    from var(--bp-palette-grey-700) l c h / 0.25
+  );
+  --bp-surface-border-color-neutral: var(--bp-palette-grey-200);
+  --bp-surface-border-color-primary: var(--bp-palette-blue-200);
+  --bp-surface-border-color-success: var(--bp-palette-green-200);
+  --bp-surface-border-color-warning: var(--bp-palette-orange-200);
+  --bp-surface-border-color-danger: var(--bp-palette-red-200);
+  --bp-surface-shadow-0: 0 0 5px 0 oklch(0 0 0 / 0.1);
+  --bp-surface-shadow-1:
+    0 1px 3px 0 oklch(0 0 0 / 0.2), 0 1px 2px -1px oklch(0 0 0 / 0.2);
+  --bp-surface-shadow-2:
+    0 4px 6px -4px oklch(0 0 0 / 0.2), 0 10px 15px -3px oklch(0 0 0 / 0.2);
+  --bp-surface-shadow-3:
+    0 20px 25px -5px oklch(0 0 0 / 0.2), 0 10px 15px -3px oklch(0 0 0 / 0.2);
+  --bp-surface-shadow-4: 0 25px 50px -12px oklch(0 0 0 / 0.4);
+  --bp-surface-background-color-base-rest: var(--bp-palette-white-1000);
+  --bp-surface-background-color-base-hover: var(--bp-palette-grey-100);
+  --bp-surface-background-color-base-active: var(--bp-palette-grey-200);
+  --bp-surface-layer-neutral-rest: linear-gradient(
+    var(--bp-palette-grey-100) 0 0
+  );
+  --bp-surface-layer-neutral-hover: linear-gradient(
+    var(--bp-palette-grey-200) 0 0
+  );
+  --bp-surface-layer-neutral-active: linear-gradient(
+    var(--bp-palette-grey-300) 0 0
+  );
+  --bp-surface-layer-primary-rest: linear-gradient(
+    var(--bp-palette-blue-100) 0 0
+  );
+  --bp-surface-layer-primary-hover: linear-gradient(
+    var(--bp-palette-blue-200) 0 0
+  );
+  --bp-surface-layer-primary-active: linear-gradient(
+    var(--bp-palette-blue-300) 0 0
+  );
+  --bp-typography-color-base: var(--bp-palette-grey-1000);
+  --bp-typography-color-intent-neutral: var(--bp-palette-grey-700);
+  --bp-typography-color-intent-primary: var(--bp-palette-blue-600);
+  --bp-typography-color-intent-success: var(--bp-palette-green-600);
+  --bp-typography-color-intent-warning: var(--bp-palette-orange-600);
+  --bp-typography-color-intent-danger: var(--bp-palette-red-600);
+  --bp-emphasis-focus-color: var(--bp-intent-primary-500);
 }

--- a/packages/react-components-storybook/.storybook/addons/brand-theme-extractor/decorator.tsx
+++ b/packages/react-components-storybook/.storybook/addons/brand-theme-extractor/decorator.tsx
@@ -19,125 +19,38 @@ import type { Decorator } from "@storybook/react-vite";
 import { useEffect, useMemo } from "react";
 
 import { GLOBALS_KEY } from "./constants.js";
-import { resolveAvailableFontFamily } from "./font-utils.js";
 import { parseBrandThemeState } from "./state.js";
-import { getTokenRole } from "./token-map.js";
 
-const STYLE_ID = "brand-theme-overrides";
-
-/**
- * Preview-side decorator that reads brand theme globals and injects
- * a <style> tag with CSS custom property overrides into the preview
- * document head. Uses :root with high specificity to override theme values.
- */
 export const BrandThemeDecorator: Decorator = (Story, context) => {
   const rawState = context.globals[GLOBALS_KEY];
   const brandTheme = useMemo(() => parseBrandThemeState(rawState), [rawState]);
 
-  const cssText = useMemo(() => {
-    if (!brandTheme.assignments || brandTheme.assignments.length === 0) {
-      return "";
+  useEffect(() => {
+    const root = document.documentElement;
+    const customTheme = brandTheme.selectedPresetId.startsWith("workshop-")
+      ? undefined
+      : brandTheme.selectedPresetId;
+
+    if (customTheme) {
+      root.dataset.theme = customTheme;
+    } else {
+      delete root.dataset.theme;
     }
 
-    // Apply the current preset's overrides. No reset phase is needed:
-    // the style element's textContent is fully replaced on each theme
-    // switch, so stale values from a previous preset cannot linger.
-    // Avoiding `initial` resets preserves compound tokens (e.g.
-    // --osdk-input-bg, --osdk-dialog-bg) that reference overridden
-    // properties via var() — `initial` would make them the
-    // guaranteed-invalid value, breaking the entire derivation chain.
-    const overrides: string[] = [];
-
-    for (const assignment of brandTheme.assignments) {
-      const roleDef = getTokenRole(assignment.role);
-      if (!roleDef) continue;
-
-      let value: string | undefined = assignment.customValue;
-
-      if (!value) continue;
-
-      if (
-        (roleDef.inputType === "px" || roleDef.inputType === "ms") &&
-        /^\d+(\.\d+)?$/u.test(value)
-      ) {
-        value = `${value}${roleDef.inputType}`;
-      }
-
-      // For font families, only apply fonts actually installed on this machine.
-      // A missing brand font would otherwise be swapped for the browser default
-      // (serif) on some surfaces while others keep the sans, producing a
-      // two-font mismatch. When no named font is available locally we skip the
-      // override so the base token's default stack stands everywhere.
-      if (roleDef.inputType === "font") {
-        value = resolveAvailableFontFamily(value);
-        if (!value) continue;
-      }
-
-      for (const prop of roleDef.cssProperties) {
-        overrides.push(`  ${prop}: ${value};`);
-      }
+    if (brandTheme.colorMode === "dark") {
+      root.setAttribute("data-bp-color-scheme", "dark");
+      root.classList.add(Classes.DARK);
+    } else {
+      root.removeAttribute("data-bp-color-scheme");
+      root.classList.remove(Classes.DARK);
     }
 
-    if (overrides.length === 0) return "";
-
-    // Re-assert compound tokens so custom themes use the themed surface
-    // border instead of the Blueprint palette-based box-shadow defaults.
-    overrides.push(
-      "  --osdk-input-focus-outline: 1px solid var(--osdk-intent-primary-rest);",
-      "  --osdk-surface-border: var(--osdk-surface-border-width) solid var(--osdk-surface-border-color-default);",
-      "  --osdk-input-shadow: inset 0 0 0 var(--osdk-surface-border-width) var(--osdk-surface-border-color-default);",
-      "  --osdk-input-shadow-error: inset 0 0 0 var(--osdk-surface-border-width) var(--osdk-intent-danger-rest);",
-      "  --osdk-input-focus-shadow: inset 0 0 0 var(--osdk-surface-border-width) var(--osdk-surface-border-color-default);",
-      "  --osdk-input-focus-shadow-error: inset 0 0 0 var(--osdk-surface-border-width) var(--osdk-intent-danger-rest);",
-      "  --osdk-button-shadow: inset 0 0 0 var(--osdk-surface-border-width) var(--osdk-surface-border-color-default);",
-    );
-
-    // Use :root:root (doubled specificity) to override theme layers.
-    return `:root:root {\n${overrides.join("\n")}\n}`;
-  }, [brandTheme.assignments]);
-
-  useEffect(
-    function syncBrandThemeOverrideStyle() {
-      let styleEl = document.getElementById(STYLE_ID);
-
-      if (cssText) {
-        if (!styleEl) {
-          styleEl = document.createElement("style");
-          styleEl.id = STYLE_ID;
-          document.head.appendChild(styleEl);
-        }
-        styleEl.textContent = cssText;
-      } else if (styleEl) {
-        styleEl.remove();
-      }
-
-      return () => {
-        if (styleEl) styleEl.remove();
-      };
-    },
-    [cssText],
-  );
-
-  useEffect(
-    function applyBlueprintColorMode() {
-      const root = document.documentElement;
-      if (brandTheme.colorMode === "dark") {
-        root.setAttribute("data-bp-color-scheme", "dark");
-        // Blueprint component styles still use this class in addition to its
-        // design-token attribute, including dialogs portaled to document.body.
-        root.classList.add(Classes.DARK);
-      } else {
-        root.removeAttribute("data-bp-color-scheme");
-        root.classList.remove(Classes.DARK);
-      }
-
-      return () => {
-        root.removeAttribute("data-bp-color-scheme");
-        root.classList.remove(Classes.DARK);
-      };
-    },
-    [brandTheme.colorMode],
-  );
+    return () => {
+      delete root.dataset.theme;
+      root.removeAttribute("data-bp-color-scheme");
+      root.classList.remove(Classes.DARK);
+    };
+  }, [brandTheme.colorMode, brandTheme.selectedPresetId]);
 
   return <Story />;
 };

--- a/packages/react-components-storybook/.storybook/themes.css
+++ b/packages/react-components-storybook/.storybook/themes.css
@@ -1,165 +1,98 @@
-/* light and dark themes are handled in the components by default `*/
-
-/* Modern theme - based on e2e.sandbox.peopleapp theme-overrides.css */
-[data-theme="modern"] {
-  /* Blueprint palette tokens from peopleapp */
-  --bp-palette-black: oklch(0.2827 0.019 238.86);
-  --bp-palette-white: oklch(1 0 89.88);
-
-  /* Gray scale: dark-gray (1-5), gray (1-5), light-gray (1-5) */
-  --bp-palette-dark-gray-1: oklch(0.2519 0.0152 244.29);
-  --bp-palette-dark-gray-2: oklch(0.312 0.0154 240.46);
-  --bp-palette-dark-gray-3: oklch(0.404 0.032 243.49);
-  --bp-palette-dark-gray-4: oklch(0.5926 0.0263 240.38);
-  --bp-palette-dark-gray-5: oklch(0.6109 0.0257 244.46);
-  --bp-palette-gray-1: oklch(0.6792 0.0229 243.66);
-  --bp-palette-gray-2: oklch(0.6792 0.0229 243.66);
-  --bp-palette-gray-3: oklch(0.8562 0.0148 244.74);
-  --bp-palette-gray-4: oklch(0.8562 0.0148 244.74);
-  --bp-palette-gray-5: oklch(0.9178 0.0101 227.89);
-  --bp-palette-gray-100: oklch(0.93 0.008 240);
-  --bp-palette-gray-200: oklch(0.88 0.012 240);
-  --bp-palette-light-gray-1: oklch(0.9178 0.0101 227.89);
-  --bp-palette-light-gray-2: oklch(0.9587 0.0051 228.82);
-  --bp-palette-light-gray-3: oklch(0.9587 0.0051 228.82);
-  --bp-palette-light-gray-4: oklch(0.9809 0.0025 228.78);
-  --bp-palette-light-gray-5: oklch(0.9809 0.0025 228.78);
-
-  /* Blue scale */
-  --bp-palette-blue-1: oklch(0.3466 0.153 261.33);
-  --bp-palette-blue-2: oklch(0.4996 0.1637 254.86);
-  --bp-palette-blue-3: oklch(0.51 0.1695 254.68);
-  --bp-palette-blue-4: oklch(0.7307 0.1063 236.4);
-  --bp-palette-blue-5: oklch(0.917 0.0248 254.68);
-
-  /* Green scale */
-  --bp-palette-green-1: oklch(0.3681 0.0965 152.16);
-  --bp-palette-green-2: oklch(0.4717 0.1263 151.24);
-  --bp-palette-green-3: oklch(0.4967 0.1412 150.75);
-  --bp-palette-green-4: oklch(0.6507 0.1428 154.17);
-  --bp-palette-green-5: oklch(0.9272 0.0284 150.75);
-
-  /* Orange scale */
-  --bp-palette-orange-1: oklch(0.4409 0.0946 62.22);
-  --bp-palette-orange-2: oklch(0.5558 0.1209 62.16);
-  --bp-palette-orange-3: oklch(0.599 0.1403 61.84);
-  --bp-palette-orange-4: oklch(0.753 0.1439 65.59);
-  --bp-palette-orange-5: oklch(0.9056 0.0455 61.84);
-
-  /* Red scale */
-  --bp-palette-red-1: oklch(0.4614 0.1643 29.2);
-  --bp-palette-red-2: oklch(0.5378 0.1973 29.19);
-  --bp-palette-red-3: oklch(0.5513 0.2089 29.6);
-  --bp-palette-red-4: oklch(0.6553 0.1748 27.42);
-  --bp-palette-red-5: oklch(0.8913 0.0408 29.6);
-
-  /* OSDK tokens overrides from peopleapp */
-  --osdk-checkbox-border: var(--bp-surface-border-width) solid
-    var(--bp-surface-border-color-strong);
-  --osdk-checkbox-bg-hover: var(--bp-palette-gray-5);
-  --osdk-checkbox-bg-active: var(--bp-palette-gray-4);
-  --osdk-checkbox-bg-checked: var(--bp-palette-white);
-  --osdk-checkbox-bg-checked-hover: var(--bp-palette-light-gray-5);
-  --osdk-checkbox-bg-checked-active: var(--osdk-checkbox-bg-active);
-  --osdk-checkbox-checked-foreground: var(--bp-palette-dark-gray-1);
-
-  --osdk-table-header-color: var(--bp-typography-color-default-rest);
-  --osdk-table-row-bg-default: var(--bp-palette-white);
-  --osdk-table-row-bg-alternate: oklch(
-    from var(--bp-palette-light-gray-5) l c h / 0.5
-  );
-  --osdk-table-row-bg-hover: var(--bp-surface-background-color-default-hover);
-  --osdk-table-row-border-color-hover: var(--osdk-table-border-color);
-  --osdk-table-row-bg-active: var(--bp-palette-blue-5);
-
-  /* Background for the app */
-  background-color: var(--bp-palette-white);
-  color: var(--bp-palette-dark-gray-1);
+[data-theme="devcon"] {
+  --bp-surface-background-color-base-rest: #0a0a0a;
+  --bp-surface-background-color-base-hover: #111111;
+  --bp-surface-background-color-base-active: #1a1a1a;
+  --bp-surface-divider-color-default: #15803d;
+  --bp-surface-divider-color-strong: #16a34a;
+  --bp-intent-neutral-300: #166534;
+  --bp-intent-neutral-400: #15803d;
+  --bp-intent-neutral-500: #16a34a;
+  --bp-intent-neutral-600: #22c55e;
+  --bp-intent-neutral-700: #4ade80;
+  --bp-intent-neutral-800: #86efac;
+  --bp-intent-neutral-900: #bbf7d0;
+  --bp-intent-neutral-1000: #dcfce7;
+  --bp-intent-neutral-foreground: #0a0a0a;
+  --bp-intent-primary-300: #15803d;
+  --bp-intent-primary-500: #16a34a;
+  --bp-intent-primary-600: #22c55e;
+  --bp-intent-primary-700: #4ade80;
+  --bp-intent-primary-foreground: #0a0a0a;
+  --bp-typography-color-base: #86efac;
+  --bp-typography-color-intent-neutral: #16a34a;
+  --bp-typography-color-intent-primary: #22c55e;
+  --bp-emphasis-focus-color: #16a34a;
 }
 
-[data-theme="devcon"] {
-  /* ===== DevCon Green Palette ===== */
-  --devcon-green-50: #f0fdf4;
-  --devcon-green-100: #dcfce7;
-  --devcon-green-200: #bbf7d0;
-  --devcon-green-300: #86efac;
-  --devcon-green-400: #4ade80;
-  --devcon-green-500: #22c55e;
-  --devcon-green-600: #16a34a;
-  --devcon-green-700: #15803d;
-  --devcon-green-800: #166534;
-  --devcon-green-900: #14532d;
+[data-theme="midnight-blue"] {
+  --bp-surface-background-color-base-rest: #0f172a;
+  --bp-surface-background-color-base-hover: #1e293b;
+  --bp-surface-background-color-base-active: #334155;
+  --bp-surface-divider-color-default: #334155;
+  --bp-surface-divider-color-strong: #475569;
+  --bp-intent-neutral-300: #475569;
+  --bp-intent-neutral-400: #64748b;
+  --bp-intent-neutral-500: #94a3b8;
+  --bp-intent-neutral-600: #cbd5e1;
+  --bp-intent-neutral-700: #e2e8f0;
+  --bp-intent-neutral-foreground: #0f172a;
+  --bp-intent-primary-300: #60a5fa;
+  --bp-intent-primary-500: #2563eb;
+  --bp-intent-primary-600: #1d4ed8;
+  --bp-intent-primary-700: #1e40af;
+  --bp-intent-primary-foreground: #ffffff;
+  --bp-typography-color-base: #e2e8f0;
+  --bp-typography-color-intent-neutral: #94a3b8;
+  --bp-typography-color-intent-primary: #60a5fa;
+  --bp-emphasis-focus-color: #2563eb;
+}
 
-  --devcon-bg-dark: #0a0a0a;
-  --devcon-bg-card: #111111;
-  --devcon-bg-elevated: #1a1a1a;
+[data-theme="warm-sand"] {
+  --bp-surface-background-color-base-rest: #faf8f5;
+  --bp-surface-background-color-base-hover: #f5f0eb;
+  --bp-surface-background-color-base-active: #ebe5de;
+  --bp-surface-divider-color-default: #d6d3d1;
+  --bp-surface-divider-color-strong: #a8a29e;
+  --bp-intent-neutral-300: #d6d3d1;
+  --bp-intent-neutral-400: #a8a29e;
+  --bp-intent-neutral-500: #78716c;
+  --bp-intent-neutral-600: #57534e;
+  --bp-intent-neutral-700: #44403c;
+  --bp-intent-neutral-800: #292524;
+  --bp-intent-neutral-900: #1c1917;
+  --bp-intent-neutral-1000: #0c0a09;
+  --bp-intent-neutral-foreground: #ffffff;
+  --bp-intent-primary-300: #fb923c;
+  --bp-intent-primary-500: #c2410c;
+  --bp-intent-primary-600: #9a3412;
+  --bp-intent-primary-700: #7c2d12;
+  --bp-intent-primary-foreground: #ffffff;
+  --bp-typography-color-base: #1c1917;
+  --bp-typography-color-intent-neutral: #78716c;
+  --bp-typography-color-intent-primary: #c2410c;
+  --bp-emphasis-focus-color: #c2410c;
+}
 
-  /* ===== OSDK Intent Token Mappings ===== */
-  --osdk-intent-default-foreground: black;
-  --osdk-intent-default-hover: #2a2a2a;
-  --osdk-intent-primary-rest: var(--devcon-green-600);
-  --osdk-intent-primary-foreground: var(--devcon-bg-dark);
-  --osdk-intent-primary-hover: var(--devcon-green-500);
-  --osdk-intent-primary-active: var(--devcon-green-400);
-
-  /* ===== OSDK Emphasis Token Mappings ===== */
-  --osdk-emphasis-focus-color: var(--osdk-intent-primary-rest);
-
-  /* ===== Checkbox Overrides ===== */
-  --osdk-checkbox-border: 1px solid var(--devcon-green-600);
-  --osdk-checkbox-bg: transparent;
-  --osdk-checkbox-bg-hover: rgba(34, 197, 94, 0.1);
-  --osdk-checkbox-bg-active: rgba(34, 197, 94, 0.2);
-  --osdk-checkbox-bg-checked: var(--devcon-green-600);
-  --osdk-checkbox-bg-checked-hover: var(--devcon-green-500);
-  --osdk-checkbox-bg-checked-active: var(--devcon-green-400);
-  --osdk-checkbox-checked-foreground: var(--devcon-bg-dark);
-
-  /* ===== Table Overrides ===== */
-  --osdk-table-border-color: var(--devcon-green-700);
-  --osdk-table-header-bg: var(--devcon-green-900);
-  --osdk-table-header-color: var(--devcon-green-300);
-
-  --osdk-table-row-bg-default: var(--devcon-bg-dark);
-  --osdk-table-row-bg-alternate: var(--devcon-bg-dark);
-  --osdk-table-row-bg-active: rgba(34, 197, 94, 0.2);
-  --osdk-table-row-border-color-hover: var(--devcon-green-500);
-  --osdk-table-row-border-color-active: var(--devcon-green-400);
-
-  --osdk-table-cell-color: var(--devcon-green-300);
-
-  --osdk-table-pinned-column-border: 1px solid var(--devcon-green-500);
-
-  /* Skeleton loading */
-  --osdk-table-skeleton-color-from: rgba(34, 197, 94, 0.1);
-  --osdk-table-skeleton-color-to: rgba(34, 197, 94, 0.2);
-
-  /* ===== Surface Overrides ===== */
-  --osdk-surface-border-color-default: var(--devcon-green-700);
-  --osdk-surface-background-color-default-rest: var(--devcon-bg-card);
-  --osdk-surface-background-color-default-hover: var(--devcon-bg-elevated);
-  --osdk-surface-background-color-default-active: rgba(34, 197, 94, 0.2);
-  --osdk-background-primary: var(--devcon-bg-dark);
-  --osdk-background-secondary: var(--devcon-bg-elevated);
-  --osdk-background-backdrop: color-mix(
-    in srgb,
-    var(--osdk-palette-white) 50%,
-    transparent
-  );
-
-  /* ===== Typography Overrides ===== */
-  --osdk-typography-color-muted: var(--devcon-green-600);
-  --osdk-typography-color-default-rest: var(--devcon-green-300);
-
-  /* ===== Header Menu Button (3-dot menu) ===== */
-  --osdk-table-header-menu-bg: transparent;
-  --osdk-table-header-menu-bg-hover: rgba(34, 197, 94, 0.15);
-  --osdk-table-header-menu-bg-active: rgba(34, 197, 94, 0.25);
-  --osdk-table-header-menu-color: var(--devcon-green-400);
-
-  body,
-  input {
-    color: var(--osdk-typography-color-default-rest);
-    background-color: var(--devcon-bg-dark);
-  }
+[data-theme="royal-purple"] {
+  --bp-surface-background-color-base-rest: #1a1025;
+  --bp-surface-background-color-base-hover: #2d1b4e;
+  --bp-surface-background-color-base-active: #3b2563;
+  --bp-surface-divider-color-default: #4c1d95;
+  --bp-surface-divider-color-strong: #6d28d9;
+  --bp-intent-neutral-300: #4c1d95;
+  --bp-intent-neutral-400: #7c3aed;
+  --bp-intent-neutral-500: #a78bfa;
+  --bp-intent-neutral-600: #c4b5fd;
+  --bp-intent-neutral-700: #ddd6fe;
+  --bp-intent-neutral-800: #e9d5ff;
+  --bp-intent-neutral-foreground: #1a1025;
+  --bp-intent-primary-300: #c084fc;
+  --bp-intent-primary-500: #9333ea;
+  --bp-intent-primary-600: #a855f7;
+  --bp-intent-primary-700: #c084fc;
+  --bp-intent-primary-foreground: #ffffff;
+  --bp-typography-color-base: #e9d5ff;
+  --bp-typography-color-intent-neutral: #a78bfa;
+  --bp-typography-color-intent-primary: #c084fc;
+  --bp-emphasis-focus-color: #a855f7;
 }

--- a/packages/react-components/docs/CSSVariables.md
+++ b/packages/react-components/docs/CSSVariables.md
@@ -96,7 +96,6 @@ Control layout, spacing, shadows, and z-index layering.
 | `--osdk-surface-background-color-default-active` | `--bp-surface-background-color-default-active` | Active state background for surfaces       |
 | `--osdk-surface-background-color-danger-rest`    | `--bp-surface-background-color-danger-rest`    | Danger rest state background               |
 | `--osdk-surface-background-color-danger-hover`   | `--bp-surface-background-color-danger-hover`   | Danger hover state background              |
-| `--osdk-surface-background-color-danger-active`  | `--bp-surface-background-color-danger-active`  | Danger active state background             |
 | `--osdk-surface-spacing`                         | `--bp-surface-spacing`                         | Base spacing unit (4px)                    |
 | `--osdk-surface-shadow-2`                        | `--bp-surface-shadow-2`                        | Shadow for tooltips and popovers           |
 
@@ -104,24 +103,20 @@ Control layout, spacing, shadows, and z-index layering.
 
 Control text appearance.
 
-| Variable                                   | Maps to Blueprint Token                  | Description                  |
-| ------------------------------------------ | ---------------------------------------- | ---------------------------- |
-| `--osdk-typography-family-default`         | `--bp-typography-family-default`         | Default font family          |
-| `--osdk-typography-color-muted`            | `--bp-typography-color-muted`            | Muted/subtle text color      |
-| `--osdk-typography-color-default-rest`     | `--bp-typography-color-default-rest`     | Default text color           |
-| `--osdk-typography-color-default-hover`    | `--bp-typography-color-default-hover`    | Default hover text color     |
-| `--osdk-typography-color-default-active`   | `--bp-typography-color-default-active`   | Default active text color    |
-| `--osdk-typography-color-default-disabled` | `--bp-typography-color-default-disabled` | Default disabled text color  |
-| `--osdk-typography-color-primary-rest`     | `--bp-typography-color-primary-rest`     | Theme-aware primary text     |
-| `--osdk-typography-color-danger-rest`      | `--bp-typography-color-danger-rest`      | Danger text color            |
-| `--osdk-typography-color-danger-active`    | `--bp-typography-color-danger-active`    | Danger active text color     |
-| `--osdk-typography-size-body-x-small`      | `--bp-typography-size-body-x-small`      | Extra-small body text size   |
-| `--osdk-typography-size-body-small`        | `--bp-typography-size-body-small`        | Small body text size         |
-| `--osdk-typography-size-body-medium`       | `--bp-typography-size-body-medium`       | Medium body text size (13px) |
-| `--osdk-typography-size-body-large`        | `--bp-typography-size-body-large`        | Large body text size         |
-| `--osdk-typography-line-height-default`    | `--bp-typography-line-height-default`    | Default line height          |
-| `--osdk-typography-weight-default`         | `--bp-typography-weight-default`         | Default font weight          |
-| `--osdk-typography-weight-bold`            | `--bp-typography-weight-bold`            | Bold font weight             |
+| Variable                                | Maps to Blueprint Token               | Description                  |
+| --------------------------------------- | ------------------------------------- | ---------------------------- |
+| `--osdk-typography-family-default`      | `--bp-typography-family-default`      | Default font family          |
+| `--osdk-typography-color-muted`         | `--bp-typography-color-muted`         | Muted/subtle text color      |
+| `--osdk-typography-color-default-rest`  | `--bp-typography-color-default-rest`  | Default text color           |
+| `--osdk-typography-color-primary-rest`  | `--bp-typography-color-primary-rest`  | Theme-aware primary text     |
+| `--osdk-typography-color-danger-rest`   | `--bp-typography-color-danger-rest`   | Danger text color            |
+| `--osdk-typography-size-body-x-small`   | `--bp-typography-size-body-x-small`   | Extra-small body text size   |
+| `--osdk-typography-size-body-small`     | `--bp-typography-size-body-small`     | Small body text size         |
+| `--osdk-typography-size-body-medium`    | `--bp-typography-size-body-medium`    | Medium body text size (13px) |
+| `--osdk-typography-size-body-large`     | `--bp-typography-size-body-large`     | Large body text size         |
+| `--osdk-typography-line-height-default` | `--bp-typography-line-height-default` | Default line height          |
+| `--osdk-typography-weight-default`      | `--bp-typography-weight-default`      | Default font weight          |
+| `--osdk-typography-weight-bold`         | `--bp-typography-weight-bold`         | Bold font weight             |
 
 ### Intent Tokens
 
@@ -129,30 +124,23 @@ Semantic colors for interactive elements and states.
 
 | Variable                           | Maps to Blueprint Token          | Description                       |
 | ---------------------------------- | -------------------------------- | --------------------------------- |
-| `--osdk-intent-default-rest`       | `--bp-intent-default-rest`       | Default rest state                |
-| `--osdk-intent-default-hover`      | `--bp-intent-default-hover`      | Default hover state               |
-| `--osdk-intent-default-active`     | `--bp-intent-default-active`     | Default active/pressed state      |
-| `--osdk-intent-default-disabled`   | `--bp-intent-default-disabled`   | Default disabled state            |
-| `--osdk-intent-default-foreground` | `--bp-intent-default-foreground` | Text color on default backgrounds |
-| `--osdk-intent-primary-rest`       | `--bp-intent-primary-rest`       | Primary rest state                |
-| `--osdk-intent-primary-hover`      | `--bp-intent-primary-hover`      | Primary hover state               |
-| `--osdk-intent-primary-active`     | `--bp-intent-primary-active`     | Primary active/pressed state      |
-| `--osdk-intent-primary-disabled`   | `--bp-intent-primary-disabled`   | Primary disabled state            |
+| `--osdk-intent-default-rest`       | `--bp-intent-neutral-500`        | Default rest state                |
+| `--osdk-intent-default-hover`      | `--bp-intent-neutral-600`        | Default hover state               |
+| `--osdk-intent-default-active`     | `--bp-intent-neutral-700`        | Default active/pressed state      |
+| `--osdk-intent-primary-rest`       | `--bp-intent-primary-500`        | Primary rest state                |
+| `--osdk-intent-primary-hover`      | `--bp-intent-primary-600`        | Primary hover state               |
+| `--osdk-intent-primary-active`     | `--bp-intent-primary-700`        | Primary active/pressed state      |
 | `--osdk-intent-primary-foreground` | `--bp-intent-primary-foreground` | Text color on primary backgrounds |
-| `--osdk-intent-success-rest`       | `--bp-intent-success-rest`       | Success rest state                |
-| `--osdk-intent-success-hover`      | `--bp-intent-success-hover`      | Success hover state               |
-| `--osdk-intent-success-active`     | `--bp-intent-success-active`     | Success active/pressed state      |
-| `--osdk-intent-success-disabled`   | `--bp-intent-success-disabled`   | Success disabled state            |
+| `--osdk-intent-success-rest`       | `--bp-intent-success-500`        | Success rest state                |
+| `--osdk-intent-success-hover`      | `--bp-intent-success-600`        | Success hover state               |
+| `--osdk-intent-success-active`     | `--bp-intent-success-700`        | Success active/pressed state      |
 | `--osdk-intent-success-foreground` | `--bp-intent-success-foreground` | Text color on success backgrounds |
-| `--osdk-intent-warning-rest`       | `--bp-intent-warning-rest`       | Warning rest state                |
-| `--osdk-intent-warning-hover`      | `--bp-intent-warning-hover`      | Warning hover state               |
-| `--osdk-intent-warning-active`     | `--bp-intent-warning-active`     | Warning active/pressed state      |
-| `--osdk-intent-warning-disabled`   | `--bp-intent-warning-disabled`   | Warning disabled state            |
-| `--osdk-intent-warning-foreground` | `--bp-intent-warning-foreground` | Text color on warning backgrounds |
-| `--osdk-intent-danger-rest`        | `--bp-intent-danger-rest`        | Danger rest state                 |
-| `--osdk-intent-danger-hover`       | `--bp-intent-danger-hover`       | Danger hover state                |
-| `--osdk-intent-danger-active`      | `--bp-intent-danger-active`      | Danger active/pressed state       |
-| `--osdk-intent-danger-disabled`    | `--bp-intent-danger-disabled`    | Danger disabled state             |
+| `--osdk-intent-warning-rest`       | `--bp-intent-warning-500`        | Warning rest state                |
+| `--osdk-intent-warning-hover`      | `--bp-intent-warning-600`        | Warning hover state               |
+| `--osdk-intent-warning-active`     | `--bp-intent-warning-700`        | Warning active/pressed state      |
+| `--osdk-intent-danger-rest`        | `--bp-intent-danger-500`         | Danger rest state                 |
+| `--osdk-intent-danger-hover`       | `--bp-intent-danger-600`         | Danger hover state                |
+| `--osdk-intent-danger-active`      | `--bp-intent-danger-700`         | Danger active/pressed state       |
 | `--osdk-intent-danger-foreground`  | `--bp-intent-danger-foreground`  | Text color on danger backgrounds  |
 
 ### Iconography Tokens
@@ -182,15 +170,9 @@ Raw color palette tokens.
 
 | Variable                      | Maps to Blueprint Token     | Description  |
 | ----------------------------- | --------------------------- | ------------ |
-| `--osdk-palette-blue-4`       | `--bp-palette-blue-4`       | Blue 4       |
 | `--osdk-palette-gray-1`       | `--bp-palette-gray-1`       | Gray 1       |
 | `--osdk-palette-gray-2`       | `--bp-palette-gray-2`       | Gray 2       |
 | `--osdk-palette-gray-4`       | `--bp-palette-gray-4`       | Gray 4       |
-| `--osdk-palette-red-4`        | `--bp-palette-red-4`        | Red 4        |
-| `--osdk-palette-dark-gray-2`  | `--bp-palette-dark-gray-2`  | Dark gray 2  |
-| `--osdk-palette-dark-gray-3`  | `--bp-palette-dark-gray-3`  | Dark gray 3  |
-| `--osdk-palette-light-gray-1` | `--bp-palette-light-gray-1` | Light gray 1 |
-| `--osdk-palette-light-gray-3` | `--bp-palette-light-gray-3` | Light gray 3 |
 | `--osdk-palette-light-gray-4` | `--bp-palette-light-gray-4` | Light gray 4 |
 | `--osdk-palette-light-gray-5` | `--bp-palette-light-gray-5` | Light gray 5 |
 | `--osdk-palette-white`        | `--bp-palette-white`        | White        |
@@ -228,7 +210,6 @@ These tokens are pre-calculated colors with opacity for specific UI effects.
 | `--osdk-custom-color-gray-2`       | `color-mix(in srgb, var(--osdk-palette-gray-1) 8%, transparent)`        | Gray at 8% opacity           |
 | `--osdk-custom-color-gray-3`       | `color-mix(in srgb, var(--osdk-palette-gray-1) 10%, transparent)`       | Gray at 10% opacity          |
 | `--osdk-custom-color-gray-4`       | `color-mix(in srgb, var(--osdk-palette-gray-1) 20%, transparent)`       | Gray at 20% opacity          |
-| `--osdk-custom-color-light-gray-1` | `color-mix(in srgb, var(--osdk-palette-light-gray-1) 60%, transparent)` | Light gray at 60% opacity    |
 | `--osdk-custom-color-light-gray-2` | `color-mix(in srgb, var(--osdk-palette-light-gray-5) 50%, transparent)` | Light gray at 50% opacity    |
 | `--osdk-custom-color-primary-1`    | `color-mix(in srgb, var(--osdk-intent-primary-rest) 50%, transparent)`  | Primary color at 50% opacity |
 

--- a/packages/react-components/docs/CSSVariables.md
+++ b/packages/react-components/docs/CSSVariables.md
@@ -1869,4 +1869,5 @@ To customize dark-mode tokens beyond the defaults, declare your overrides in a h
 
 ### Tokens flipped in dark mode
 
-The package overrides only `--osdk-*` tokens in dark mode. `--bp-*` tokens flip independently via Blueprint's own dark block. Tokens with identical light/dark values (primary/danger/success intents, sizes, weights, spacing, focus width) are not overridden. See `src/tokens/base-tokens/dark.css` for the full list.
+The package maps OSDK aliases to Blueprint next tokens. Blueprint's dark block
+changes the same `--bp-*` tokens, so no OSDK-specific dark overrides are needed.

--- a/packages/react-components/docs/TokenColors.md
+++ b/packages/react-components/docs/TokenColors.md
@@ -15,10 +15,6 @@ semantic tokens.
 | `--osdk-palette-gray-1`       | `--bp-palette-gray-1`       |
 | `--osdk-palette-gray-2`       | `--bp-palette-gray-2`       |
 | `--osdk-palette-gray-4`       | `--bp-palette-gray-4`       |
-| `--osdk-palette-dark-gray-2`  | `--bp-palette-dark-gray-2`  |
-| `--osdk-palette-dark-gray-3`  | `--bp-palette-dark-gray-3`  |
-| `--osdk-palette-light-gray-1` | `--bp-palette-light-gray-1` |
-| `--osdk-palette-light-gray-3` | `--bp-palette-light-gray-3` |
 | `--osdk-palette-light-gray-4` | `--bp-palette-light-gray-4` |
 | `--osdk-palette-light-gray-5` | `--bp-palette-light-gray-5` |
 
@@ -37,57 +33,49 @@ Higher-level tokens that abstract palette usage into meaningful roles.
 
 ## Intent Tokens
 
-Intent tokens define interactive color states. Each intent has five states:
-`rest`, `hover`, `active`, `disabled`, and `foreground`.
+Intent tokens define interactive color states and foreground pairings.
 
 ### Default
 
-| Token                              | Maps to                          |
-| ---------------------------------- | -------------------------------- |
-| `--osdk-intent-default-rest`       | `--bp-intent-default-rest`       |
-| `--osdk-intent-default-hover`      | `--bp-intent-default-hover`      |
-| `--osdk-intent-default-active`     | `--bp-intent-default-active`     |
-| `--osdk-intent-default-disabled`   | `--bp-intent-default-disabled`   |
-| `--osdk-intent-default-foreground` | `--bp-intent-default-foreground` |
+| Token                          | Maps to                   |
+| ------------------------------ | ------------------------- |
+| `--osdk-intent-default-rest`   | `--bp-intent-neutral-500` |
+| `--osdk-intent-default-hover`  | `--bp-intent-neutral-600` |
+| `--osdk-intent-default-active` | `--bp-intent-neutral-700` |
 
 ### Primary
 
 | Token                              | Maps to                          |
 | ---------------------------------- | -------------------------------- |
-| `--osdk-intent-primary-rest`       | `--bp-intent-primary-rest`       |
-| `--osdk-intent-primary-hover`      | `--bp-intent-primary-hover`      |
-| `--osdk-intent-primary-active`     | `--bp-intent-primary-active`     |
-| `--osdk-intent-primary-disabled`   | `--bp-intent-primary-disabled`   |
+| `--osdk-intent-primary-rest`       | `--bp-intent-primary-500`        |
+| `--osdk-intent-primary-hover`      | `--bp-intent-primary-600`        |
+| `--osdk-intent-primary-active`     | `--bp-intent-primary-700`        |
 | `--osdk-intent-primary-foreground` | `--bp-intent-primary-foreground` |
 
 ### Success
 
 | Token                              | Maps to                          |
 | ---------------------------------- | -------------------------------- |
-| `--osdk-intent-success-rest`       | `--bp-intent-success-rest`       |
-| `--osdk-intent-success-hover`      | `--bp-intent-success-hover`      |
-| `--osdk-intent-success-active`     | `--bp-intent-success-active`     |
-| `--osdk-intent-success-disabled`   | `--bp-intent-success-disabled`   |
+| `--osdk-intent-success-rest`       | `--bp-intent-success-500`        |
+| `--osdk-intent-success-hover`      | `--bp-intent-success-600`        |
+| `--osdk-intent-success-active`     | `--bp-intent-success-700`        |
 | `--osdk-intent-success-foreground` | `--bp-intent-success-foreground` |
 
 ### Warning
 
-| Token                              | Maps to                          |
-| ---------------------------------- | -------------------------------- |
-| `--osdk-intent-warning-rest`       | `--bp-intent-warning-rest`       |
-| `--osdk-intent-warning-hover`      | `--bp-intent-warning-hover`      |
-| `--osdk-intent-warning-active`     | `--bp-intent-warning-active`     |
-| `--osdk-intent-warning-disabled`   | `--bp-intent-warning-disabled`   |
-| `--osdk-intent-warning-foreground` | `--bp-intent-warning-foreground` |
+| Token                          | Maps to                   |
+| ------------------------------ | ------------------------- |
+| `--osdk-intent-warning-rest`   | `--bp-intent-warning-500` |
+| `--osdk-intent-warning-hover`  | `--bp-intent-warning-600` |
+| `--osdk-intent-warning-active` | `--bp-intent-warning-700` |
 
 ### Danger
 
 | Token                             | Maps to                         |
 | --------------------------------- | ------------------------------- |
-| `--osdk-intent-danger-rest`       | `--bp-intent-danger-rest`       |
-| `--osdk-intent-danger-hover`      | `--bp-intent-danger-hover`      |
-| `--osdk-intent-danger-active`     | `--bp-intent-danger-active`     |
-| `--osdk-intent-danger-disabled`   | `--bp-intent-danger-disabled`   |
+| `--osdk-intent-danger-rest`       | `--bp-intent-danger-500`        |
+| `--osdk-intent-danger-hover`      | `--bp-intent-danger-600`        |
+| `--osdk-intent-danger-active`     | `--bp-intent-danger-700`        |
 | `--osdk-intent-danger-foreground` | `--bp-intent-danger-foreground` |
 
 ## Surface Tokens
@@ -99,7 +87,6 @@ Intent tokens define interactive color states. Each intent has five states:
 | `--osdk-surface-background-color-default-active` | `--bp-surface-background-color-default-active` |
 | `--osdk-surface-background-color-danger-rest`    | `--bp-surface-background-color-danger-rest`    |
 | `--osdk-surface-background-color-danger-hover`   | `--bp-surface-background-color-danger-hover`   |
-| `--osdk-surface-background-color-danger-active`  | `--bp-surface-background-color-danger-active`  |
 | `--osdk-surface-border-color-default`            | `--bp-surface-border-color-default`            |
 | `--osdk-surface-border-color-strong`             | `--bp-surface-border-color-strong`             |
 
@@ -113,18 +100,13 @@ Derived colors using `color-mix()` for opacity effects.
 | `--osdk-custom-color-gray-2`       | `color-mix(gray-1, 8%)`               |
 | `--osdk-custom-color-gray-3`       | `color-mix(gray-1, 10%)`              |
 | `--osdk-custom-color-gray-4`       | `color-mix(gray-1, 20%)`              |
-| `--osdk-custom-color-light-gray-1` | `color-mix(light-gray-1, 60%)`        |
 | `--osdk-custom-color-light-gray-2` | `color-mix(light-gray-5, 50%)`        |
 | `--osdk-custom-color-primary-1`    | `color-mix(intent-primary-rest, 50%)` |
 
 ## Typography Color Tokens
 
-| Token                                      | Maps to                                  |
-| ------------------------------------------ | ---------------------------------------- |
-| `--osdk-typography-color-default-rest`     | `--bp-typography-color-default-rest`     |
-| `--osdk-typography-color-default-hover`    | `--bp-typography-color-default-hover`    |
-| `--osdk-typography-color-default-active`   | `--bp-typography-color-default-active`   |
-| `--osdk-typography-color-default-disabled` | `--bp-typography-color-default-disabled` |
-| `--osdk-typography-color-muted`            | `--bp-typography-color-muted`            |
-| `--osdk-typography-color-danger-rest`      | `--bp-typography-color-danger-rest`      |
-| `--osdk-typography-color-danger-active`    | `--bp-typography-color-danger-active`    |
+| Token                                  | Maps to                              |
+| -------------------------------------- | ------------------------------------ |
+| `--osdk-typography-color-default-rest` | `--bp-typography-color-default-rest` |
+| `--osdk-typography-color-muted`        | `--bp-typography-color-muted`        |
+| `--osdk-typography-color-danger-rest`  | `--bp-typography-color-danger-rest`  |

--- a/packages/react-components/src/theme/OsdkThemeProvider.tsx
+++ b/packages/react-components/src/theme/OsdkThemeProvider.tsx
@@ -61,7 +61,7 @@ export interface OsdkThemeProviderProps {
 /**
  * Provides OSDK theme state to descendants and writes a
  * `data-bp-color-scheme` attribute onto the document so the CSS in
- * `tokens/base-tokens/dark.css` activates the right theme.
+ * Blueprint's next-token dark selector activates the right theme.
  *
  * `defaultTheme="system"` (default) follows the OS `prefers-color-scheme`
  * setting and re-renders when it changes. `defaultTheme="light"` /

--- a/packages/react-components/src/tokens.css
+++ b/packages/react-components/src/tokens.css
@@ -1,6 +1,5 @@
 /* Base tokens: Blueprint design tokens → OSDK semantic tokens */
 @import "./tokens/base-tokens/base.css";
-@import "./tokens/base-tokens/dark.css";
 
 /* Component tokens: component-specific tokens that reference base tokens */
 @import "./tokens/component-tokens/aip-agent-chat.css";

--- a/packages/react-components/src/tokens/base-tokens/base.css
+++ b/packages/react-components/src/tokens/base-tokens/base.css
@@ -1,25 +1,23 @@
-@import "./blueprint-design-tokens.css";
+@import "./next-tokens.css";
 
-/* Level 1 - Blueprint Tokens */
 :root {
-  /* Blueprint token mappings - Surface tokens */
   --osdk-surface-z-index-1: var(--bp-surface-z-index-1);
   --osdk-surface-z-index-2: var(--bp-surface-z-index-2);
   --osdk-surface-z-index-3: var(--bp-surface-z-index-3);
   --osdk-surface-z-index-4: var(--bp-surface-z-index-4);
   --osdk-surface-border-radius: var(--bp-surface-border-radius);
-  --osdk-surface-layer-primary: var(--bp-surface-layer-primary);
+  --osdk-surface-layer-primary: var(--bp-surface-layer-primary-rest);
   --osdk-surface-border-width: var(--bp-surface-border-width);
-  --osdk-surface-border-color-default: var(--bp-surface-border-color-default);
-  --osdk-surface-border-color-strong: var(--bp-surface-border-color-strong);
+  --osdk-surface-border-color-default: var(--bp-surface-divider-color-default);
+  --osdk-surface-border-color-strong: var(--bp-surface-divider-color-strong);
   --osdk-surface-background-color-default-rest: var(
-    --bp-surface-background-color-default-rest
+    --bp-surface-background-color-base-rest
   );
   --osdk-surface-background-color-default-hover: var(
-    --bp-surface-background-color-default-hover
+    --bp-surface-background-color-base-hover
   );
   --osdk-surface-background-color-default-active: var(
-    --bp-surface-background-color-default-active
+    --bp-surface-background-color-base-active
   );
   --osdk-surface-background-color-danger-rest: var(
     --bp-surface-background-color-danger-rest
@@ -32,200 +30,114 @@
   );
   --osdk-surface-spacing: var(--bp-surface-spacing);
   --osdk-surface-shadow-2: var(--bp-surface-shadow-2);
-
-  /* Blueprint token mappings - Typography tokens */
-  --osdk-typography-family-default: var(--bp-typography-family-default);
-  --osdk-typography-color-muted: var(--bp-typography-color-muted);
-  --osdk-typography-color-default-rest: var(--bp-typography-color-default-rest);
-  --osdk-typography-color-default-hover: var(
-    --bp-typography-color-default-hover
+  --osdk-typography-family-default: var(--bp-typography-family-body);
+  --osdk-typography-color-muted: var(--bp-typography-color-intent-neutral);
+  --osdk-typography-color-default-rest: var(--bp-typography-color-base);
+  --osdk-typography-color-default-hover: var(--bp-intent-neutral-900);
+  --osdk-typography-color-default-active: var(--bp-intent-neutral-800);
+  --osdk-typography-color-default-disabled: var(--bp-intent-neutral-300);
+  --osdk-typography-color-primary-rest: var(
+    --bp-typography-color-intent-primary
   );
-  --osdk-typography-color-default-active: var(
-    --bp-typography-color-default-active
-  );
-  --osdk-typography-color-default-disabled: var(
-    --bp-typography-color-default-disabled
-  );
-  --osdk-typography-color-primary-rest: var(--bp-typography-color-primary-rest);
-  --osdk-typography-color-danger-rest: var(--bp-typography-color-danger-rest);
-  --osdk-typography-color-danger-active: var(
-    --bp-typography-color-danger-active
-  );
-  --osdk-typography-size-body-x-small: var(--bp-typography-size-body-x-small);
-  --osdk-typography-size-body-small: var(--bp-typography-size-body-small);
-  --osdk-typography-size-body-medium: var(--bp-typography-size-body-medium);
-  --osdk-typography-size-body-large: var(--bp-typography-size-body-large);
+  --osdk-typography-color-danger-rest: var(--bp-typography-color-intent-danger);
+  --osdk-typography-color-danger-active: var(--bp-intent-danger-700);
+  --osdk-typography-size-body-x-small: var(--bp-typography-size-xs);
+  --osdk-typography-size-body-small: var(--bp-typography-size-sm);
+  --osdk-typography-size-body-medium: var(--bp-typography-size-lg);
+  --osdk-typography-size-body-large: var(--bp-typography-size-2xl);
   --osdk-typography-line-height-default: var(
-    --bp-typography-line-height-default
+    --bp-typography-line-height-running-factor
   );
   --osdk-typography-weight-default: var(--bp-typography-weight-default);
-  --osdk-typography-weight-bold: var(--bp-typography-weight-bold);
-
-  /* Blueprint token mappings - Intent tokens */
-  --osdk-intent-default-rest: var(--bp-intent-default-rest);
-  --osdk-intent-default-hover: var(--bp-intent-default-hover);
-  --osdk-intent-default-active: var(--bp-intent-default-active);
-  --osdk-intent-default-disabled: var(--bp-intent-default-disabled);
-  --osdk-intent-default-foreground: var(--bp-intent-default-foreground);
-  --osdk-intent-primary-rest: var(--bp-intent-primary-rest);
-  --osdk-intent-primary-hover: var(--bp-intent-primary-hover);
-  --osdk-intent-primary-active: var(--bp-intent-primary-active);
-  --osdk-intent-primary-disabled: var(--bp-intent-primary-disabled);
+  --osdk-typography-weight-bold: var(--bp-typography-weight-strong);
+  --osdk-intent-default-rest: var(--bp-intent-neutral-500);
+  --osdk-intent-default-hover: var(--bp-intent-neutral-600);
+  --osdk-intent-default-active: var(--bp-intent-neutral-700);
+  --osdk-intent-default-disabled: var(--bp-intent-neutral-300);
+  --osdk-intent-default-foreground: var(--bp-intent-neutral-foreground);
+  --osdk-intent-primary-rest: var(--bp-intent-primary-500);
+  --osdk-intent-primary-hover: var(--bp-intent-primary-600);
+  --osdk-intent-primary-active: var(--bp-intent-primary-700);
+  --osdk-intent-primary-disabled: var(--bp-intent-primary-300);
   --osdk-intent-primary-foreground: var(--bp-intent-primary-foreground);
-  --osdk-intent-success-rest: var(--bp-intent-success-rest);
-  --osdk-intent-success-hover: var(--bp-intent-success-hover);
-  --osdk-intent-success-active: var(--bp-intent-success-active);
-  --osdk-intent-success-disabled: var(--bp-intent-success-disabled);
+  --osdk-intent-success-rest: var(--bp-intent-success-500);
+  --osdk-intent-success-hover: var(--bp-intent-success-600);
+  --osdk-intent-success-active: var(--bp-intent-success-700);
+  --osdk-intent-success-disabled: var(--bp-intent-success-300);
   --osdk-intent-success-foreground: var(--bp-intent-success-foreground);
-  --osdk-intent-warning-rest: var(--bp-intent-warning-rest);
-  --osdk-intent-warning-hover: var(--bp-intent-warning-hover);
-  --osdk-intent-warning-active: var(--bp-intent-warning-active);
-  --osdk-intent-warning-disabled: var(--bp-intent-warning-disabled);
+  --osdk-intent-warning-rest: var(--bp-intent-warning-500);
+  --osdk-intent-warning-hover: var(--bp-intent-warning-600);
+  --osdk-intent-warning-active: var(--bp-intent-warning-700);
+  --osdk-intent-warning-disabled: var(--bp-intent-warning-300);
   --osdk-intent-warning-foreground: var(--bp-intent-warning-foreground);
-  --osdk-intent-danger-rest: var(--bp-intent-danger-rest);
-  --osdk-intent-danger-hover: var(--bp-intent-danger-hover);
-  --osdk-intent-danger-active: var(--bp-intent-danger-active);
-  --osdk-intent-danger-disabled: var(--bp-intent-danger-disabled);
+  --osdk-intent-danger-rest: var(--bp-intent-danger-500);
+  --osdk-intent-danger-hover: var(--bp-intent-danger-600);
+  --osdk-intent-danger-active: var(--bp-intent-danger-700);
+  --osdk-intent-danger-disabled: var(--bp-intent-danger-300);
   --osdk-intent-danger-foreground: var(--bp-intent-danger-foreground);
-
-  /* Blueprint token mappings - Emphasis tokens */
   --osdk-emphasis-focus-width: var(--bp-emphasis-focus-width);
   --osdk-emphasis-focus-color: var(--bp-emphasis-focus-color);
   --osdk-emphasis-focus-offset: var(--bp-emphasis-focus-offset);
   --osdk-emphasis-transition-duration: var(--bp-emphasis-transition-duration);
   --osdk-emphasis-ease-default: var(--bp-emphasis-ease-default);
-
-  /* Blueprint token mappings - Palette tokens */
-  --osdk-palette-gray-1: var(--bp-palette-gray-1);
-  --osdk-palette-gray-2: var(--bp-palette-gray-2);
-  --osdk-palette-gray-4: var(--bp-palette-gray-4);
-  --osdk-palette-blue-4: var(--bp-palette-blue-4);
-  --osdk-palette-red-4: var(--bp-palette-red-4);
-  --osdk-palette-dark-gray-2: var(--bp-palette-dark-gray-2);
-  --osdk-palette-dark-gray-3: var(--bp-palette-dark-gray-3);
-  --osdk-palette-light-gray-1: var(--bp-palette-light-gray-1);
-  --osdk-palette-light-gray-3: var(--bp-palette-light-gray-3);
-  --osdk-palette-light-gray-4: var(--bp-palette-light-gray-4);
-  --osdk-palette-light-gray-5: var(--bp-palette-light-gray-5);
-
-  --osdk-palette-white: var(--bp-palette-white);
-  --osdk-palette-black: var(--bp-palette-black);
-
-  /* Semantic color tokens - abstracting palette usage */
-  /* Typography colors */
-  /* These aliases let components use one role-specific token across themes.
-     Error text is not a 1:1 Blueprint mapping: light mode uses
-     --bp-typography-color-danger-hover, while dark mode uses another color since Blueprint has no dark equivalent. */
-  --osdk-typography-color-error: var(--bp-typography-color-danger-hover);
-  --osdk-typography-color-placeholder: var(--osdk-typography-color-muted);
-
-  /* Background colors */
-  --osdk-background-primary: var(--osdk-palette-white);
-  --osdk-background-secondary: var(--osdk-palette-light-gray-5);
-  --osdk-background-tertiary: var(--osdk-palette-light-gray-4);
-  --osdk-background-skeleton-from: color-mix(
-    in srgb,
-    var(--osdk-palette-gray-1) 5%,
-    transparent
-  );
-  --osdk-background-skeleton-to: color-mix(
-    in srgb,
-    var(--osdk-palette-gray-1) 40%,
-    transparent
-  );
-  --osdk-background-backdrop: color-mix(
-    in srgb,
-    var(--osdk-palette-black) 50%,
-    transparent
-  );
-
-  /* Custom colors */
-  --osdk-custom-color-gray-1: color-mix(
-    in srgb,
-    var(--osdk-palette-gray-1) 5%,
-    transparent
-  );
-  --osdk-custom-color-gray-2: color-mix(
-    in srgb,
-    var(--osdk-palette-gray-1) 8%,
-    transparent
-  );
-  --osdk-custom-color-gray-3: color-mix(
-    in srgb,
-    var(--osdk-palette-gray-1) 10%,
-    transparent
-  );
-  --osdk-custom-color-gray-4: color-mix(
-    in srgb,
-    var(--osdk-palette-gray-1) 20%,
-    transparent
-  );
-  --osdk-custom-color-light-gray-1: color-mix(
-    in srgb,
-    var(--osdk-palette-light-gray-1) 60%,
-    transparent
-  );
-  --osdk-custom-color-light-gray-2: color-mix(
-    in srgb,
-    var(--osdk-palette-light-gray-5) 50%,
-    transparent
-  );
-  --osdk-custom-color-primary-1: color-mix(
-    in srgb,
-    var(--osdk-intent-primary-rest) 50%,
-    transparent
-  );
-
-  /* Shared Styling */
-  --osdk-focus-outline: var(--osdk-emphasis-focus-width) solid
-    var(--osdk-emphasis-focus-color);
-  --osdk-focus-visible-outline-offset: var(--osdk-emphasis-focus-offset);
-  --osdk-surface-border: var(--osdk-surface-border-width) solid
-    var(--osdk-surface-border-color-default);
-  --osdk-disabled-opacity: 0.5;
-
-  /* Shared drag handle tokens */
-  --osdk-drag-handle-color: var(--osdk-typography-color-muted);
-  --osdk-drag-handle-color-hover: var(--osdk-typography-color-default-rest);
+  --osdk-disabled-opacity: var(--bp-emphasis-disabled-opacity);
+  --osdk-palette-gray-1: var(--bp-palette-grey-500);
+  --osdk-palette-gray-2: var(--bp-palette-grey-400);
+  --osdk-palette-gray-4: var(--bp-palette-grey-200);
+  --osdk-palette-blue-4: var(--bp-palette-blue-300);
+  --osdk-palette-red-4: var(--bp-palette-red-300);
+  --osdk-palette-dark-gray-2: var(--bp-palette-grey-800);
+  --osdk-palette-dark-gray-3: var(--bp-palette-grey-700);
+  --osdk-palette-light-gray-1: var(--bp-palette-grey-200);
+  --osdk-palette-light-gray-3: var(--bp-palette-grey-100);
+  --osdk-palette-light-gray-4: var(--bp-palette-white-900);
+  --osdk-palette-light-gray-5: var(--bp-palette-white-1000);
+  --osdk-palette-white: var(--bp-palette-white-1000);
+  --osdk-palette-black: var(--bp-palette-black-1000);
+  --osdk-typography-color-error: var(--bp-typography-color-intent-danger);
+  --osdk-typography-color-placeholder: var(--bp-intent-neutral-400);
+  --osdk-background-primary: var(--bp-surface-background-color-base-rest);
+  --osdk-background-secondary: var(--bp-surface-layer-neutral-rest);
+  --osdk-background-tertiary: var(--bp-surface-layer-neutral-hover);
+  --osdk-background-skeleton-from: var(--bp-surface-layer-neutral-rest);
+  --osdk-background-skeleton-to: var(--bp-surface-layer-neutral-active);
+  --osdk-background-backdrop: var(--bp-palette-black-500);
+  --osdk-custom-color-gray-1: var(--bp-surface-layer-neutral-rest);
+  --osdk-custom-color-gray-2: var(--bp-surface-layer-neutral-hover);
+  --osdk-custom-color-gray-3: var(--bp-surface-layer-neutral-hover);
+  --osdk-custom-color-gray-4: var(--bp-surface-layer-neutral-active);
+  --osdk-custom-color-light-gray-1: var(--bp-palette-white-600);
+  --osdk-custom-color-light-gray-2: var(--bp-palette-white-500);
+  --osdk-custom-color-primary-1: var(--bp-surface-layer-primary-active);
+  --osdk-focus-outline: var(--bp-emphasis-focus-width) solid
+    var(--bp-emphasis-focus-color);
+  --osdk-focus-visible-outline-offset: var(--bp-emphasis-focus-offset);
+  --osdk-surface-border: var(--bp-surface-border-width) solid
+    var(--bp-surface-divider-color-default);
+  --osdk-drag-handle-color: var(--bp-typography-color-intent-neutral);
+  --osdk-drag-handle-color-hover: var(--bp-typography-color-base);
   --osdk-drag-handle-cursor: grab;
   --osdk-drag-handle-cursor-active: grabbing;
-
-  /* Shared icon styling */
-  --osdk-iconography-size-small: var(--osdk-typography-size-body-large);
-  --osdk-iconography-color-muted: var(--osdk-intent-default-rest);
-
-  /* Global styling */
-  font-family: var(--osdk-typography-family-default);
-  color: var(--osdk-typography-color-default-rest);
-  font-size: var(--osdk-typography-size-body-medium);
-
-  /* Blueprint icon alignment and color override */
+  --osdk-iconography-size-small: var(--bp-typography-size-2xl);
+  --osdk-iconography-color-muted: var(--bp-intent-neutral-500);
+  font-family: var(--bp-typography-family-body);
+  color: var(--bp-typography-color-base);
+  font-size: var(--bp-typography-size-lg);
   .bp6-icon {
     display: inline-block;
     flex: 0 0 auto;
     vertical-align: text-bottom;
     fill: currentColor;
   }
-
-  /*
-   * Blueprint 6 icon components use oversized path coordinates (320×320)
-   * with scale(0.05, -0.05) transforms. During rendering the path extends
-   * beyond the SVG viewBox, so overflow must be visible to prevent clipping.
-   */
   .bp6-icon > svg {
     overflow: visible;
   }
-
   *,
   *::before,
   *::after {
     box-sizing: border-box;
   }
 }
-
-/* Override Blueprint's global :focus { outline } rule.
-   When consumed inside a CSS layer (e.g. @layer osdk.tokens),
-   this beats Blueprint's earlier layer. */
 :focus,
 :focus-visible {
   outline: none;

--- a/packages/react-components/src/tokens/base-tokens/base.css
+++ b/packages/react-components/src/tokens/base-tokens/base.css
@@ -25,26 +25,15 @@
   --osdk-surface-background-color-danger-hover: var(
     --bp-surface-background-color-danger-hover
   );
-  --osdk-surface-background-color-danger-active: var(
-    --bp-surface-background-color-danger-active
-  );
   --osdk-surface-spacing: var(--bp-surface-spacing);
   --osdk-surface-shadow-2: var(--bp-surface-shadow-2);
   --osdk-typography-family-default: var(--bp-typography-family-body);
   --osdk-typography-color-muted: var(--bp-typography-color-intent-neutral);
   --osdk-typography-color-default-rest: var(--bp-typography-color-base);
-  --osdk-typography-color-default-hover: var(--bp-typography-color-base);
-  --osdk-typography-color-default-active: var(--bp-typography-color-base);
-  --osdk-typography-color-default-disabled: var(
-    --bp-typography-color-intent-neutral
-  );
   --osdk-typography-color-primary-rest: var(
     --bp-typography-color-intent-primary
   );
   --osdk-typography-color-danger-rest: var(--bp-typography-color-intent-danger);
-  --osdk-typography-color-danger-active: var(
-    --bp-typography-color-intent-danger
-  );
   --osdk-typography-size-body-x-small: var(--bp-typography-size-2xs);
   --osdk-typography-size-body-small: var(--bp-typography-size-sm);
   --osdk-typography-size-body-medium: var(--bp-typography-size-md);
@@ -54,46 +43,23 @@
   );
   --osdk-typography-weight-default: var(--bp-typography-weight-default);
   --osdk-typography-weight-bold: var(--bp-typography-weight-strong);
-  --osdk-intent-default-rest: var(--bp-surface-background-color-neutral-rest);
-  --osdk-intent-default-hover: var(--bp-surface-background-color-neutral-hover);
-  --osdk-intent-default-active: var(
-    --bp-surface-background-color-neutral-active
-  );
-  --osdk-intent-default-disabled: var(
-    --bp-surface-background-color-neutral-rest
-  );
-  --osdk-intent-default-foreground: var(--bp-intent-neutral-foreground);
-  --osdk-intent-primary-rest: var(--bp-surface-background-color-primary-rest);
-  --osdk-intent-primary-hover: var(--bp-surface-background-color-primary-hover);
-  --osdk-intent-primary-active: var(
-    --bp-surface-background-color-primary-active
-  );
-  --osdk-intent-primary-disabled: var(
-    --bp-surface-background-color-primary-rest
-  );
+  --osdk-intent-default-rest: var(--bp-intent-neutral-500);
+  --osdk-intent-default-hover: var(--bp-intent-neutral-600);
+  --osdk-intent-default-active: var(--bp-intent-neutral-700);
+  --osdk-intent-primary-rest: var(--bp-intent-primary-500);
+  --osdk-intent-primary-hover: var(--bp-intent-primary-600);
+  --osdk-intent-primary-active: var(--bp-intent-primary-700);
   --osdk-intent-primary-foreground: var(--bp-intent-primary-foreground);
-  --osdk-intent-success-rest: var(--bp-surface-background-color-success-rest);
-  --osdk-intent-success-hover: var(--bp-surface-background-color-success-hover);
-  --osdk-intent-success-active: var(
-    --bp-surface-background-color-success-active
-  );
-  --osdk-intent-success-disabled: var(
-    --bp-surface-background-color-success-rest
-  );
+  --osdk-intent-success-rest: var(--bp-intent-success-500);
+  --osdk-intent-success-hover: var(--bp-intent-success-600);
+  --osdk-intent-success-active: var(--bp-intent-success-700);
   --osdk-intent-success-foreground: var(--bp-intent-success-foreground);
-  --osdk-intent-warning-rest: var(--bp-surface-background-color-warning-rest);
-  --osdk-intent-warning-hover: var(--bp-surface-background-color-warning-hover);
-  --osdk-intent-warning-active: var(
-    --bp-surface-background-color-warning-active
-  );
-  --osdk-intent-warning-disabled: var(
-    --bp-surface-background-color-warning-rest
-  );
-  --osdk-intent-warning-foreground: var(--bp-intent-warning-foreground);
-  --osdk-intent-danger-rest: var(--bp-surface-background-color-danger-rest);
-  --osdk-intent-danger-hover: var(--bp-surface-background-color-danger-hover);
-  --osdk-intent-danger-active: var(--bp-surface-background-color-danger-active);
-  --osdk-intent-danger-disabled: var(--bp-surface-background-color-danger-rest);
+  --osdk-intent-warning-rest: var(--bp-intent-warning-500);
+  --osdk-intent-warning-hover: var(--bp-intent-warning-600);
+  --osdk-intent-warning-active: var(--bp-intent-warning-700);
+  --osdk-intent-danger-rest: var(--bp-intent-danger-500);
+  --osdk-intent-danger-hover: var(--bp-intent-danger-600);
+  --osdk-intent-danger-active: var(--bp-intent-danger-700);
   --osdk-intent-danger-foreground: var(--bp-intent-danger-foreground);
   --osdk-emphasis-focus-width: var(--bp-emphasis-focus-width);
   --osdk-emphasis-focus-color: var(--bp-emphasis-focus-color);
@@ -104,12 +70,6 @@
   --osdk-palette-gray-1: var(--bp-palette-grey-500);
   --osdk-palette-gray-2: var(--bp-palette-grey-400);
   --osdk-palette-gray-4: var(--bp-palette-grey-200);
-  --osdk-palette-blue-4: var(--bp-palette-blue-300);
-  --osdk-palette-red-4: var(--bp-palette-red-300);
-  --osdk-palette-dark-gray-2: var(--bp-palette-grey-800);
-  --osdk-palette-dark-gray-3: var(--bp-palette-grey-700);
-  --osdk-palette-light-gray-1: var(--bp-palette-grey-200);
-  --osdk-palette-light-gray-3: var(--bp-palette-grey-100);
   --osdk-palette-light-gray-4: var(--bp-palette-grey-100);
   --osdk-palette-light-gray-5: var(--bp-palette-grey-100);
   --osdk-palette-white: var(--bp-palette-white-1000);
@@ -128,7 +88,6 @@
   --osdk-custom-color-gray-2: var(--bp-surface-layer-color-neutral-hover);
   --osdk-custom-color-gray-3: var(--bp-surface-layer-color-neutral-hover);
   --osdk-custom-color-gray-4: var(--bp-surface-layer-color-neutral-active);
-  --osdk-custom-color-light-gray-1: var(--bp-surface-layer-color-neutral-hover);
   --osdk-custom-color-light-gray-2: var(--bp-surface-layer-color-neutral-rest);
   --osdk-custom-color-primary-1: var(--bp-surface-layer-color-primary-active);
   --osdk-focus-outline: var(--bp-emphasis-focus-width) solid

--- a/packages/react-components/src/tokens/base-tokens/base.css
+++ b/packages/react-components/src/tokens/base-tokens/base.css
@@ -8,16 +8,16 @@
   --osdk-surface-border-radius: var(--bp-surface-border-radius);
   --osdk-surface-layer-primary: var(--bp-surface-layer-primary-rest);
   --osdk-surface-border-width: var(--bp-surface-border-width);
-  --osdk-surface-border-color-default: var(--bp-surface-border-color-neutral);
-  --osdk-surface-border-color-strong: var(--bp-surface-border-color-neutral);
+  --osdk-surface-border-color-default: var(--bp-surface-divider-color-default);
+  --osdk-surface-border-color-strong: var(--bp-surface-divider-color-strong);
   --osdk-surface-background-color-default-rest: var(
     --bp-surface-background-color-base-rest
   );
   --osdk-surface-background-color-default-hover: var(
-    --bp-surface-background-color-base-hover
+    --bp-surface-layer-color-neutral-hover
   );
   --osdk-surface-background-color-default-active: var(
-    --bp-surface-background-color-base-active
+    --bp-surface-layer-color-neutral-active
   );
   --osdk-surface-background-color-danger-rest: var(
     --bp-surface-background-color-danger-rest
@@ -54,30 +54,46 @@
   );
   --osdk-typography-weight-default: var(--bp-typography-weight-default);
   --osdk-typography-weight-bold: var(--bp-typography-weight-strong);
-  --osdk-intent-default-rest: var(--bp-intent-neutral-500);
-  --osdk-intent-default-hover: var(--bp-intent-neutral-600);
-  --osdk-intent-default-active: var(--bp-intent-neutral-700);
-  --osdk-intent-default-disabled: var(--bp-intent-neutral-300);
+  --osdk-intent-default-rest: var(--bp-surface-background-color-neutral-rest);
+  --osdk-intent-default-hover: var(--bp-surface-background-color-neutral-hover);
+  --osdk-intent-default-active: var(
+    --bp-surface-background-color-neutral-active
+  );
+  --osdk-intent-default-disabled: var(
+    --bp-surface-background-color-neutral-rest
+  );
   --osdk-intent-default-foreground: var(--bp-intent-neutral-foreground);
-  --osdk-intent-primary-rest: var(--bp-intent-primary-500);
-  --osdk-intent-primary-hover: var(--bp-intent-primary-600);
-  --osdk-intent-primary-active: var(--bp-intent-primary-700);
-  --osdk-intent-primary-disabled: var(--bp-intent-primary-300);
+  --osdk-intent-primary-rest: var(--bp-surface-background-color-primary-rest);
+  --osdk-intent-primary-hover: var(--bp-surface-background-color-primary-hover);
+  --osdk-intent-primary-active: var(
+    --bp-surface-background-color-primary-active
+  );
+  --osdk-intent-primary-disabled: var(
+    --bp-surface-background-color-primary-rest
+  );
   --osdk-intent-primary-foreground: var(--bp-intent-primary-foreground);
-  --osdk-intent-success-rest: var(--bp-intent-success-500);
-  --osdk-intent-success-hover: var(--bp-intent-success-600);
-  --osdk-intent-success-active: var(--bp-intent-success-700);
-  --osdk-intent-success-disabled: var(--bp-intent-success-300);
+  --osdk-intent-success-rest: var(--bp-surface-background-color-success-rest);
+  --osdk-intent-success-hover: var(--bp-surface-background-color-success-hover);
+  --osdk-intent-success-active: var(
+    --bp-surface-background-color-success-active
+  );
+  --osdk-intent-success-disabled: var(
+    --bp-surface-background-color-success-rest
+  );
   --osdk-intent-success-foreground: var(--bp-intent-success-foreground);
-  --osdk-intent-warning-rest: var(--bp-intent-warning-500);
-  --osdk-intent-warning-hover: var(--bp-intent-warning-600);
-  --osdk-intent-warning-active: var(--bp-intent-warning-700);
-  --osdk-intent-warning-disabled: var(--bp-intent-warning-300);
+  --osdk-intent-warning-rest: var(--bp-surface-background-color-warning-rest);
+  --osdk-intent-warning-hover: var(--bp-surface-background-color-warning-hover);
+  --osdk-intent-warning-active: var(
+    --bp-surface-background-color-warning-active
+  );
+  --osdk-intent-warning-disabled: var(
+    --bp-surface-background-color-warning-rest
+  );
   --osdk-intent-warning-foreground: var(--bp-intent-warning-foreground);
-  --osdk-intent-danger-rest: var(--bp-intent-danger-500);
-  --osdk-intent-danger-hover: var(--bp-intent-danger-600);
-  --osdk-intent-danger-active: var(--bp-intent-danger-700);
-  --osdk-intent-danger-disabled: var(--bp-intent-danger-300);
+  --osdk-intent-danger-rest: var(--bp-surface-background-color-danger-rest);
+  --osdk-intent-danger-hover: var(--bp-surface-background-color-danger-hover);
+  --osdk-intent-danger-active: var(--bp-surface-background-color-danger-active);
+  --osdk-intent-danger-disabled: var(--bp-surface-background-color-danger-rest);
   --osdk-intent-danger-foreground: var(--bp-intent-danger-foreground);
   --osdk-emphasis-focus-width: var(--bp-emphasis-focus-width);
   --osdk-emphasis-focus-color: var(--bp-emphasis-focus-color);
@@ -107,9 +123,7 @@
   --osdk-background-tertiary: var(--bp-surface-layer-color-neutral-hover);
   --osdk-background-skeleton-from: var(--bp-surface-layer-color-neutral-rest);
   --osdk-background-skeleton-to: var(--bp-surface-layer-color-neutral-active);
-  --osdk-background-backdrop: oklch(
-    from var(--bp-surface-background-color-neutral-active) l c h / 0.5
-  );
+  --osdk-background-backdrop: var(--bp-palette-black-500);
   --osdk-custom-color-gray-1: var(--bp-surface-layer-color-neutral-rest);
   --osdk-custom-color-gray-2: var(--bp-surface-layer-color-neutral-hover);
   --osdk-custom-color-gray-3: var(--bp-surface-layer-color-neutral-hover);
@@ -121,7 +135,7 @@
     var(--bp-emphasis-focus-color);
   --osdk-focus-visible-outline-offset: var(--bp-emphasis-focus-offset);
   --osdk-surface-border: var(--bp-surface-border-width) solid
-    var(--bp-surface-border-color-neutral);
+    var(--bp-surface-divider-color-default);
   --osdk-drag-handle-color: var(--bp-typography-color-intent-neutral);
   --osdk-drag-handle-color-hover: var(--bp-typography-color-base);
   --osdk-drag-handle-cursor: grab;

--- a/packages/react-components/src/tokens/base-tokens/base.css
+++ b/packages/react-components/src/tokens/base-tokens/base.css
@@ -8,8 +8,8 @@
   --osdk-surface-border-radius: var(--bp-surface-border-radius);
   --osdk-surface-layer-primary: var(--bp-surface-layer-primary-rest);
   --osdk-surface-border-width: var(--bp-surface-border-width);
-  --osdk-surface-border-color-default: var(--bp-surface-divider-color-default);
-  --osdk-surface-border-color-strong: var(--bp-surface-divider-color-strong);
+  --osdk-surface-border-color-default: var(--bp-surface-border-color-neutral);
+  --osdk-surface-border-color-strong: var(--bp-surface-border-color-neutral);
   --osdk-surface-background-color-default-rest: var(
     --bp-surface-background-color-base-rest
   );
@@ -33,20 +33,24 @@
   --osdk-typography-family-default: var(--bp-typography-family-body);
   --osdk-typography-color-muted: var(--bp-typography-color-intent-neutral);
   --osdk-typography-color-default-rest: var(--bp-typography-color-base);
-  --osdk-typography-color-default-hover: var(--bp-intent-neutral-900);
-  --osdk-typography-color-default-active: var(--bp-intent-neutral-800);
-  --osdk-typography-color-default-disabled: var(--bp-intent-neutral-300);
+  --osdk-typography-color-default-hover: var(--bp-typography-color-base);
+  --osdk-typography-color-default-active: var(--bp-typography-color-base);
+  --osdk-typography-color-default-disabled: var(
+    --bp-typography-color-intent-neutral
+  );
   --osdk-typography-color-primary-rest: var(
     --bp-typography-color-intent-primary
   );
   --osdk-typography-color-danger-rest: var(--bp-typography-color-intent-danger);
-  --osdk-typography-color-danger-active: var(--bp-intent-danger-700);
-  --osdk-typography-size-body-x-small: var(--bp-typography-size-xs);
+  --osdk-typography-color-danger-active: var(
+    --bp-typography-color-intent-danger
+  );
+  --osdk-typography-size-body-x-small: var(--bp-typography-size-2xs);
   --osdk-typography-size-body-small: var(--bp-typography-size-sm);
-  --osdk-typography-size-body-medium: var(--bp-typography-size-lg);
-  --osdk-typography-size-body-large: var(--bp-typography-size-2xl);
-  --osdk-typography-line-height-default: var(
-    --bp-typography-line-height-running-factor
+  --osdk-typography-size-body-medium: var(--bp-typography-size-md);
+  --osdk-typography-size-body-large: var(--bp-typography-size-xl);
+  --osdk-typography-line-height-default: calc(
+    var(--bp-typography-line-height-running-factor) * 1.164
   );
   --osdk-typography-weight-default: var(--bp-typography-weight-default);
   --osdk-typography-weight-bold: var(--bp-typography-weight-strong);
@@ -90,36 +94,40 @@
   --osdk-palette-dark-gray-3: var(--bp-palette-grey-700);
   --osdk-palette-light-gray-1: var(--bp-palette-grey-200);
   --osdk-palette-light-gray-3: var(--bp-palette-grey-100);
-  --osdk-palette-light-gray-4: var(--bp-palette-white-900);
-  --osdk-palette-light-gray-5: var(--bp-palette-white-1000);
+  --osdk-palette-light-gray-4: var(--bp-palette-grey-100);
+  --osdk-palette-light-gray-5: var(--bp-palette-grey-100);
   --osdk-palette-white: var(--bp-palette-white-1000);
   --osdk-palette-black: var(--bp-palette-black-1000);
   --osdk-typography-color-error: var(--bp-typography-color-intent-danger);
-  --osdk-typography-color-placeholder: var(--bp-intent-neutral-400);
+  --osdk-typography-color-placeholder: var(
+    --bp-typography-color-intent-neutral
+  );
   --osdk-background-primary: var(--bp-surface-background-color-base-rest);
-  --osdk-background-secondary: var(--bp-surface-layer-neutral-rest);
-  --osdk-background-tertiary: var(--bp-surface-layer-neutral-hover);
-  --osdk-background-skeleton-from: var(--bp-surface-layer-neutral-rest);
-  --osdk-background-skeleton-to: var(--bp-surface-layer-neutral-active);
-  --osdk-background-backdrop: var(--bp-palette-black-500);
-  --osdk-custom-color-gray-1: var(--bp-surface-layer-neutral-rest);
-  --osdk-custom-color-gray-2: var(--bp-surface-layer-neutral-hover);
-  --osdk-custom-color-gray-3: var(--bp-surface-layer-neutral-hover);
-  --osdk-custom-color-gray-4: var(--bp-surface-layer-neutral-active);
-  --osdk-custom-color-light-gray-1: var(--bp-palette-white-600);
-  --osdk-custom-color-light-gray-2: var(--bp-palette-white-500);
-  --osdk-custom-color-primary-1: var(--bp-surface-layer-primary-active);
+  --osdk-background-secondary: var(--bp-surface-layer-color-neutral-rest);
+  --osdk-background-tertiary: var(--bp-surface-layer-color-neutral-hover);
+  --osdk-background-skeleton-from: var(--bp-surface-layer-color-neutral-rest);
+  --osdk-background-skeleton-to: var(--bp-surface-layer-color-neutral-active);
+  --osdk-background-backdrop: oklch(
+    from var(--bp-surface-background-color-neutral-active) l c h / 0.5
+  );
+  --osdk-custom-color-gray-1: var(--bp-surface-layer-color-neutral-rest);
+  --osdk-custom-color-gray-2: var(--bp-surface-layer-color-neutral-hover);
+  --osdk-custom-color-gray-3: var(--bp-surface-layer-color-neutral-hover);
+  --osdk-custom-color-gray-4: var(--bp-surface-layer-color-neutral-active);
+  --osdk-custom-color-light-gray-1: var(--bp-surface-layer-color-neutral-hover);
+  --osdk-custom-color-light-gray-2: var(--bp-surface-layer-color-neutral-rest);
+  --osdk-custom-color-primary-1: var(--bp-surface-layer-color-primary-active);
   --osdk-focus-outline: var(--bp-emphasis-focus-width) solid
     var(--bp-emphasis-focus-color);
   --osdk-focus-visible-outline-offset: var(--bp-emphasis-focus-offset);
   --osdk-surface-border: var(--bp-surface-border-width) solid
-    var(--bp-surface-divider-color-default);
+    var(--bp-surface-border-color-neutral);
   --osdk-drag-handle-color: var(--bp-typography-color-intent-neutral);
   --osdk-drag-handle-color-hover: var(--bp-typography-color-base);
   --osdk-drag-handle-cursor: grab;
   --osdk-drag-handle-cursor-active: grabbing;
   --osdk-iconography-size-small: var(--bp-typography-size-2xl);
-  --osdk-iconography-color-muted: var(--bp-intent-neutral-500);
+  --osdk-iconography-color-muted: var(--bp-typography-color-intent-neutral);
   font-family: var(--bp-typography-family-body);
   color: var(--bp-typography-color-base);
   font-size: var(--bp-typography-size-lg);

--- a/packages/react-components/src/tokens/base-tokens/next-tokens.css
+++ b/packages/react-components/src/tokens/base-tokens/next-tokens.css
@@ -1,0 +1,816 @@
+/**
+ * Do not edit directly, this file was auto-generated.
+ */
+
+:root {
+  --bp-emphasis-transition-duration: 100ms;
+  --bp-emphasis-ease-default: cubic-bezier(0.4, 1, 0.75, 0.9);
+  --bp-emphasis-ease-bounce: cubic-bezier(0.54, 1.12, 0.38, 1.11);
+  --bp-emphasis-focus-color: var(--bp-intent-primary-500);
+  --bp-emphasis-focus-width: 2px;
+  --bp-emphasis-focus-offset: 2px;
+  --bp-emphasis-motion-reduced: 0; /** 0 = motion allowed, 1 = reduced motion */
+  --bp-emphasis-disabled-opacity: 0.4;
+  --bp-emphasis-translucence-opacity: 0.95;
+  --bp-emphasis-blur: 12px;
+  --bp-intent-neutral-100: var(--bp-palette-grey-100);
+  --bp-intent-neutral-200: var(--bp-palette-grey-200);
+  --bp-intent-neutral-300: var(--bp-palette-grey-300);
+  --bp-intent-neutral-400: var(--bp-palette-grey-400);
+  --bp-intent-neutral-500: var(--bp-palette-grey-500);
+  --bp-intent-neutral-600: var(--bp-palette-grey-600);
+  --bp-intent-neutral-700: var(--bp-palette-grey-700);
+  --bp-intent-neutral-800: var(--bp-palette-grey-800);
+  --bp-intent-neutral-900: var(--bp-palette-grey-900);
+  --bp-intent-neutral-1000: var(--bp-palette-grey-1000);
+  --bp-intent-neutral-foreground: var(--bp-palette-white-1000);
+  --bp-intent-primary-100: var(--bp-palette-blue-100);
+  --bp-intent-primary-200: var(--bp-palette-blue-200);
+  --bp-intent-primary-300: var(--bp-palette-blue-300);
+  --bp-intent-primary-400: var(--bp-palette-blue-400);
+  --bp-intent-primary-500: var(--bp-palette-blue-500);
+  --bp-intent-primary-600: var(--bp-palette-blue-600);
+  --bp-intent-primary-700: var(--bp-palette-blue-700);
+  --bp-intent-primary-800: var(--bp-palette-blue-800);
+  --bp-intent-primary-900: var(--bp-palette-blue-900);
+  --bp-intent-primary-1000: var(--bp-palette-blue-1000);
+  --bp-intent-primary-foreground: var(--bp-palette-white-1000);
+  --bp-intent-success-100: var(--bp-palette-green-100);
+  --bp-intent-success-200: var(--bp-palette-green-200);
+  --bp-intent-success-300: var(--bp-palette-green-300);
+  --bp-intent-success-400: var(--bp-palette-green-400);
+  --bp-intent-success-500: var(--bp-palette-green-500);
+  --bp-intent-success-600: var(--bp-palette-green-600);
+  --bp-intent-success-700: var(--bp-palette-green-700);
+  --bp-intent-success-800: var(--bp-palette-green-800);
+  --bp-intent-success-900: var(--bp-palette-green-900);
+  --bp-intent-success-1000: var(--bp-palette-green-1000);
+  --bp-intent-success-foreground: var(--bp-palette-white-1000);
+  --bp-intent-warning-100: var(--bp-palette-orange-100);
+  --bp-intent-warning-200: var(--bp-palette-orange-200);
+  --bp-intent-warning-300: var(--bp-palette-orange-300);
+  --bp-intent-warning-400: var(--bp-palette-orange-400);
+  --bp-intent-warning-500: var(--bp-palette-orange-500);
+  --bp-intent-warning-600: var(--bp-palette-orange-600);
+  --bp-intent-warning-700: var(--bp-palette-orange-700);
+  --bp-intent-warning-800: var(--bp-palette-orange-800);
+  --bp-intent-warning-900: var(--bp-palette-orange-900);
+  --bp-intent-warning-1000: var(--bp-palette-orange-1000);
+  --bp-intent-warning-foreground: var(--bp-palette-white-1000);
+  --bp-intent-danger-100: var(--bp-palette-red-100);
+  --bp-intent-danger-200: var(--bp-palette-red-200);
+  --bp-intent-danger-300: var(--bp-palette-red-300);
+  --bp-intent-danger-400: var(--bp-palette-red-400);
+  --bp-intent-danger-500: var(--bp-palette-red-500);
+  --bp-intent-danger-600: var(--bp-palette-red-600);
+  --bp-intent-danger-700: var(--bp-palette-red-700);
+  --bp-intent-danger-800: var(--bp-palette-red-800);
+  --bp-intent-danger-900: var(--bp-palette-red-900);
+  --bp-intent-danger-1000: var(--bp-palette-red-1000);
+  --bp-intent-danger-foreground: var(--bp-palette-white-1000);
+  --bp-palette-orange-100: oklch(0.9147 0.0427 47.48); /* #fcdbcb */
+  --bp-palette-orange-200: oklch(0.8297 0.0891 47.62); /* #f8b695 */
+  --bp-palette-orange-300: oklch(0.7426 0.1236 47.04); /* #eb9265 */
+  --bp-palette-orange-400: oklch(0.6562 0.1455 47.13); /* #d77139 */
+  --bp-palette-orange-500: oklch(0.5673 0.1563 47.24); /* #bd5200 */
+  --bp-palette-orange-600: oklch(0.4784 0.1481 40.69); /* #9e3600 */
+  --bp-palette-orange-700: oklch(0.3867 0.1248 38.65); /* #782300 */
+  --bp-palette-orange-800: oklch(0.2943 0.0996 36.52); /* #531200 */
+  --bp-palette-orange-900: oklch(0.1971 0.0737 32.5); /* #2f0300 */
+  --bp-palette-orange-1000: oklch(0.1011 0.0325 38.79); /* #0b0100 */
+  --bp-palette-blue-100: oklch(0.8953 0.0437 257.97); /* #cbdefa */
+  --bp-palette-blue-200: oklch(0.8131 0.0896 257.95); /* #9ec4fc */
+  --bp-palette-blue-300: oklch(0.7293 0.123 257.52); /* #75a9f4 */
+  --bp-palette-blue-400: oklch(0.6431 0.1457 257.47); /* #508de4 */
+  --bp-palette-blue-500: oklch(0.5557 0.1571 257.76); /* #3071cd */
+  --bp-palette-blue-600: oklch(0.467 0.1561 257.84); /* #1356af */
+  --bp-palette-blue-700: oklch(0.3785 0.1417 258.25); /* #003d8b */
+  --bp-palette-blue-800: oklch(0.289 0.1158 259.67); /* #002663 */
+  --bp-palette-blue-900: oklch(0.194 0.0808 260.38); /* #001138 */
+  --bp-palette-blue-1000: oklch(0.0988 0.033 255.43); /* #00030d */
+  --bp-palette-green-100: oklch(0.8664 0.0399 151.03); /* #c1dbc6 */
+  --bp-palette-green-200: oklch(0.7863 0.0825 151.47); /* #92c99f */
+  --bp-palette-green-300: oklch(0.7046 0.1131 151.66); /* #66b47c */
+  --bp-palette-green-400: oklch(0.6219 0.1338 151.49); /* #3b9d5c */
+  --bp-palette-green-500: oklch(0.5369 0.1429 151.47); /* #008440 */
+  --bp-palette-green-600: oklch(0.4574 0.1316 148.23); /* #006a28 */
+  --bp-palette-green-700: oklch(0.3721 0.1132 146.14); /* #004f15 */
+  --bp-palette-green-800: oklch(0.2859 0.0898 145.06); /* #003508 */
+  --bp-palette-green-900: oklch(0.193 0.0615 144.56); /* #001b02 */
+  --bp-palette-green-1000: oklch(0.1005 0.0274 150.49); /* #000501 */
+  --bp-palette-red-100: oklch(0.9185 0.0416 23.42); /* #ffdad7 */
+  --bp-palette-red-200: oklch(0.8345 0.0896 22.52); /* #feb2ae */
+  --bp-palette-red-300: oklch(0.7494 0.1236 23.45); /* #f28d88 */
+  --bp-palette-red-400: oklch(0.6607 0.1471 22.9); /* #de6967 */
+  --bp-palette-red-500: oklch(0.5713 0.1567 23.01); /* #c3494a */
+  --bp-palette-red-600: oklch(0.4801 0.1549 23.09); /* #a32c31 */
+  --bp-palette-red-700: oklch(0.3886 0.1429 23.25); /* #80121c */
+  --bp-palette-red-800: oklch(0.2937 0.1173 22.8); /* #59010d */
+  --bp-palette-red-900: oklch(0.2001 0.0808 22.84); /* #320004 */
+  --bp-palette-red-1000: oklch(0.102 0.0309 24.44); /* #0b0101 */
+  --bp-palette-vermilion-100: oklch(0.917 0.0432 33.91); /* #ffdad1 */
+  --bp-palette-vermilion-200: oklch(0.8341 0.0895 34.36); /* #fdb4a2 */
+  --bp-palette-vermilion-300: oklch(0.7479 0.1246 34.63); /* #f18f77 */
+  --bp-palette-vermilion-400: oklch(0.6585 0.1462 34.32); /* #dc6c52 */
+  --bp-palette-vermilion-500: oklch(0.5699 0.1573 34.33); /* #c24c31 */
+  --bp-palette-vermilion-600: oklch(0.478 0.1557 34.35); /* #a22f13 */
+  --bp-palette-vermilion-700: oklch(0.387 0.1424 33.11); /* #7f1600 */
+  --bp-palette-vermilion-800: oklch(0.2946 0.1166 30.46); /* #590400 */
+  --bp-palette-vermilion-900: oklch(0.1984 0.079 30.23); /* #310100 */
+  --bp-palette-vermilion-1000: oklch(0.1011 0.0325 38.79); /* #0b0100 */
+  --bp-palette-rose-100: oklch(0.9215 0.0423 3.33); /* #ffdae2 */
+  --bp-palette-rose-200: oklch(0.8376 0.0883 4.91); /* #fcb2c2 */
+  --bp-palette-rose-300: oklch(0.7502 0.1218 4.01); /* #ee8ca5 */
+  --bp-palette-rose-400: oklch(0.6618 0.1459 4.19); /* #da6888 */
+  --bp-palette-rose-500: oklch(0.5721 0.1557 4.17); /* #bf486d */
+  --bp-palette-rose-600: oklch(0.4799 0.1541 4.27); /* #9f2b53 */
+  --bp-palette-rose-700: oklch(0.388 0.1414 3.77); /* #7c123c */
+  --bp-palette-rose-800: oklch(0.2948 0.1172 4.61); /* #570125 */
+  --bp-palette-rose-900: oklch(0.1989 0.0799 4.8); /* #300011 */
+  --bp-palette-rose-1000: oklch(0.1039 0.0313 3.71); /* #0b0103 */
+  --bp-palette-violet-100: oklch(0.9228 0.0425 328.32); /* #f6dcf4 */
+  --bp-palette-violet-200: oklch(0.8364 0.0895 328.2); /* #eab5e7 */
+  --bp-palette-violet-300: oklch(0.75 0.124 327.69); /* #d891d6 */
+  --bp-palette-violet-400: oklch(0.6621 0.145 327.5); /* #c170c0 */
+  --bp-palette-violet-500: oklch(0.572 0.1561 327.81); /* #a751a6 */
+  --bp-palette-violet-600: oklch(0.4817 0.1545 328.12); /* #8a3689 */
+  --bp-palette-violet-700: oklch(0.3889 0.1414 327.88); /* #6a1f6a */
+  --bp-palette-violet-800: oklch(0.295 0.1167 328.04); /* #490d49 */
+  --bp-palette-violet-900: oklch(0.1975 0.0818 326.99); /* #270328 */
+  --bp-palette-violet-1000: oklch(0.1013 0.0343 327.74); /* #080108 */
+  --bp-palette-indigo-100: oklch(0.912 0.0434 288.37); /* #e0defe */
+  --bp-palette-indigo-200: oklch(0.8286 0.0892 288.58); /* #c4befe */
+  --bp-palette-indigo-300: oklch(0.7421 0.1227 288.9); /* #a99ef4 */
+  --bp-palette-indigo-400: oklch(0.6536 0.1458 288.58); /* #8e7fe3 */
+  --bp-palette-indigo-500: oklch(0.5656 0.1566 288.7); /* #7562cb */
+  --bp-palette-indigo-600: oklch(0.4756 0.156 288.49); /* #5c47ad */
+  --bp-palette-indigo-700: oklch(0.3843 0.1425 288.57); /* #442f89 */
+  --bp-palette-indigo-800: oklch(0.291 0.1183 289.19); /* #2d1a61 */
+  --bp-palette-indigo-900: oklch(0.1967 0.0822 288.73); /* #160a37 */
+  --bp-palette-indigo-1000: oklch(0.1002 0.0333 285.73); /* #03020d */
+  --bp-palette-cerulean-100: oklch(0.8861 0.0377 243.27); /* #c5ddf1 */
+  --bp-palette-cerulean-200: oklch(0.8036 0.0779 244.22); /* #94c5ee */
+  --bp-palette-cerulean-300: oklch(0.7208 0.1084 244.25); /* #66ace4 */
+  --bp-palette-cerulean-400: oklch(0.6365 0.1268 244.16); /* #3b92d2 */
+  --bp-palette-cerulean-500: oklch(0.5494 0.1372 244.6); /* #0077bb */
+  --bp-palette-cerulean-600: oklch(0.4684 0.1282 248.68); /* #005d9e */
+  --bp-palette-cerulean-700: oklch(0.3806 0.1132 251.81); /* #00437c */
+  --bp-palette-cerulean-800: oklch(0.2905 0.0912 253.59); /* #002b57 */
+  --bp-palette-cerulean-900: oklch(0.1976 0.0634 254.23); /* #001531 */
+  --bp-palette-cerulean-1000: oklch(0.0966 0.0291 252.27); /* #00030b */
+  --bp-palette-turquoise-100: oklch(0.8725 0.0262 184.65); /* #c3dbd7 */
+  --bp-palette-turquoise-200: oklch(0.7913 0.0548 182.81); /* #94c7be */
+  --bp-palette-turquoise-300: oklch(0.7094 0.0754 183.44); /* #68b1a6 */
+  --bp-palette-turquoise-400: oklch(0.6269 0.0903 182.73); /* #3c9a8d */
+  --bp-palette-turquoise-500: oklch(0.5415 0.0966 182.68); /* #008174 */
+  --bp-palette-turquoise-600: oklch(0.4607 0.0829 181.22); /* #00675b */
+  --bp-palette-turquoise-700: oklch(0.3766 0.0682 180.32); /* #004d43 */
+  --bp-palette-turquoise-800: oklch(0.2878 0.052 180.59); /* #00332c */
+  --bp-palette-turquoise-900: oklch(0.1949 0.0357 178.5); /* #001a15 */
+  --bp-palette-turquoise-1000: oklch(0.0956 0.0173 179.94); /* #000403 */
+  --bp-palette-forest-100: oklch(0.8667 0.0426 144.11); /* #c3dbc2 */
+  --bp-palette-forest-200: oklch(0.787 0.0895 143.73); /* #97c995 */
+  --bp-palette-forest-300: oklch(0.7051 0.1242 144.12); /* #6db46d */
+  --bp-palette-forest-400: oklch(0.623 0.1464 143.98); /* #479d49 */
+  --bp-palette-forest-500: oklch(0.5381 0.1571 144.01); /* #208428 */
+  --bp-palette-forest-600: oklch(0.4545 0.1523 142.96); /* #006a06 */
+  --bp-palette-forest-700: oklch(0.3705 0.1261 142.5); /* #004f00 */
+  --bp-palette-forest-800: oklch(0.285 0.097 142.5); /* #003500 */
+  --bp-palette-forest-900: oklch(0.1925 0.0655 142.5); /* #001b00 */
+  --bp-palette-forest-1000: oklch(0.0996 0.0339 142.5); /* #000500 */
+  --bp-palette-lime-100: oklch(0.8758 0.0382 125.28); /* #d0dbc0 */
+  --bp-palette-lime-200: oklch(0.7944 0.0775 124.37); /* #b1c58e */
+  --bp-palette-lime-300: oklch(0.7124 0.1075 124.87); /* #93ae61 */
+  --bp-palette-lime-400: oklch(0.6277 0.1265 124.4); /* #789536 */
+  --bp-palette-lime-500: oklch(0.5429 0.136 124.73); /* #5e7c00 */
+  --bp-palette-lime-600: oklch(0.4574 0.1165 126.06); /* #476200 */
+  --bp-palette-lime-700: oklch(0.3694 0.0951 126.85); /* #324800 */
+  --bp-palette-lime-800: oklch(0.2803 0.0725 127.2); /* #1f2f00 */
+  --bp-palette-lime-900: oklch(0.1911 0.0504 128.58); /* #0d1800 */
+  --bp-palette-lime-1000: oklch(0.0982 0.0252 126.59); /* #020400 */
+  --bp-palette-gold-100: oklch(0.8988 0.0332 74.78); /* #ebdbc6 */
+  --bp-palette-gold-200: oklch(0.8146 0.0671 75.64); /* #dcbd92 */
+  --bp-palette-gold-300: oklch(0.7311 0.0931 75.76); /* #caa063 */
+  --bp-palette-gold-400: oklch(0.6442 0.1092 75.02); /* #b48338 */
+  --bp-palette-gold-500: oklch(0.5574 0.1175 75.26); /* #9b6800 */
+  --bp-palette-gold-600: oklch(0.4692 0.1024 68.88); /* #7f4e00 */
+  --bp-palette-gold-700: oklch(0.381 0.0844 66.66); /* #603800 */
+  --bp-palette-gold-800: oklch(0.2896 0.0652 64.49); /* #412300 */
+  --bp-palette-gold-900: oklch(0.1963 0.0464 59.25); /* #240f00 */
+  --bp-palette-gold-1000: oklch(0.0977 0.0227 60.92); /* #070200 */
+  --bp-palette-sepia-100: oklch(0.9069 0.0377 59.53); /* #f4dbc8 */
+  --bp-palette-sepia-200: oklch(0.8228 0.0771 57.37); /* #ecb994 */
+  --bp-palette-sepia-300: oklch(0.7373 0.1061 58.48); /* #dc9964 */
+  --bp-palette-sepia-400: oklch(0.6514 0.1261 57.88); /* #c87a38 */
+  --bp-palette-sepia-500: oklch(0.5625 0.1348 57.87); /* #ae5d00 */
+  --bp-palette-sepia-600: oklch(0.4758 0.1241 50.96); /* #914300 */
+  --bp-palette-sepia-700: oklch(0.383 0.1032 48.71); /* #6d2e00 */
+  --bp-palette-sepia-800: oklch(0.2915 0.0818 46.09); /* #4b1b00 */
+  --bp-palette-sepia-900: oklch(0.1963 0.0595 41.82); /* #2a0900 */
+  --bp-palette-sepia-1000: oklch(0.1027 0.0258 53.71); /* #090200 */
+  --bp-palette-grey-100: oklch(0.92 0.0138 258.35); /* #dfe5ee */
+  --bp-palette-grey-200: oklch(0.8301 0.0148 254.62); /* #c1c8d1 */
+  --bp-palette-grey-300: oklch(0.7381 0.014 251.6); /* #a4abb3 */
+  --bp-palette-grey-400: oklch(0.6447 0.0151 258.36); /* #888e97 */
+  --bp-palette-grey-500: oklch(0.5531 0.0144 255.56); /* #6d737b */
+  --bp-palette-grey-600: oklch(0.4579 0.0151 255.58); /* #525860 */
+  --bp-palette-grey-700: oklch(0.3648 0.0145 252.28); /* #393f46 */
+  --bp-palette-grey-800: oklch(0.2598 0.0162 264.24); /* #20242c */
+  --bp-palette-grey-900: oklch(0.2028 0.016 256.82); /* #12171e */
+  --bp-palette-grey-1000: oklch(0.1487 0.0168 259.92); /* #070b12 */
+  --bp-palette-white-100: oklch(1 0 none / 0.06); /* #ffffff0f */
+  --bp-palette-white-200: oklch(1 0 none / 0.12); /* #ffffff1f */
+  --bp-palette-white-300: oklch(1 0 none / 0.2); /* #ffffff33 */
+  --bp-palette-white-400: oklch(1 0 none / 0.3); /* #ffffff4d */
+  --bp-palette-white-500: oklch(1 0 none / 0.5); /* #ffffff80 */
+  --bp-palette-white-600: oklch(1 0 none / 0.8); /* #ffffffcc */
+  --bp-palette-white-700: oklch(1 0 none / 0.85); /* #ffffffd9 */
+  --bp-palette-white-800: oklch(1 0 none / 0.9); /* #ffffffe6 */
+  --bp-palette-white-900: oklch(1 0 none / 0.95); /* #fffffff2 */
+  --bp-palette-white-1000: oklch(1 0 none); /* #ffffff */
+  --bp-palette-black-100: oklch(0.0696 0.0248 257.1 / 0.025); /* #00010506 */
+  --bp-palette-black-200: oklch(0.0696 0.0248 257.1 / 0.09); /* #00010517 */
+  --bp-palette-black-300: oklch(0.0696 0.0248 257.1 / 0.12); /* #0001051f */
+  --bp-palette-black-400: oklch(0.0696 0.0248 257.1 / 0.3); /* #0001054d */
+  --bp-palette-black-500: oklch(0.0696 0.0248 257.1 / 0.5); /* #00010580 */
+  --bp-palette-black-600: oklch(0.0696 0.0248 257.1 / 0.8); /* #000105cc */
+  --bp-palette-black-700: oklch(0.0696 0.0248 257.1 / 0.85); /* #000105d9 */
+  --bp-palette-black-800: oklch(0.0696 0.0248 257.1 / 0.9); /* #000105e6 */
+  --bp-palette-black-900: oklch(0.0696 0.0248 257.1 / 0.95); /* #000105f2 */
+  --bp-palette-black-1000: oklch(0.0696 0.0248 257.1); /* #000105 */
+  --bp-surface-divider-color-default: #00010517; /* black/1000 at 9% */
+  --bp-surface-divider-color-strong: #0001051f; /* black/1000 at 12% */
+  --bp-surface-border-color-neutral: var(--bp-intent-neutral-200);
+  --bp-surface-border-color-primary: var(--bp-intent-primary-200);
+  --bp-surface-border-color-success: var(--bp-intent-success-200);
+  --bp-surface-border-color-warning: var(--bp-intent-warning-200);
+  --bp-surface-border-color-danger: var(--bp-intent-danger-200);
+  --bp-surface-border-width: 1px;
+  --bp-surface-border-radius: 4px;
+  --bp-surface-shadow-0:
+    0px 0px 0px 1px rgba(0, 0, 0, 0.15), 0px 0px 5px 0px rgba(0, 0, 0, 0.02); /** Level 0 - border only, 0 0 0 1px rgba(black, 15%), 0 0 5px 0 rgba(0,0,0, 2%) */
+  --bp-surface-shadow-1:
+    0px 0px 0px 1px rgba(0, 0, 0, 0.1), 0px 1px 3px 0px rgba(0, 0, 0, 0.1),
+    0px 1px 2px -1px rgba(0, 0, 0, 0.1); /** Level 1 - subtle elevation */
+  --bp-surface-shadow-2:
+    0px 0px 0px 1px rgba(0, 0, 0, 0.1), 0px 4px 6px -4px rgba(0, 0, 0, 0.1),
+    0px 10px 15px -3px rgba(0, 0, 0, 0.1); /** Level 2 - standard elevation */
+  --bp-surface-shadow-3:
+    0px 0px 0px 1px rgba(0, 0, 0, 0.1), 0px 20px 25px -5px rgba(0, 0, 0, 0.1),
+    0px 10px 15px -3px rgba(0, 0, 0, 0.1); /** Level 3 - popover/dialog elevation */
+  --bp-surface-shadow-4:
+    0px 0px 0px 1px rgba(0, 0, 0, 0.1), 0px 25px 50px -12px rgba(0, 0, 0, 0.3); /** Level 4 - maximum elevation */
+  --bp-surface-spacing: 4px; /** Base spacing unit — components multiply this */
+  --bp-surface-z-index-0: 0;
+  --bp-surface-z-index-1: 10;
+  --bp-surface-z-index-2: 20;
+  --bp-surface-z-index-3: 30;
+  --bp-surface-z-index-4: 40;
+  --bp-surface-color-code: #ffffffb3; /* white/1000 at 70% */
+  --bp-surface-layer-opacity-base: 0.01;
+  --bp-surface-layer-opacity-intent-rest: 0.03;
+  --bp-surface-layer-opacity-intent-hover: 0.06;
+  --bp-surface-layer-opacity-intent-active: 0.12;
+  --bp-surface-layer-color-base: #00113803; /* blue/900 at 1% */
+  --bp-surface-layer-color-neutral-rest: #6d737b08; /* grey/500 at 3% */
+  --bp-surface-layer-color-neutral-hover: #393f460f; /* grey/700 at 6% */
+  --bp-surface-layer-color-neutral-active: #393f461f; /* grey/700 at 12% */
+  --bp-surface-layer-color-primary-rest: #3071cd08; /* blue/500 at 3% */
+  --bp-surface-layer-color-primary-hover: #1356af0f; /* blue/600 at 6% */
+  --bp-surface-layer-color-primary-active: #1356af1f; /* blue/600 at 12% */
+  --bp-surface-layer-color-success-rest: #00844008; /* green/500 at 3% */
+  --bp-surface-layer-color-success-hover: #006a280f; /* green/600 at 6% */
+  --bp-surface-layer-color-success-active: #006a281f; /* green/600 at 12% */
+  --bp-surface-layer-color-warning-rest: #bd520008; /* orange/500 at 3% */
+  --bp-surface-layer-color-warning-hover: #9e36000f; /* orange/600 at 6% */
+  --bp-surface-layer-color-warning-active: #9e36001f; /* orange/600 at 12% */
+  --bp-surface-layer-color-danger-rest: #c3494a08; /* red/500 at 3% */
+  --bp-surface-layer-color-danger-hover: #a32c310f; /* red/600 at 6% */
+  --bp-surface-layer-color-danger-active: #a32c311f; /* red/600 at 12% */
+  --bp-surface-layer-base: linear-gradient(
+    var(--bp-surface-layer-color-base) 0 0
+  );
+  --bp-surface-layer-neutral-rest: linear-gradient(
+    var(--bp-surface-layer-color-neutral-rest) 0 0
+  );
+  --bp-surface-layer-neutral-hover: linear-gradient(
+    var(--bp-surface-layer-color-neutral-hover) 0 0
+  );
+  --bp-surface-layer-neutral-active: linear-gradient(
+    var(--bp-surface-layer-color-neutral-active) 0 0
+  );
+  --bp-surface-layer-primary-rest: linear-gradient(
+    var(--bp-surface-layer-color-primary-rest) 0 0
+  );
+  --bp-surface-layer-primary-hover: linear-gradient(
+    var(--bp-surface-layer-color-primary-hover) 0 0
+  );
+  --bp-surface-layer-primary-active: linear-gradient(
+    var(--bp-surface-layer-color-primary-active) 0 0
+  );
+  --bp-surface-layer-success-rest: linear-gradient(
+    var(--bp-surface-layer-color-success-rest) 0 0
+  );
+  --bp-surface-layer-success-hover: linear-gradient(
+    var(--bp-surface-layer-color-success-hover) 0 0
+  );
+  --bp-surface-layer-success-active: linear-gradient(
+    var(--bp-surface-layer-color-success-active) 0 0
+  );
+  --bp-surface-layer-warning-rest: linear-gradient(
+    var(--bp-surface-layer-color-warning-rest) 0 0
+  );
+  --bp-surface-layer-warning-hover: linear-gradient(
+    var(--bp-surface-layer-color-warning-hover) 0 0
+  );
+  --bp-surface-layer-warning-active: linear-gradient(
+    var(--bp-surface-layer-color-warning-active) 0 0
+  );
+  --bp-surface-layer-danger-rest: linear-gradient(
+    var(--bp-surface-layer-color-danger-rest) 0 0
+  );
+  --bp-surface-layer-danger-hover: linear-gradient(
+    var(--bp-surface-layer-color-danger-hover) 0 0
+  );
+  --bp-surface-layer-danger-active: linear-gradient(
+    var(--bp-surface-layer-color-danger-active) 0 0
+  );
+  --bp-surface-background-color-base-rest: var(--bp-palette-white-1000);
+  --bp-surface-background-color-base-hover: var(--bp-palette-white-1000);
+  --bp-surface-background-color-base-active: var(--bp-palette-white-1000);
+  --bp-surface-background-color-neutral-rest: var(--bp-intent-neutral-500);
+  --bp-surface-background-color-neutral-hover: var(--bp-intent-neutral-600);
+  --bp-surface-background-color-neutral-active: var(--bp-intent-neutral-700);
+  --bp-surface-background-color-primary-rest: var(--bp-intent-primary-500);
+  --bp-surface-background-color-primary-hover: var(--bp-intent-primary-600);
+  --bp-surface-background-color-primary-active: var(--bp-intent-primary-700);
+  --bp-surface-background-color-success-rest: var(--bp-intent-success-500);
+  --bp-surface-background-color-success-hover: var(--bp-intent-success-600);
+  --bp-surface-background-color-success-active: var(--bp-intent-success-700);
+  --bp-surface-background-color-warning-rest: var(--bp-intent-warning-500);
+  --bp-surface-background-color-warning-hover: var(--bp-intent-warning-600);
+  --bp-surface-background-color-warning-active: var(--bp-intent-warning-700);
+  --bp-surface-background-color-danger-rest: var(--bp-intent-danger-500);
+  --bp-surface-background-color-danger-hover: var(--bp-intent-danger-600);
+  --bp-surface-background-color-danger-active: var(--bp-intent-danger-700);
+  --bp-typography-family-body:
+    -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, Ubuntu,
+    Cantarell, "Open Sans", "Helvetica Neue", blueprint-icons-16, sans-serif;
+  --bp-typography-family-heading: var(
+    --bp-typography-family-body
+  ); /** Aliases the body family; kept as its own slot so a distinct heading face can be supplied without touching body. */
+  --bp-typography-family-display: var(
+    --bp-typography-family-body
+  ); /** Placeholder display face: aliases the body family for now; swap in a dedicated display stack when one is supplied. */
+  --bp-typography-family-mono: monospace;
+  --bp-typography-size-2xs: 9px;
+  --bp-typography-size-xs: 10px;
+  --bp-typography-size-sm: 11px;
+  --bp-typography-size-md: 13px;
+  --bp-typography-size-lg: 14px;
+  --bp-typography-size-xl: 15px;
+  --bp-typography-size-2xl: 16px;
+  --bp-typography-size-3xl: 20px;
+  --bp-typography-size-4xl: 24px;
+  --bp-typography-size-5xl: 28px;
+  --bp-typography-size-6xl: 48px;
+  --bp-typography-weight-default: 400;
+  --bp-typography-weight-strong: 500;
+  --bp-typography-line-height-running-factor: 1.105; /** Multiplier applied to a style's standard line-height for multi-line running/body text (midpoint of the former per-size running ratios). Components/users stack their own line-height scaling on top. */
+  --bp-typography-color-base: var(--bp-palette-grey-1000);
+  --bp-typography-color-intent-neutral: var(--bp-intent-neutral-600);
+  --bp-typography-color-intent-primary: var(--bp-intent-primary-600);
+  --bp-typography-color-intent-success: var(--bp-intent-success-600);
+  --bp-typography-color-intent-warning: var(--bp-intent-warning-600);
+  --bp-typography-color-intent-danger: var(--bp-intent-danger-600);
+}
+
+@supports (color: oklch(from var(--any-color) l c h)) {
+  :root {
+    --bp-surface-divider-color-default: oklch(
+      from var(--bp-palette-black-1000) l c h / 0.09
+    );
+    --bp-surface-divider-color-strong: oklch(
+      from var(--bp-palette-black-1000) l c h / 0.12
+    );
+    --bp-surface-color-code: oklch(
+      from var(--bp-palette-white-1000) l c h / 0.7
+    );
+    --bp-surface-layer-color-base: oklch(
+      from var(--bp-intent-primary-900) l c h /
+        var(--bp-surface-layer-opacity-base)
+    );
+    --bp-surface-layer-color-neutral-rest: oklch(
+      from var(--bp-intent-neutral-500) l c h /
+        var(--bp-surface-layer-opacity-intent-rest)
+    );
+    --bp-surface-layer-color-neutral-hover: oklch(
+      from var(--bp-intent-neutral-700) l c h /
+        var(--bp-surface-layer-opacity-intent-hover)
+    );
+    --bp-surface-layer-color-neutral-active: oklch(
+      from var(--bp-intent-neutral-700) l c h /
+        var(--bp-surface-layer-opacity-intent-active)
+    );
+    --bp-surface-layer-color-primary-rest: oklch(
+      from var(--bp-intent-primary-500) l c h /
+        var(--bp-surface-layer-opacity-intent-rest)
+    );
+    --bp-surface-layer-color-primary-hover: oklch(
+      from var(--bp-intent-primary-600) l c h /
+        var(--bp-surface-layer-opacity-intent-hover)
+    );
+    --bp-surface-layer-color-primary-active: oklch(
+      from var(--bp-intent-primary-600) l c h /
+        var(--bp-surface-layer-opacity-intent-active)
+    );
+    --bp-surface-layer-color-success-rest: oklch(
+      from var(--bp-intent-success-500) l c h /
+        var(--bp-surface-layer-opacity-intent-rest)
+    );
+    --bp-surface-layer-color-success-hover: oklch(
+      from var(--bp-intent-success-600) l c h /
+        var(--bp-surface-layer-opacity-intent-hover)
+    );
+    --bp-surface-layer-color-success-active: oklch(
+      from var(--bp-intent-success-600) l c h /
+        var(--bp-surface-layer-opacity-intent-active)
+    );
+    --bp-surface-layer-color-warning-rest: oklch(
+      from var(--bp-intent-warning-500) l c h /
+        var(--bp-surface-layer-opacity-intent-rest)
+    );
+    --bp-surface-layer-color-warning-hover: oklch(
+      from var(--bp-intent-warning-600) l c h /
+        var(--bp-surface-layer-opacity-intent-hover)
+    );
+    --bp-surface-layer-color-warning-active: oklch(
+      from var(--bp-intent-warning-600) l c h /
+        var(--bp-surface-layer-opacity-intent-active)
+    );
+    --bp-surface-layer-color-danger-rest: oklch(
+      from var(--bp-intent-danger-500) l c h /
+        var(--bp-surface-layer-opacity-intent-rest)
+    );
+    --bp-surface-layer-color-danger-hover: oklch(
+      from var(--bp-intent-danger-600) l c h /
+        var(--bp-surface-layer-opacity-intent-hover)
+    );
+    --bp-surface-layer-color-danger-active: oklch(
+      from var(--bp-intent-danger-600) l c h /
+        var(--bp-surface-layer-opacity-intent-active)
+    );
+  }
+}
+
+/**
+ * Do not edit directly, this file was auto-generated.
+ */
+
+[data-bp-color-scheme="dark"],
+.bp6-dark {
+  --bp-palette-orange-100: oklch(0.8886 0.0492 47.64); /* #f7d1bf */
+  --bp-palette-orange-200: oklch(0.7812 0.0987 47.58); /* #eca480 */
+  --bp-palette-orange-300: oklch(0.6748 0.1304 46.68); /* #d77b4c */
+  --bp-palette-orange-400: oklch(0.5731 0.1453 46.11); /* #bb571e */
+  --bp-palette-orange-500: oklch(0.4738 0.143 41.97); /* #9a3700 */
+  --bp-palette-orange-600: oklch(0.3781 0.1298 35.91); /* #771c00 */
+  --bp-palette-orange-700: oklch(0.2853 0.1028 33.93); /* #520c00 */
+  --bp-palette-orange-800: oklch(0.1988 0.0759 31.74); /* #300200 */
+  --bp-palette-orange-900: oklch(0.1188 0.0487 29.23); /* #140000 */
+  --bp-palette-orange-1000: oklch(0.0483 0.0197 29.35); /* #010000 */
+  --bp-palette-blue-100: oklch(0.8632 0.0517 257.55); /* #bdd4f5 */
+  --bp-palette-blue-200: oklch(0.7598 0.1032 257.69); /* #87b3f2 */
+  --bp-palette-blue-300: oklch(0.6581 0.1376 257.21); /* #5892e4 */
+  --bp-palette-blue-400: oklch(0.5575 0.1574 257.09); /* #2e72ce */
+  --bp-palette-blue-500: oklch(0.4602 0.1628 257.32); /* #0454b0 */
+  --bp-palette-blue-600: oklch(0.3697 0.1506 259.98); /* #00388d */
+  --bp-palette-blue-700: oklch(0.2821 0.1276 261.69); /* #002167 */
+  --bp-palette-blue-800: oklch(0.1978 0.0972 262.74); /* #000e40 */
+  --bp-palette-blue-900: oklch(0.1173 0.0616 263.37); /* #00031c */
+  --bp-palette-blue-1000: oklch(0.0488 0.022 261.66); /* #000002 */
+  --bp-palette-green-100: oklch(0.8268 0.0461 151.6); /* #b1cfb8 */
+  --bp-palette-green-200: oklch(0.7272 0.092 151.86); /* #7ab88a */
+  --bp-palette-green-300: oklch(0.6289 0.1213 152.07); /* #479d63 */
+  --bp-palette-green-400: oklch(0.5331 0.1374 151.99); /* #0a8242 */
+  --bp-palette-green-500: oklch(0.4463 0.1281 148.32); /* #006627 */
+  --bp-palette-green-600: oklch(0.361 0.1123 145.38); /* #004c11 */
+  --bp-palette-green-700: oklch(0.2748 0.0905 143.51); /* #003203 */
+  --bp-palette-green-800: oklch(0.194 0.066 142.5); /* #001b00 */
+  --bp-palette-green-900: oklch(0.1157 0.0394 142.5); /* #000800 */
+  --bp-palette-green-1000: oklch(0.0493 0.0157 144.72); /* #000100 */
+  --bp-palette-red-100: oklch(0.8935 0.048 23.4); /* #fad0cd */
+  --bp-palette-red-200: oklch(0.7869 0.0998 22.6); /* #f3a09c */
+  --bp-palette-red-300: oklch(0.6826 0.1321 23.56); /* #df7571 */
+  --bp-palette-red-400: oklch(0.5779 0.1498 23); /* #c24e4e */
+  --bp-palette-red-500: oklch(0.4769 0.1513 23.05); /* #a12d31 */
+  --bp-palette-red-600: oklch(0.3789 0.1407 23); /* #7c101b */
+  --bp-palette-red-700: oklch(0.2899 0.1173 24.22); /* #580009 */
+  --bp-palette-red-800: oklch(0.2051 0.0833 25.99); /* #340002 */
+  --bp-palette-red-900: oklch(0.1246 0.0507 26.74); /* #160000 */
+  --bp-palette-red-1000: oklch(0.0487 0.0196 24); /* #020000 */
+  --bp-palette-vermilion-100: oklch(0.8915 0.0499 33.99); /* #fad0c6 */
+  --bp-palette-vermilion-200: oklch(0.7866 0.0995 34.43); /* #f2a28f */
+  --bp-palette-vermilion-300: oklch(0.6811 0.1325 34.59); /* #de785f */
+  --bp-palette-vermilion-400: oklch(0.5756 0.1478 34.07); /* #c05239 */
+  --bp-palette-vermilion-500: oklch(0.4756 0.1503 33.66); /* #9f3119 */
+  --bp-palette-vermilion-600: oklch(0.3771 0.1393 32.96); /* #7b1400 */
+  --bp-palette-vermilion-700: oklch(0.2861 0.1174 29.23); /* #570000 */
+  --bp-palette-vermilion-800: oklch(0.2043 0.0838 29.23); /* #340000 */
+  --bp-palette-vermilion-900: oklch(0.1222 0.0502 29.23); /* #150000 */
+  --bp-palette-vermilion-1000: oklch(0.0483 0.0197 29.35); /* #010000 */
+  --bp-palette-rose-100: oklch(0.8972 0.0491 3.08); /* #fbd0da */
+  --bp-palette-rose-200: oklch(0.7906 0.099 4.85); /* #f1a0b2 */
+  --bp-palette-rose-300: oklch(0.6833 0.1312 4.01); /* #db7490 */
+  --bp-palette-rose-400: oklch(0.5787 0.1501 4.24); /* #bf4d6f */
+  --bp-palette-rose-500: oklch(0.4773 0.1523 4.26); /* #9d2b52 */
+  --bp-palette-rose-600: oklch(0.3783 0.142 4.39); /* #790d39 */
+  --bp-palette-rose-700: oklch(0.2896 0.1164 5.07); /* #550023 */
+  --bp-palette-rose-800: oklch(0.2063 0.0826 7.95); /* #330010 */
+  --bp-palette-rose-900: oklch(0.1236 0.0495 8.93); /* #140004 */
+  --bp-palette-rose-1000: oklch(0.0498 0.02 4.05); /* #020000 */
+  --bp-palette-violet-100: oklch(0.8987 0.0499 327.73); /* #f0d3ef */
+  --bp-palette-violet-200: oklch(0.7888 0.1021 327.82); /* #dea3dc */
+  --bp-palette-violet-300: oklch(0.6826 0.1368 327.3); /* #c579c4 */
+  --bp-palette-violet-400: oklch(0.5787 0.1538 327.08); /* #a854a8 */
+  --bp-palette-violet-500: oklch(0.477 0.1581 327.35); /* #89338a */
+  --bp-palette-violet-600: oklch(0.3799 0.1484 327.6); /* #691869 */
+  --bp-palette-violet-700: oklch(0.2864 0.1273 327.3); /* #48034a */
+  --bp-palette-violet-800: oklch(0.2015 0.0931 327.23); /* #2a002b */
+  --bp-palette-violet-900: oklch(0.1207 0.0562 325.76); /* #0f0011 */
+  --bp-palette-violet-1000: oklch(0.0487 0.0226 326.61); /* #010001 */
+  --bp-palette-indigo-100: oklch(0.8848 0.0514 287.81); /* #d6d4fa */
+  --bp-palette-indigo-200: oklch(0.7791 0.103 288.32); /* #b4adf5 */
+  --bp-palette-indigo-300: oklch(0.6733 0.1375 288.7); /* #9486e5 */
+  --bp-palette-indigo-400: oklch(0.5695 0.1575 288.4); /* #7663cd */
+  --bp-palette-indigo-500: oklch(0.4708 0.1621 288.51); /* #5b44ae */
+  --bp-palette-indigo-600: oklch(0.3749 0.1536 288.31); /* #42298b */
+  --bp-palette-indigo-700: oklch(0.2833 0.1319 288.39); /* #2b1365 */
+  --bp-palette-indigo-800: oklch(0.1967 0.1013 289); /* #17043f */
+  --bp-palette-indigo-900: oklch(0.1176 0.0638 288.53); /* #06001b */
+  --bp-palette-indigo-1000: oklch(0.0483 0.0234 285.48); /* #000002 */
+  --bp-palette-cerulean-100: oklch(0.8515 0.0445 242.89); /* #b6d2ea */
+  --bp-palette-cerulean-200: oklch(0.7479 0.0894 243.91); /* #7bb4e2 */
+  --bp-palette-cerulean-300: oklch(0.6478 0.1209 243.85); /* #4496d2 */
+  --bp-palette-cerulean-400: oklch(0.5502 0.1357 244.01); /* #0078ba */
+  --bp-palette-cerulean-500: oklch(0.4611 0.1307 250.05); /* #005a9d */
+  --bp-palette-cerulean-600: oklch(0.3736 0.1183 253.84); /* #00407d */
+  --bp-palette-cerulean-700: oklch(0.284 0.0994 256.64); /* #002859 */
+  --bp-palette-cerulean-800: oklch(0.199 0.0746 258.28); /* #001437 */
+  --bp-palette-cerulean-900: oklch(0.1199 0.047 259.22); /* #000517 */
+  --bp-palette-cerulean-1000: oklch(0.0474 0.019 259.73); /* #000002 */
+  --bp-palette-turquoise-100: oklch(0.8344 0.0308 185.02); /* #b3d0cb */
+  --bp-palette-turquoise-200: oklch(0.7331 0.0622 182.96); /* #7cb6ac */
+  --bp-palette-turquoise-300: oklch(0.6342 0.0828 183.51); /* #489b90 */
+  --bp-palette-turquoise-400: oklch(0.5384 0.0957 182.77); /* #028073 */
+  --bp-palette-turquoise-500: oklch(0.452 0.0815 180.88); /* #006458 */
+  --bp-palette-turquoise-600: oklch(0.365 0.0666 179.18); /* #004a3f */
+  --bp-palette-turquoise-700: oklch(0.2797 0.0514 178.08); /* #003129 */
+  --bp-palette-turquoise-800: oklch(0.1961 0.036 178.27); /* #001a15 */
+  --bp-palette-turquoise-900: oklch(0.1174 0.022 175.47); /* #000705 */
+  --bp-palette-turquoise-1000: oklch(0.0463 0.0087 175.49); /* #000000 */
+  --bp-palette-forest-100: oklch(0.8273 0.0491 144.69); /* #b4cfb3 */
+  --bp-palette-forest-200: oklch(0.7282 0.0992 144.14); /* #80b87f */
+  --bp-palette-forest-300: oklch(0.6297 0.1318 144.59); /* #519d54 */
+  --bp-palette-forest-400: oklch(0.5346 0.1481 144.58); /* #25822e */
+  --bp-palette-forest-500: oklch(0.4432 0.1461 143.47); /* #00660c */
+  --bp-palette-forest-600: oklch(0.3584 0.122 142.5); /* #004b00 */
+  --bp-palette-forest-700: oklch(0.2737 0.0931 142.5); /* #003200 */
+  --bp-palette-forest-800: oklch(0.1936 0.0659 142.5); /* #001b00 */
+  --bp-palette-forest-900: oklch(0.1155 0.0393 142.5); /* #000800 */
+  --bp-palette-forest-1000: oklch(0.0489 0.0166 142.5); /* #000100 */
+  --bp-palette-lime-100: oklch(0.8388 0.0439 125.92); /* #c3d0b1 */
+  --bp-palette-lime-200: oklch(0.7374 0.0853 124.71); /* #9eb478 */
+  --bp-palette-lime-300: oklch(0.6385 0.1125 125.19); /* #7c9747 */
+  --bp-palette-lime-400: oklch(0.5403 0.1246 124.76); /* #5f7a18 */
+  --bp-palette-lime-500: oklch(0.447 0.1142 126.27); /* #445f00 */
+  --bp-palette-lime-600: oklch(0.3564 0.0929 127.79); /* #2e4500 */
+  --bp-palette-lime-700: oklch(0.2685 0.071 128.76); /* #1b2c00 */
+  --bp-palette-lime-800: oklch(0.1864 0.0496 129.29); /* #0c1700 */
+  --bp-palette-lime-900: oklch(0.1123 0.0308 131.26); /* #020600 */
+  --bp-palette-lime-1000: oklch(0.0465 0.0126 130.51); /* #000000 */
+  --bp-palette-gold-100: oklch(0.8682 0.038 75.21); /* #e3d1b9 */
+  --bp-palette-gold-200: oklch(0.7624 0.074 75.64); /* #cdac7d */
+  --bp-palette-gold-300: oklch(0.661 0.0976 75.36); /* #b58a49 */
+  --bp-palette-gold-400: oklch(0.5593 0.1078 74); /* #99691c */
+  --bp-palette-gold-500: oklch(0.4629 0.1004 69.82); /* #7c4d00 */
+  --bp-palette-gold-600: oklch(0.3685 0.084 63.01); /* #5e3400 */
+  --bp-palette-gold-700: oklch(0.2797 0.0653 60.5); /* #3f2000 */
+  --bp-palette-gold-800: oklch(0.1946 0.0466 57.85); /* #240e00 */
+  --bp-palette-gold-900: oklch(0.1162 0.0301 51.4); /* #0d0300 */
+  --bp-palette-gold-1000: oklch(0.0461 0.0126 47.63); /* #010000 */
+  --bp-palette-sepia-100: oklch(0.8787 0.0433 59.8); /* #edd1bb */
+  --bp-palette-sepia-200: oklch(0.7726 0.0852 57.33); /* #dfa87f */
+  --bp-palette-sepia-300: oklch(0.6685 0.1117 58.05); /* #c8824b */
+  --bp-palette-sepia-400: oklch(0.5676 0.1254 56.74); /* #ad601c */
+  --bp-palette-sepia-500: oklch(0.4684 0.1204 52.05); /* #8d4200 */
+  --bp-palette-sepia-600: oklch(0.3753 0.1067 45.33); /* #6d2a00 */
+  --bp-palette-sepia-700: oklch(0.2816 0.0834 43.04); /* #491700 */
+  --bp-palette-sepia-800: oklch(0.1963 0.0613 40.23); /* #2b0800 */
+  --bp-palette-sepia-900: oklch(0.1163 0.0404 35.43); /* #110100 */
+  --bp-palette-sepia-1000: oklch(0.0493 0.015 41.67); /* #010000 */
+  --bp-palette-grey-100: oklch(0.8951 0.0167 257.04); /* #d6dde8 */
+  --bp-palette-grey-200: oklch(0.781 0.0171 253.57); /* #b0b9c3 */
+  --bp-palette-grey-300: oklch(0.6684 0.0156 250.66); /* #8e969e */
+  --bp-palette-grey-400: oklch(0.5587 0.0161 257.5); /* #6e757e */
+  --bp-palette-grey-500: oklch(0.4561 0.0146 254.8); /* #52585f */
+  --bp-palette-grey-600: oklch(0.3552 0.0145 254.96); /* #373c44 */
+  --bp-palette-grey-700: oklch(0.2629 0.013 251.76); /* #20252b */
+  --bp-palette-grey-800: oklch(0.1677 0.0132 263.8); /* #0c0f15 */
+  --bp-palette-grey-900: oklch(0.1208 0.0123 256.42); /* #04060a */
+  --bp-palette-grey-1000: oklch(0.0801 0.0122 259.5); /* #010204 */
+  --bp-surface-divider-color-default: #ffffff1f; /* white/1000 at 12% */
+  --bp-surface-divider-color-strong: #ffffff33; /* white/1000 at 20% */
+  --bp-surface-border-color-neutral: var(--bp-intent-neutral-500);
+  --bp-surface-border-color-primary: var(--bp-intent-primary-500);
+  --bp-surface-border-color-success: var(--bp-intent-success-500);
+  --bp-surface-border-color-warning: var(--bp-intent-warning-500);
+  --bp-surface-border-color-danger: var(--bp-intent-danger-500);
+  --bp-surface-shadow-0:
+    inset 0px 0px 0px 1px rgba(255, 255, 255, 0.2),
+    0px 0px 10px 0px rgba(0, 0, 0, 0.2); /** Level 0 - border only, inset 0 0 0 1px rgba(white, 20%), 0 0 10px 0 rgba(0,0,0, 20%) */
+  --bp-surface-shadow-1:
+    inset 0px 0px 0px 1px rgba(255, 255, 255, 0.2),
+    0px 1px 10px 0px rgba(0, 0, 0, 0.2), 0px 1px 10px -1px rgba(0, 0, 0, 0.2); /** Level 1 - subtle elevation with inner highlights */
+  --bp-surface-shadow-2:
+    inset 0px 0px 0px 1px rgba(255, 255, 255, 0.2),
+    0px 4px 6px -4px rgba(0, 0, 0, 0.5), 0px 10px 30px -5px rgba(0, 0, 0, 0.5); /** Level 2 - standard elevation */
+  --bp-surface-shadow-3:
+    inset 0px 0px 0px 1px rgba(255, 255, 255, 0.2),
+    0px 20px 25px -5px rgba(0, 0, 0, 0.3), 0px 10px 30px -5px rgba(0, 0, 0, 0.3); /** Level 3 - popover/dialog elevation */
+  --bp-surface-shadow-4:
+    inset 0px 0px 0px 1px rgba(255, 255, 255, 0.2),
+    0px 25px 60px -12px rgba(0, 0, 0, 0.85); /** Level 4 - maximum elevation */
+  --bp-surface-color-code: #0001054d; /* black/1000 at 30% */
+  --bp-surface-layer-opacity-base: 0.03;
+  --bp-surface-layer-opacity-intent-rest: 0.1;
+  --bp-surface-layer-opacity-intent-hover: 0.2;
+  --bp-surface-layer-opacity-intent-active: 0.1;
+  --bp-surface-layer-color-base: #87b3f208; /* blue/200 at 3% */
+  --bp-surface-layer-color-neutral-rest: #52585f1a; /* grey/500 at 10% */
+  --bp-surface-layer-color-neutral-hover: #6e757e33; /* grey/400 at 20% */
+  --bp-surface-layer-color-neutral-active: #373c441a; /* grey/600 at 10% */
+  --bp-surface-layer-color-primary-rest: #0454b01a; /* blue/500 at 10% */
+  --bp-surface-layer-color-primary-hover: #2e72ce33; /* blue/400 at 20% */
+  --bp-surface-layer-color-primary-active: #00388d1a; /* blue/600 at 10% */
+  --bp-surface-layer-color-success-rest: #0066271a; /* green/500 at 10% */
+  --bp-surface-layer-color-success-hover: #0a824233; /* green/400 at 20% */
+  --bp-surface-layer-color-success-active: #004c111a; /* green/600 at 10% */
+  --bp-surface-layer-color-warning-rest: #9a37001a; /* orange/500 at 10% */
+  --bp-surface-layer-color-warning-hover: #bb571e33; /* orange/400 at 20% */
+  --bp-surface-layer-color-warning-active: #771c001a; /* orange/600 at 10% */
+  --bp-surface-layer-color-danger-rest: #a12d311a; /* red/500 at 10% */
+  --bp-surface-layer-color-danger-hover: #c24e4e33; /* red/400 at 20% */
+  --bp-surface-layer-color-danger-active: #7c101b1a; /* red/600 at 10% */
+  --bp-surface-layer-base: linear-gradient(
+    var(--bp-surface-layer-color-base) 0 0
+  );
+  --bp-surface-layer-neutral-rest: linear-gradient(
+    var(--bp-surface-layer-color-neutral-rest) 0 0
+  );
+  --bp-surface-layer-neutral-hover: linear-gradient(
+    var(--bp-surface-layer-color-neutral-hover) 0 0
+  );
+  --bp-surface-layer-neutral-active: linear-gradient(
+    var(--bp-surface-layer-color-neutral-active) 0 0
+  );
+  --bp-surface-layer-primary-rest: linear-gradient(
+    var(--bp-surface-layer-color-primary-rest) 0 0
+  );
+  --bp-surface-layer-primary-hover: linear-gradient(
+    var(--bp-surface-layer-color-primary-hover) 0 0
+  );
+  --bp-surface-layer-primary-active: linear-gradient(
+    var(--bp-surface-layer-color-primary-active) 0 0
+  );
+  --bp-surface-layer-success-rest: linear-gradient(
+    var(--bp-surface-layer-color-success-rest) 0 0
+  );
+  --bp-surface-layer-success-hover: linear-gradient(
+    var(--bp-surface-layer-color-success-hover) 0 0
+  );
+  --bp-surface-layer-success-active: linear-gradient(
+    var(--bp-surface-layer-color-success-active) 0 0
+  );
+  --bp-surface-layer-warning-rest: linear-gradient(
+    var(--bp-surface-layer-color-warning-rest) 0 0
+  );
+  --bp-surface-layer-warning-hover: linear-gradient(
+    var(--bp-surface-layer-color-warning-hover) 0 0
+  );
+  --bp-surface-layer-warning-active: linear-gradient(
+    var(--bp-surface-layer-color-warning-active) 0 0
+  );
+  --bp-surface-layer-danger-rest: linear-gradient(
+    var(--bp-surface-layer-color-danger-rest) 0 0
+  );
+  --bp-surface-layer-danger-hover: linear-gradient(
+    var(--bp-surface-layer-color-danger-hover) 0 0
+  );
+  --bp-surface-layer-danger-active: linear-gradient(
+    var(--bp-surface-layer-color-danger-active) 0 0
+  );
+  --bp-surface-background-color-base-rest: var(--bp-palette-grey-800);
+  --bp-surface-background-color-base-hover: var(--bp-palette-grey-800);
+  --bp-surface-background-color-base-active: var(--bp-palette-grey-800);
+  --bp-surface-background-color-neutral-rest: var(--bp-intent-neutral-500);
+  --bp-surface-background-color-neutral-hover: var(--bp-intent-neutral-400);
+  --bp-surface-background-color-neutral-active: var(--bp-intent-neutral-600);
+  --bp-surface-background-color-primary-rest: var(--bp-intent-primary-500);
+  --bp-surface-background-color-primary-hover: var(--bp-intent-primary-400);
+  --bp-surface-background-color-primary-active: var(--bp-intent-primary-600);
+  --bp-surface-background-color-success-rest: var(--bp-intent-success-500);
+  --bp-surface-background-color-success-hover: var(--bp-intent-success-400);
+  --bp-surface-background-color-success-active: var(--bp-intent-success-600);
+  --bp-surface-background-color-warning-rest: var(--bp-intent-warning-500);
+  --bp-surface-background-color-warning-hover: var(--bp-intent-warning-400);
+  --bp-surface-background-color-warning-active: var(--bp-intent-warning-600);
+  --bp-surface-background-color-danger-rest: var(--bp-intent-danger-500);
+  --bp-surface-background-color-danger-hover: var(--bp-intent-danger-400);
+  --bp-surface-background-color-danger-active: var(--bp-intent-danger-600);
+  --bp-typography-color-base: var(--bp-palette-grey-100);
+  --bp-typography-color-intent-neutral: var(--bp-intent-neutral-200);
+  --bp-typography-color-intent-primary: var(--bp-intent-primary-200);
+  --bp-typography-color-intent-success: var(--bp-intent-success-200);
+  --bp-typography-color-intent-warning: var(--bp-intent-warning-200);
+  --bp-typography-color-intent-danger: var(--bp-intent-danger-200);
+}
+
+@supports (color: oklch(from var(--any-color) l c h)) {
+  [data-bp-color-scheme="dark"],
+  .bp6-dark {
+    --bp-surface-divider-color-default: oklch(
+      from var(--bp-palette-white-1000) l c h / 0.12
+    );
+    --bp-surface-divider-color-strong: oklch(
+      from var(--bp-palette-white-1000) l c h / 0.2
+    );
+    --bp-surface-color-code: oklch(
+      from var(--bp-palette-black-1000) l c h / 0.3
+    );
+    --bp-surface-layer-color-base: oklch(
+      from var(--bp-intent-primary-200) l c h /
+        var(--bp-surface-layer-opacity-base)
+    );
+    --bp-surface-layer-color-neutral-rest: oklch(
+      from var(--bp-intent-neutral-500) l c h /
+        var(--bp-surface-layer-opacity-intent-rest)
+    );
+    --bp-surface-layer-color-neutral-hover: oklch(
+      from var(--bp-intent-neutral-400) l c h /
+        var(--bp-surface-layer-opacity-intent-hover)
+    );
+    --bp-surface-layer-color-neutral-active: oklch(
+      from var(--bp-intent-neutral-600) l c h /
+        var(--bp-surface-layer-opacity-intent-active)
+    );
+    --bp-surface-layer-color-primary-rest: oklch(
+      from var(--bp-intent-primary-500) l c h /
+        var(--bp-surface-layer-opacity-intent-rest)
+    );
+    --bp-surface-layer-color-primary-hover: oklch(
+      from var(--bp-intent-primary-400) l c h /
+        var(--bp-surface-layer-opacity-intent-hover)
+    );
+    --bp-surface-layer-color-primary-active: oklch(
+      from var(--bp-intent-primary-600) l c h /
+        var(--bp-surface-layer-opacity-intent-active)
+    );
+    --bp-surface-layer-color-success-rest: oklch(
+      from var(--bp-intent-success-500) l c h /
+        var(--bp-surface-layer-opacity-intent-rest)
+    );
+    --bp-surface-layer-color-success-hover: oklch(
+      from var(--bp-intent-success-400) l c h /
+        var(--bp-surface-layer-opacity-intent-hover)
+    );
+    --bp-surface-layer-color-success-active: oklch(
+      from var(--bp-intent-success-600) l c h /
+        var(--bp-surface-layer-opacity-intent-active)
+    );
+    --bp-surface-layer-color-warning-rest: oklch(
+      from var(--bp-intent-warning-500) l c h /
+        var(--bp-surface-layer-opacity-intent-rest)
+    );
+    --bp-surface-layer-color-warning-hover: oklch(
+      from var(--bp-intent-warning-400) l c h /
+        var(--bp-surface-layer-opacity-intent-hover)
+    );
+    --bp-surface-layer-color-warning-active: oklch(
+      from var(--bp-intent-warning-600) l c h /
+        var(--bp-surface-layer-opacity-intent-active)
+    );
+    --bp-surface-layer-color-danger-rest: oklch(
+      from var(--bp-intent-danger-500) l c h /
+        var(--bp-surface-layer-opacity-intent-rest)
+    );
+    --bp-surface-layer-color-danger-hover: oklch(
+      from var(--bp-intent-danger-400) l c h /
+        var(--bp-surface-layer-opacity-intent-hover)
+    );
+    --bp-surface-layer-color-danger-active: oklch(
+      from var(--bp-intent-danger-600) l c h /
+        var(--bp-surface-layer-opacity-intent-active)
+    );
+  }
+}

--- a/packages/react-components/src/tokens/component-tokens/button.css
+++ b/packages/react-components/src/tokens/component-tokens/button.css
@@ -4,14 +4,14 @@
   --osdk-button-min-height: calc(var(--osdk-surface-spacing) * 7.5);
   --osdk-button-border-color: color-mix(
     in oklch,
-    var(--bp-palette-black) 20%,
+    var(--bp-palette-black-1000) 20%,
     transparent
   );
   --osdk-button-border: none;
   --osdk-button-border-radius: var(--osdk-surface-border-radius);
   --osdk-button-drop-shadow-color: color-mix(
     in oklch,
-    var(--bp-palette-black) 10%,
+    var(--bp-palette-black-1000) 10%,
     transparent
   );
   --osdk-button-shadow:
@@ -79,18 +79,18 @@
 .bp6-dark {
   --osdk-button-secondary-bg: color-mix(
     in srgb,
-    var(--bp-intent-default-rest) 40%,
-    var(--bp-palette-black)
+    var(--bp-surface-background-color-neutral-rest) 40%,
+    var(--bp-palette-black-1000)
   );
-  --osdk-button-secondary-color: var(--bp-intent-default-foreground);
+  --osdk-button-secondary-color: var(--bp-intent-neutral-foreground);
   --osdk-button-border-color: color-mix(
     in oklch,
-    var(--bp-surface-border-color-default) 50%,
+    var(--bp-surface-divider-color-default) 50%,
     transparent
   );
   --osdk-button-drop-shadow-color: color-mix(
     in oklch,
-    var(--bp-palette-black) 20%,
+    var(--bp-palette-black-1000) 20%,
     transparent
   );
   --osdk-button-shadow:

--- a/packages/react-components/src/tokens/component-tokens/input.css
+++ b/packages/react-components/src/tokens/component-tokens/input.css
@@ -15,10 +15,10 @@
      count for smooth CSS transitions when focus adds a visible glow. */
   --osdk-input-shadow:
     inset 0 0 0 var(--osdk-input-border-width)
-      color-mix(in oklch, var(--bp-palette-black) 20%, transparent),
+      color-mix(in oklch, var(--bp-palette-black-1000) 20%, transparent),
     0 0 0 0 transparent,
     inset 0 1px 1px
-      color-mix(in oklch, var(--bp-palette-black) 30%, transparent);
+      color-mix(in oklch, var(--bp-palette-black-1000) 30%, transparent);
 
   /* Input backgrounds */
   --osdk-input-bg: var(--osdk-surface-background-color-default-rest);
@@ -56,12 +56,12 @@
 [data-bp-color-scheme="dark"],
 .bp6-dark {
   --osdk-input-shadow:
-    0 0 0 0 color-mix(in srgb, var(--bp-intent-primary-rest) 0%, transparent),
-    0 0 0 0 color-mix(in srgb, var(--bp-intent-primary-rest) 0%, transparent),
+    0 0 0 0 color-mix(in srgb, var(--bp-emphasis-focus-color) 0%, transparent),
+    0 0 0 0 color-mix(in srgb, var(--bp-emphasis-focus-color) 0%, transparent),
     inset 0 0 0 1px
-      color-mix(in oklch, var(--bp-palette-white) 20%, transparent),
+      color-mix(in oklch, var(--bp-palette-white-1000) 20%, transparent),
     inset 0 -1px 1px 0
-      color-mix(in oklch, var(--bp-palette-white) 30%, transparent);
+      color-mix(in oklch, var(--bp-palette-white-1000) 30%, transparent);
   --osdk-input-bg: color-mix(
     in srgb,
     var(--osdk-palette-black) 30%,

--- a/packages/react-components/src/tokens/component-tokens/object-set.css
+++ b/packages/react-components/src/tokens/component-tokens/object-set.css
@@ -3,7 +3,9 @@
   --osdk-object-set-min-height: 30px;
   --osdk-object-set-padding: calc(var(--osdk-surface-spacing) * 1.5) 0;
   --osdk-object-set-color: var(--osdk-typography-color-default-rest);
-  --osdk-object-set-icon-default-color: var(--bp-palette-blue-4);
+  --osdk-object-set-icon-default-color: var(
+    --bp-typography-color-intent-primary
+  );
   --osdk-object-set-placeholder-color: var(--osdk-typography-color-muted);
   --osdk-object-set-font-family: var(--osdk-typography-family-default);
   --osdk-object-set-font-size: var(--osdk-typography-size-body-medium);


### PR DESCRIPTION
## Summary

Tests replacing the React Components base-token vocabulary with Blueprint's proposed next tokens from palantir/blueprint#8250. The goal is to evaluate whether product themes can override only Blueprint's public `--bp-*` contract while existing OSDK component-token names continue to work.

## Changes

- Import `next-tokens.css` instead of the legacy Blueprint token copy.
- Map retained OSDK base aliases to tokens from the new Blueprint vocabulary.
- Preserve token categories: retained `--osdk-intent-*` aliases map to `--bp-intent-*`, typography to typography, palette to palette, and emphasis to emphasis.
- Map the legacy `default` intent to Blueprint's `neutral` intent, using `500 / 600 / 700` for rest, hover, and active.
- Use base surface color for resting ground and neutral layer colors for interactive default hover and active backgrounds.
- Use default and strong divider tokens for the legacy neutral separator aliases.
- Use component-level `--bp-emphasis-disabled-opacity` instead of disabled color aliases.
- Replace remaining component-token references to removed legacy Blueprint names with valid next tokens.
- Remove 18 OSDK aliases with no runtime `var(...)` consumers and remove their documentation entries.
- Apply Storybook and People App themes as later CSS layers containing only next-token `--bp-*` overrides; remove Storybook's runtime one-to-many token expansion.
- Keep the legacy `blueprint-design-tokens.css` and `dark.css` files unchanged and unimported.

## Mapping model

The RFC defines `palette → intent → applied token → component`.

- Palette tokens are used directly only for values without semantic meaning, such as shadow construction and the dialog scrim.
- Intent aliases remain intent-to-intent. Foregrounds use the matching intent foreground.
- Opaque surfaces use `--bp-surface-background-color-*`.
- Translucent `background-color` consumers use `--bp-surface-layer-color-*`; stackable background-image consumers use `--bp-surface-layer-*`.
- Standard and semantic text use `--bp-typography-color-base` and `--bp-typography-color-intent-*`.
- Focus, disabled state, motion, spacing, radius, elevation, and stacking use their corresponding emphasis or surface tokens.

## Concerns and token gaps

- **Intent aliases have mixed consumers.** Existing `--osdk-intent-*` aliases are used for filled backgrounds as well as text, icons, borders, and focus treatments. Keeping them in the intent category satisfies the mapping constraint, but those text and structural consumers still bypass the RFC's applied typography and surface roles.
- **Dark interaction ramps differ.** Category-preserving aliases use `500 / 600 / 700`. Blueprint's applied dark filled surfaces use `500 / 400 / 600`, so existing components that treat an OSDK intent alias as a fill will not follow the new dark surface interaction ramp.
- **Generic border aliases mix roles.** OSDK's default border token is used for both component outlines and separators. Blueprint distinguishes intent-bound component borders from neutral dividers, so no single mapping is semantically correct for every current consumer.
- **No strong neutral component-border role.** The new set has a strong divider but only one border color per intent. A component that needs a stronger neutral outline has no direct applied token.
- **No disabled intent or surface color states.** The RFC uses opacity on the entire component. This works for current disabled controls, but there is no token for a design that needs a distinct disabled color without dimming the whole component.
- **No stateful typography intent colors.** Semantic text has one color per intent, with no hover or active variants.
- **No dedicated placeholder/secondary-foreground token.** Placeholder and muted content currently share neutral intent typography, although these roles may require different contrast.
- **No dedicated backdrop/scrim token.** The dialog backdrop maps to mode-independent `--bp-palette-black-500` because it has no semantic intent.
- **Line height exposes only a factor.** Preserving the previous OSDK line height requires a consumer multiplier (`1.105 × 1.164 ≈ 1.286`) rather than a direct semantic line-height token.
- **Base surfaces deliberately do not react.** Existing interactive default backgrounds therefore use translucent neutral layer colors. This preserves state feedback, but their result depends on the surface underneath.
- **Skeleton contrast changes.** The old animation used approximately 5% → 40%; the new neutral layers use 3% → 12% in light mode, producing a much subtler glow.
- **Typography changes are visible.** Body sizes move from `10/12/14/16px` to `9/11/13/15px`, strong weight moves from 600 to 500, and disabled opacity moves from 0.5 to 0.4.
- **Intent foregrounds require theme validation.** The new warning foreground is white instead of the previous dark foreground. Any custom palette, intent, foreground, or applied filled-surface override must rerun the RFC's 4.5:1 contrast checks.

## Assumptions

- This is intentionally a breaking-change experiment; possible external consumers of removed OSDK aliases are not preserved.
- A runtime consumer means a `var(--osdk-...)` reference in this repository. Documentation and the unimported legacy `dark.css` do not count as consumers.
- Component-token names remain the compatibility boundary even where their current usage does not cleanly fit the new architecture.
