### PR TITLE
[2/5] ITSM OAC DSL: Create some helper methods for IT property requirements

### DIFF
--- a/.changeset/itsm-2-interface-property-accessors.md
+++ b/.changeset/itsm-2-interface-property-accessors.md
@@ -1,0 +1,6 @@
+---
+"@osdk/maker": minor
+"@osdk/maker-experimental": patch
+---
+
+Adds isInterfacePropertyRequired, resolving whether implementing object types must provide a property across interface-defined and shared-property-backed properties on an interface type.

--- a/packages/maker-experimental/src/conversion/toMarketplace/convertInterfacePropertyType.ts
+++ b/packages/maker-experimental/src/conversion/toMarketplace/convertInterfacePropertyType.ts
@@ -17,6 +17,7 @@
 import type { MarketplaceInterfacePropertyType } from "@osdk/client.unstable";
 import type { InterfacePropertyType } from "@osdk/maker";
 import {
+  isInterfacePropertyRequired,
   isInterfaceSharedPropertyType,
   shouldBeIndexedForSearch,
   validateVectorProperty,
@@ -27,20 +28,43 @@ import { convertNullabilityToDataConstraint } from "./convertNullabilityToDataCo
 import { convertSpt } from "./convertSpt.js";
 import { propertyTypeTypeToOntologyIrInterfaceType } from "./propertyTypeTypeToOntologyIrInterfaceType.js";
 
+/**
+ * The rid a property is keyed by on the wire, accounting for both interface-defined
+ * and shared-property-backed properties.
+ */
+export function interfacePropertyWireRid(
+  prop: InterfacePropertyType,
+  apiName: string,
+  interfaceApiName: string,
+  ridGenerator: OntologyRidGenerator,
+): string {
+  return isInterfaceSharedPropertyType(prop)
+    ? ridGenerator.generateIptRidFromSptRid(
+        ridGenerator.generateSptRid(prop.sharedPropertyType.apiName),
+      )
+    : ridGenerator.generateInterfacePropertyTypeRid(apiName, interfaceApiName);
+}
+
 export function convertInterfaceProperty(
   prop: InterfacePropertyType,
   apiName: string,
   interfaceApiName: string,
   ridGenerator: OntologyRidGenerator,
 ): [string, MarketplaceInterfacePropertyType] {
+  const rid = interfacePropertyWireRid(
+    prop,
+    apiName,
+    interfaceApiName,
+    ridGenerator,
+  );
   if (isInterfaceSharedPropertyType(prop)) {
     const convertedSpt = convertSpt(prop.sharedPropertyType, ridGenerator);
     return [
-      ridGenerator.generateIptRidFromSptRid(convertedSpt.rid),
+      rid,
       {
         type: "sharedPropertyBasedPropertyType",
         sharedPropertyBasedPropertyType: {
-          requireImplementation: prop.required,
+          requireImplementation: isInterfacePropertyRequired(prop),
           sharedPropertyType: convertedSpt,
         },
       },
@@ -48,7 +72,7 @@ export function convertInterfaceProperty(
   } else {
     validateVectorProperty(apiName, prop.type, prop.array);
     return [
-      ridGenerator.generateInterfacePropertyTypeRid(apiName, interfaceApiName),
+      rid,
       {
         type: "interfaceDefinedPropertyType",
         interfaceDefinedPropertyType: {
@@ -76,7 +100,7 @@ export function convertInterfaceProperty(
               ),
           constraints: {
             primaryKeyConstraint: prop.primaryKeyConstraint ?? "NO_RESTRICTION",
-            requireImplementation: prop.required ?? true,
+            requireImplementation: isInterfacePropertyRequired(prop),
             indexedForSearch: shouldBeIndexedForSearch(prop.type),
             typeClasses: prop.typeClasses ?? [],
             dataConstraints: convertNullabilityToDataConstraint({
@@ -90,10 +114,7 @@ export function convertInterfaceProperty(
                 )
               : undefined,
           },
-          rid: ridGenerator.generateInterfacePropertyTypeRid(
-            apiName,
-            interfaceApiName,
-          ),
+          rid,
         },
       },
     ];

--- a/packages/maker/src/api/defineObject.ts
+++ b/packages/maker/src/api/defineObject.ts
@@ -37,6 +37,7 @@ import { getFlattenedInterfaceProperties } from "./interface/getFlattenedInterfa
 import {
   getInterfacePropertyTypeType,
   type InterfacePropertyType,
+  isInterfacePropertyRequired,
   isInterfaceSharedPropertyType,
 } from "./interface/InterfacePropertyType.js";
 import type { ObjectPropertyType } from "./object/ObjectPropertyType.js";
@@ -250,7 +251,7 @@ export function defineObject(
           objectDef,
         );
       }
-      if (interfaceProp[1].required === false) {
+      if (!isInterfacePropertyRequired(interfaceProp[1])) {
         return { type: "valid" };
       }
       return {

--- a/packages/maker/src/api/interface/InterfacePropertyType.ts
+++ b/packages/maker/src/api/interface/InterfacePropertyType.ts
@@ -50,3 +50,26 @@ export function getInterfacePropertyTypeType(
     ? interfacePropertyType.sharedPropertyType.type
     : interfacePropertyType.type;
 }
+
+/**
+ * Whether implementing object types must provide this property.
+ */
+export function isInterfacePropertyRequired(
+  interfacePropertyType: InterfacePropertyType,
+): boolean {
+  return isInterfaceSharedPropertyType(interfacePropertyType)
+    ? interfacePropertyType.required
+    : (interfacePropertyType.required ?? true);
+}
+
+/**
+ * The name a property is keyed by on the wire.
+ */
+export function interfacePropertyWireApiName(
+  interfacePropertyType: InterfacePropertyType,
+  authoredApiName: string,
+): string {
+  return isInterfaceSharedPropertyType(interfacePropertyType)
+    ? interfacePropertyType.sharedPropertyType.apiName
+    : authoredApiName;
+}

--- a/packages/maker/src/api/interface/getFlattenedInterfaceProperties.ts
+++ b/packages/maker/src/api/interface/getFlattenedInterfaceProperties.ts
@@ -16,7 +16,7 @@
 
 import {
   type InterfacePropertyType,
-  isInterfaceSharedPropertyType,
+  interfacePropertyWireApiName,
 } from "./InterfacePropertyType.js";
 import type { InterfaceType } from "./InterfaceType.js";
 
@@ -25,9 +25,7 @@ export function getFlattenedInterfaceProperties(
 ): Record<string, InterfacePropertyType> {
   let properties: Record<string, InterfacePropertyType> = Object.fromEntries(
     Object.entries(interfaceType.propertiesV3).map(([key, value]) => [
-      isInterfaceSharedPropertyType(value)
-        ? value.sharedPropertyType.apiName
-        : key,
+      interfacePropertyWireApiName(value, key),
       value,
     ]),
   );

--- a/packages/maker/src/conversion/toMarketplace/convertInterfacePropertyType.ts
+++ b/packages/maker/src/conversion/toMarketplace/convertInterfacePropertyType.ts
@@ -18,6 +18,8 @@ import type { OntologyIrMarketplaceInterfacePropertyType } from "@osdk/client.un
 
 import {
   type InterfacePropertyType,
+  interfacePropertyWireApiName,
+  isInterfacePropertyRequired,
   isInterfaceSharedPropertyType,
 } from "../../api/interface/InterfacePropertyType.js";
 import {
@@ -34,11 +36,11 @@ export function convertInterfaceProperty(
 ): [string, OntologyIrMarketplaceInterfacePropertyType] {
   if (isInterfaceSharedPropertyType(prop)) {
     return [
-      prop.sharedPropertyType.apiName,
+      interfacePropertyWireApiName(prop, apiName),
       {
         type: "sharedPropertyBasedPropertyType",
         sharedPropertyBasedPropertyType: {
-          requireImplementation: prop.required,
+          requireImplementation: isInterfacePropertyRequired(prop),
           sharedPropertyType: convertSpt(prop.sharedPropertyType),
         },
       },
@@ -66,7 +68,7 @@ export function convertInterfaceProperty(
             : propertyTypeTypeToOntologyIrInterfaceType(prop.type),
           constraints: {
             primaryKeyConstraint: prop.primaryKeyConstraint ?? "NO_RESTRICTION",
-            requireImplementation: prop.required ?? true,
+            requireImplementation: isInterfacePropertyRequired(prop),
             indexedForSearch: shouldBeIndexedForSearch(prop.type),
             typeClasses: prop.typeClasses ?? [],
             dataConstraints: convertNullabilityToDataConstraint({

--- a/packages/maker/src/index.ts
+++ b/packages/maker/src/index.ts
@@ -100,7 +100,10 @@ export type {
   InterfaceDefinedProperty,
   InterfacePropertyType,
 } from "./api/interface/InterfacePropertyType.js";
-export { isInterfaceSharedPropertyType } from "./api/interface/InterfacePropertyType.js";
+export {
+  isInterfacePropertyRequired,
+  isInterfaceSharedPropertyType,
+} from "./api/interface/InterfacePropertyType.js";
 export type { InterfaceType } from "./api/interface/InterfaceType.js";
 export type {
   LinkType,


### PR DESCRIPTION
## Targeting https://github.com/palantir/osdk-ts/pull/3967

The ITSM validations and block-data conversions will need to determine if an IT property is required and to convert an IT property to the wire/block-data RID.

We already have code to do these in the IT block-data conversions which handle the IDP vs SPT complexity -- I want to reuse these so I don't have to duplicate that logic. 