### PR TITLE
[3/5] ITSM OAC DSL: Add ITSM authoring DSL

### DIFF
--- a/.changeset/itsm-3-schema-migrations-dsl-validation.md
+++ b/.changeset/itsm-3-schema-migrations-dsl-validation.md
@@ -1,0 +1,6 @@
+---
+"@osdk/maker": minor
+"@osdk/maker-experimental": patch
+---
+
+Adds the interface type schema migration authoring DSL, enabling defineInterface to specify a schemaMigrations block declaring in-flight schema migrations.

--- a/packages/maker-experimental/src/conversion/toMarketplace/convertInterface.ts
+++ b/packages/maker-experimental/src/conversion/toMarketplace/convertInterface.ts
@@ -32,6 +32,9 @@ export function convertInterface(
     __type,
     status,
     linkedInterfaces: _linkedInterfaces,
+    // schema migrations travel in their own block data section rather than on the interface type
+    // directly, so we explicitly exclude it from "other"
+    schemaMigrations: _schemaMigrations,
     ...other
   } = interfaceType;
   // Normalize deprecated deadline format to match Java (strip .000 milliseconds)

--- a/packages/maker/src/api/defineInterface.ts
+++ b/packages/maker/src/api/defineInterface.ts
@@ -38,8 +38,10 @@ import {
   type InterfacePropertyType,
   isInterfaceSharedPropertyType,
 } from "./interface/InterfacePropertyType.js";
+import type { InterfaceSchemaMigrations } from "./interface/InterfaceSchemaMigrations.js";
 import { type InterfaceType } from "./interface/InterfaceType.js";
 import { mapSimplifiedStatusToInterfaceTypeStatus } from "./interface/mapSimplifiedStatusToInterfaceTypeStatus.js";
+import { validateInterfaceSchemaMigrations } from "./interface/validateInterfaceSchemaMigrations.js";
 import { combineApiNamespaceIfMissing } from "./namespace/combineApiNamespaceIfMissing.js";
 import { isExotic, isPropertyTypeType } from "./properties/PropertyTypeType.js";
 import { type SharedPropertyType } from "./properties/SharedPropertyType.js";
@@ -70,6 +72,7 @@ export type InterfaceTypeDefinition = {
   extends?: InterfaceType | InterfaceType[];
   searchable?: boolean;
   permission?: EntityPermission;
+  schemaMigrations?: InterfaceSchemaMigrations;
 };
 
 export function defineInterface(
@@ -210,6 +213,10 @@ export function defineInterface(
     propertiesV3,
     permission: interfaceDef.permission,
     searchable: interfaceDef.searchable ?? true,
+    schemaMigrations:
+      interfaceDef.schemaMigrations !== undefined
+        ? structuredClone(interfaceDef.schemaMigrations)
+        : undefined,
     __type: OntologyEntityTypeEnum.INTERFACE_TYPE,
   };
 
@@ -226,6 +233,15 @@ export function defineInterface(
     );
     validateStructFieldMetadata(property.type, propertyContext);
   }
+
+  if (interfaceDef.schemaMigrations !== undefined) {
+    validateInterfaceSchemaMigrations(
+      apiName,
+      interfaceDef.schemaMigrations,
+      propertiesV3,
+    );
+  }
+
   updateOntology(fullInterface);
   return fullInterface;
 }

--- a/packages/maker/src/api/interface/InterfaceSchemaMigrations.ts
+++ b/packages/maker/src/api/interface/InterfaceSchemaMigrations.ts
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Interface Schema Migrations declare impending, but not yet enforced, schema changes
+ * for an interface. These give implementing object types a grace period to comply with the
+ * schema change before it becomes enforced, enabling rollout of otherwise breaking schema changes.
+ *
+ * Presence of this field on an interface type definition opts the interface type into
+ * stricter backwards-compatibility checks (e.g. you may not add a new required-to-be-implemented
+ * property except via an interface schema migration).
+ */
+export interface InterfaceSchemaMigrations {
+  /**
+   * The set of in-flight transitions.
+   *
+   * An empty array means "opted into interface schema migrations, but no in-flight migrations".
+   */
+  transitions: InterfaceSchemaTransition[];
+}
+
+/**
+ * A logical bundle of multiple schema migrations (e.g. adding multiple related properties at once),
+ * along with metadata about the changes.
+ */
+export interface InterfaceSchemaTransition {
+  /**
+   * A stable identifier for this transition; must be unique across all transitions specified
+   * by this interface type.
+   *
+   * Must be between 1 and 150 characters, and match `^[a-zA-Z0-9][a-zA-Z0-9_-]*$`:
+   * a letter or digit followed by letters, digits, underscores, or dashes.
+   */
+  id: string;
+  title: string;
+  description?: string;
+  gracePeriod: InterfaceSchemaGracePeriod;
+  /**
+   * The individual migrations that are part of this transition.
+   */
+  instructions: InterfaceSchemaMigrationInstruction[];
+}
+
+/**
+ * How long implementing object types have to adopt the schema migrations.
+ */
+export type InterfaceSchemaGracePeriod =
+  /**
+   * The grace period begins once the schema migration is installed.
+   *
+   * This is preferred for distributed/Marketplace artifacts as it enables
+   * lagging stacks to upgrade at their own cadence.
+   */
+  | { type: "afterInstall"; days: number }
+  /**
+   * An absolute ISO-8601 UTC datetime by which the schema migration must be completed,
+   * e.g. "2026-01-31T00:00:00Z".
+   *
+   * WARNING: this fixed deadline is baked into the published artifact: installing the
+   * artifact after the deadline has passed will fail the installation.
+   * Prefer `afterInstall` grace periods for Marketplace-published ontologies, as that
+   * is relative rather than fixed.
+   */
+  | { type: "deadline"; deadline: string };
+
+/**
+ * A single interface type schema change.
+ */
+export type InterfaceSchemaMigrationInstruction =
+  /**
+   * A new or existing property will become required-to-implement once the grace period elapses.
+   *
+   * The referenced property must be declared `required: false` on the interface type until
+   * the schema migration is finalized.
+   */
+  { type: "addRequiredProperty"; property: string };

--- a/packages/maker/src/api/interface/InterfaceType.ts
+++ b/packages/maker/src/api/interface/InterfaceType.ts
@@ -26,6 +26,7 @@ import type {
   InterfacePropertyType,
   InterfaceSharedPropertyType,
 } from "./InterfacePropertyType.js";
+import type { InterfaceSchemaMigrations } from "./InterfaceSchemaMigrations.js";
 
 export interface InterfaceType
   extends
@@ -34,6 +35,8 @@ export interface InterfaceType
       OntologyIrMarketplaceInterfaceType,
       // we want our simplified representation
       | "properties"
+      // derived by conversion from the presence of `schemaMigrations`
+      | "schemaMigrationsEnabled"
       // these things don't need to exist as the system works fine without them (I'm told)
       | "propertiesV2"
       | "propertiesV3"
@@ -46,5 +49,6 @@ export interface InterfaceType
   linkedInterfaces?: Array<InterfaceType | string>; // full metadata of linked entities used for X-OAC imports
   permission?: EntityPermission;
   status: InterfaceTypeStatus;
+  schemaMigrations?: InterfaceSchemaMigrations;
   __type: OntologyEntityTypeEnum.INTERFACE_TYPE;
 }

--- a/packages/maker/src/api/interface/validateInterfaceSchemaMigrations.ts
+++ b/packages/maker/src/api/interface/validateInterfaceSchemaMigrations.ts
@@ -1,0 +1,182 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import invariant from "tiny-invariant";
+
+import {
+  type InterfacePropertyType,
+  isInterfacePropertyRequired,
+} from "./InterfacePropertyType.js";
+import type {
+  InterfaceSchemaGracePeriod,
+  InterfaceSchemaMigrationInstruction,
+  InterfaceSchemaMigrations,
+} from "./InterfaceSchemaMigrations.js";
+
+// Constants enforced by OMS at installation-time.
+const MAX_TRANSITIONS = 20;
+const MAX_INSTRUCTIONS = 500;
+const MAX_ID_LENGTH = 150;
+const ID_PATTERN = /^[a-zA-Z0-9][a-zA-Z0-9_-]*$/u;
+const MAX_TITLE_LENGTH = 500;
+const MAX_DESCRIPTION_LENGTH = 2000;
+const MIN_GRACE_PERIOD_DAYS = 7;
+const MAX_GRACE_PERIOD_DAYS = 180;
+
+/**
+ * Structural validation for authored Interface Type Schema Migrations.
+ */
+export function validateInterfaceSchemaMigrations(
+  apiName: string,
+  schemaMigrations: InterfaceSchemaMigrations,
+  // The interface type's locally-defined properties; inherited properties are not included
+  // (since migrations for those should occur in the interface that defines them)
+  propertiesV3: Record<string, InterfacePropertyType>,
+): void {
+  const { transitions } = schemaMigrations;
+
+  invariant(
+    transitions.length <= MAX_TRANSITIONS,
+    `Interface ${apiName} has ${transitions.length} schema migration transitions, which exceeds the maximum of ${MAX_TRANSITIONS}.`,
+  );
+
+  const seenIds = new Set<string>();
+  // Maps (instruction type + target property) to the transition that first declared it,
+  // across ALL transitions.
+  const seenInstructions = new Map<string, string>();
+
+  for (const transition of transitions) {
+    const { id, title, description, gracePeriod, instructions } = transition;
+
+    invariant(
+      id.length > 0 && id.length <= MAX_ID_LENGTH,
+      `Schema migration transition id "${id}" on interface ${apiName} must be between 1 and ${MAX_ID_LENGTH} characters, but was ${id.length}.`,
+    );
+    invariant(
+      ID_PATTERN.test(id),
+      `Schema migration transition id "${id}" on interface ${apiName} must match ${ID_PATTERN.source}: a letter or digit followed by letters, digits, underscores, or dashes.`,
+    );
+    invariant(
+      !seenIds.has(id),
+      `Duplicate schema migration transition id "${id}" on interface ${apiName}.`,
+    );
+    seenIds.add(id);
+
+    invariant(
+      title.length > 0 && title.length <= MAX_TITLE_LENGTH,
+      `Schema migration transition "${id}" on interface ${apiName} must have a title between 1 and ${MAX_TITLE_LENGTH} characters, but was ${title.length}.`,
+    );
+    if (description !== undefined) {
+      invariant(
+        description.length <= MAX_DESCRIPTION_LENGTH,
+        `Schema migration transition "${id}" on interface ${apiName} has a description of length ${description.length}, which exceeds the maximum of ${MAX_DESCRIPTION_LENGTH}.`,
+      );
+    }
+
+    invariant(
+      instructions.length > 0,
+      `Schema migration transition "${id}" on interface ${apiName} must have at least one instruction.`,
+    );
+    invariant(
+      instructions.length <= MAX_INSTRUCTIONS,
+      `Schema migration transition "${id}" on interface ${apiName} has ${instructions.length} instructions, which exceeds the maximum of ${MAX_INSTRUCTIONS}.`,
+    );
+
+    validateGracePeriod(apiName, id, gracePeriod);
+
+    for (const instruction of instructions) {
+      const instructionKey = `${instruction.type}:${instruction.property}`;
+      const alreadyDeclaredBy = seenInstructions.get(instructionKey);
+      invariant(
+        alreadyDeclaredBy === undefined,
+        `Schema migration transition "${id}" on interface ${apiName} repeats the instruction ${instruction.type} for property "${instruction.property}", which transition "${alreadyDeclaredBy}" already declares.`,
+      );
+      seenInstructions.set(instructionKey, id);
+
+      validateInstruction(apiName, id, instruction, propertiesV3);
+    }
+  }
+}
+
+function validateGracePeriod(
+  apiName: string,
+  transitionId: string,
+  gracePeriod: InterfaceSchemaGracePeriod,
+): void {
+  switch (gracePeriod.type) {
+    case "afterInstall": {
+      const { days } = gracePeriod;
+      invariant(
+        Number.isInteger(days) &&
+          days >= MIN_GRACE_PERIOD_DAYS &&
+          days <= MAX_GRACE_PERIOD_DAYS,
+        `Schema migration transition "${transitionId}" on interface ${apiName} has an 'afterInstall' grace period of ${days} days, but days must be an integer in [${MIN_GRACE_PERIOD_DAYS}, ${MAX_GRACE_PERIOD_DAYS}] (inclusive).`,
+      );
+      return;
+    }
+    case "deadline": {
+      const { deadline } = gracePeriod;
+      const asIsoString = Number.isNaN(Date.parse(deadline))
+        ? undefined
+        : new Date(deadline).toISOString();
+      invariant(
+        asIsoString !== undefined &&
+          // Ensures the declared deadline is actually an ISO string, rather than a bare date-only string
+          // (so we don't have to pick whether a bare date means "done by this day" or "done at the end
+          // of this day")
+          (deadline === asIsoString ||
+            deadline === asIsoString.replace(/\.000Z$/u, "Z")),
+        `Schema migration transition "${transitionId}" on interface ${apiName} has a 'deadline' grace period of "${deadline}", which is not a canonical ISO-8601 UTC datetime (e.g. "2026-01-31T00:00:00Z").`,
+      );
+      return;
+    }
+    default: {
+      const unhandled: never = gracePeriod;
+      throw new Error(
+        `Unknown schema migration grace period type: ${
+          (unhandled as InterfaceSchemaGracePeriod).type
+        }`,
+      );
+    }
+  }
+}
+
+function validateInstruction(
+  apiName: string,
+  transitionId: string,
+  instruction: InterfaceSchemaMigrationInstruction,
+  propertiesV3: Record<string, InterfacePropertyType>,
+): void {
+  const { property: propertyApiName } = instruction;
+  invariant(
+    Object.hasOwn(propertiesV3, propertyApiName),
+    `Schema migration transition "${transitionId}" on interface ${apiName} references property "${propertyApiName}" via ${instruction.type}, but interface ${apiName} does not declare that property. Properties inherited from an extended interface must be migrated by a transition on the interface that declares them.`,
+  );
+
+  switch (instruction.type) {
+    case "addRequiredProperty":
+      invariant(
+        !isInterfacePropertyRequired(propertiesV3[propertyApiName]),
+        `Schema migration transition "${transitionId}" on interface ${apiName} targets property "${propertyApiName}" via ${instruction.type}, but that property is required. Only properties declared required: false may be targeted.`,
+      );
+      return;
+    default:
+      // TODO: add a never exhaustiveness check once there's more than one instruction type
+      throw new Error(
+        `Unknown schema migration instruction type: ${instruction.type}`,
+      );
+  }
+}

--- a/packages/maker/src/api/test/interfaceSchemaMigrations.test.ts
+++ b/packages/maker/src/api/test/interfaceSchemaMigrations.test.ts
@@ -1,0 +1,625 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { beforeEach, describe, expect, it } from "vitest";
+
+import type { InterfaceTypeDefinition } from "../defineInterface.js";
+import { defineInterface } from "../defineInterface.js";
+import { defineOntology, dumpOntologyFullMetadata } from "../defineOntology.js";
+import { defineSharedPropertyType } from "../defineSpt.js";
+import type {
+  InterfaceSchemaMigrationInstruction,
+  InterfaceSchemaTransition,
+} from "../interface/InterfaceSchemaMigrations.js";
+import type { InterfaceType } from "../interface/InterfaceType.js";
+
+type AuthoredProperty = NonNullable<
+  InterfaceTypeDefinition["properties"]
+>[string];
+
+const OPTIONAL_STRING: AuthoredProperty = { required: false, type: "string" };
+
+function addRequiredProperty(
+  property: string,
+): InterfaceSchemaMigrationInstruction {
+  return { type: "addRequiredProperty", property };
+}
+
+/**
+ * `count` distinct instructions, targeting `optional0`..`optional{count-1}`.
+ *
+ * The instruction kind is incidental — callers outside the addRequiredProperty
+ * block only need instructions that survive instruction-level validation.
+ */
+function distinctInstructions(
+  count: number,
+): InterfaceSchemaMigrationInstruction[] {
+  return Array.from({ length: count }, (_, n) =>
+    addRequiredProperty(`optional${n}`),
+  );
+}
+
+function transition(
+  overrides: Partial<InterfaceSchemaTransition> = {},
+): InterfaceSchemaTransition {
+  return {
+    id: "t1",
+    title: "Some transition",
+    gracePeriod: { type: "afterInstall", days: 30 },
+    instructions: distinctInstructions(1),
+    ...overrides,
+  };
+}
+
+function distinctTransitions(count: number): InterfaceSchemaTransition[] {
+  return distinctInstructions(count).map((instruction, i) =>
+    transition({ id: `t${i}`, instructions: [instruction] }),
+  );
+}
+
+function idOfLength(length: number): string {
+  return "t".repeat(length);
+}
+
+/**
+ * Interface `Foo` carrying `transitions`, declaring every property they target
+ * as `required: false`.
+ */
+function defineWithMigrations(
+  transitions: InterfaceSchemaTransition[],
+  properties: Record<string, AuthoredProperty> = Object.fromEntries(
+    transitions
+      .flatMap((t) => t.instructions)
+      .map((instruction) => [instruction.property, OPTIONAL_STRING]),
+  ),
+): InterfaceType {
+  return defineInterface({
+    apiName: "Foo",
+    properties,
+    schemaMigrations: { transitions },
+  });
+}
+
+describe("Interface schema migrations", () => {
+  beforeEach(async () => {
+    await defineOntology("com.palantir.", () => {}, "/tmp/");
+  });
+
+  describe("opting in", () => {
+    it("carries the authored migrations onto the interface", () => {
+      const authored = transition({ description: "some description" });
+
+      expect(defineWithMigrations([authored]).schemaMigrations).toEqual({
+        transitions: [authored],
+      });
+    });
+
+    it("accepts an opted-in but empty transitions array", () => {
+      const result = defineInterface({
+        apiName: "Foo",
+        schemaMigrations: { transitions: [] },
+      });
+      expect(result.schemaMigrations).toEqual({ transitions: [] });
+    });
+
+    it("leaves schemaMigrations undefined when not opted in", () => {
+      const result = defineInterface({ apiName: "Foo" });
+      expect(result.schemaMigrations).toBeUndefined();
+    });
+
+    it("does not register the interface when validation fails", () => {
+      expect(() => defineWithMigrations([transition({ title: "" })])).toThrow();
+
+      expect(dumpOntologyFullMetadata().ontology.interfaceTypes).toEqual({});
+    });
+
+    it("does not alias the authored migrations", () => {
+      const authored = { transitions: [transition()] };
+
+      const result = defineInterface({
+        apiName: "Foo",
+        properties: { optional0: OPTIONAL_STRING },
+        schemaMigrations: authored,
+      });
+      authored.transitions.push(transition({ id: "sneaked-in" }));
+
+      expect(result.schemaMigrations!.transitions).toHaveLength(1);
+    });
+  });
+
+  describe("inherited properties", () => {
+    it("rejects a transition targeting a property from an extended interface", () => {
+      const parent = defineInterface({
+        apiName: "Parent",
+        properties: { inherited: OPTIONAL_STRING },
+      });
+
+      expect(() =>
+        defineInterface({
+          apiName: "Child",
+          extends: parent,
+          schemaMigrations: {
+            transitions: [
+              transition({
+                instructions: [addRequiredProperty("inherited")],
+              }),
+            ],
+          },
+        }),
+      ).toThrowErrorMatchingInlineSnapshot(
+        `[Error: Invariant failed: Schema migration transition "t1" on interface com.palantir.Child references property "inherited" via addRequiredProperty, but interface com.palantir.Child does not declare that property. Properties inherited from an extended interface must be migrated by a transition on the interface that declares them.]`,
+      );
+    });
+
+    it("accepts the same transition declared on the interface that owns the property", () => {
+      expect(() =>
+        defineInterface({
+          apiName: "Parent",
+          properties: { inherited: OPTIONAL_STRING },
+          schemaMigrations: {
+            transitions: [
+              transition({
+                instructions: [addRequiredProperty("inherited")],
+              }),
+            ],
+          },
+        }),
+      ).not.toThrow();
+    });
+  });
+
+  describe("addRequiredProperty", () => {
+    function defineTargeting(property: string, declaration: AuthoredProperty) {
+      return () =>
+        defineWithMigrations(
+          [
+            transition({
+              instructions: [addRequiredProperty(property)],
+            }),
+          ],
+          { [property]: declaration },
+        );
+    }
+
+    it("rejects the same instruction repeated across transitions", () => {
+      const instruction = addRequiredProperty("optional0");
+
+      expect(() =>
+        defineWithMigrations([
+          transition({ id: "t1", instructions: [instruction] }),
+          transition({ id: "t2", instructions: [instruction] }),
+        ]),
+      ).toThrowErrorMatchingInlineSnapshot(
+        `[Error: Invariant failed: Schema migration transition "t2" on interface com.palantir.Foo repeats the instruction addRequiredProperty for property "optional0", which transition "t1" already declares.]`,
+      );
+    });
+
+    it("accepts an interface-defined property declared required:false", () => {
+      expect(
+        defineTargeting("opt", { required: false, type: "string" }),
+      ).not.toThrow();
+    });
+
+    it("rejects a target property that does not exist", () => {
+      expect(() =>
+        defineWithMigrations(
+          [
+            transition({
+              instructions: [addRequiredProperty("missing")],
+            }),
+          ],
+          {},
+        ),
+      ).toThrowErrorMatchingInlineSnapshot(
+        `[Error: Invariant failed: Schema migration transition "t1" on interface com.palantir.Foo references property "missing" via addRequiredProperty, but interface com.palantir.Foo does not declare that property. Properties inherited from an extended interface must be migrated by a transition on the interface that declares them.]`,
+      );
+    });
+
+    it("rejects a target property named after an Object.prototype member", () => {
+      expect(() =>
+        defineWithMigrations(
+          [
+            transition({
+              instructions: [addRequiredProperty("toString")],
+            }),
+          ],
+          {},
+        ),
+      ).toThrowErrorMatchingInlineSnapshot(
+        `[Error: Invariant failed: Schema migration transition "t1" on interface com.palantir.Foo references property "toString" via addRequiredProperty, but interface com.palantir.Foo does not declare that property. Properties inherited from an extended interface must be migrated by a transition on the interface that declares them.]`,
+      );
+    });
+
+    it("rejects a target property that is required (explicit required:true)", () => {
+      expect(
+        defineTargeting("req", { required: true, type: "string" }),
+      ).toThrowErrorMatchingInlineSnapshot(
+        `[Error: Invariant failed: Schema migration transition "t1" on interface com.palantir.Foo targets property "req" via addRequiredProperty, but that property is required. Only properties declared required: false may be targeted.]`,
+      );
+    });
+
+    it("rejects a target property that is required by default (required omitted)", () => {
+      expect(
+        defineTargeting("def", { type: "string" }),
+      ).toThrowErrorMatchingInlineSnapshot(
+        `[Error: Invariant failed: Schema migration transition "t1" on interface com.palantir.Foo targets property "def" via addRequiredProperty, but that property is required. Only properties declared required: false may be targeted.]`,
+      );
+    });
+
+    it("accepts an SPT-backed property declared required:false", () => {
+      const optSpt = defineSharedPropertyType({
+        apiName: "optSpt",
+        type: "string",
+      });
+
+      expect(
+        defineTargeting("optSpt", {
+          sharedPropertyType: optSpt,
+          required: false,
+        }),
+      ).not.toThrow();
+    });
+
+    it("rejects an SPT-backed property declared required:true", () => {
+      const reqSpt = defineSharedPropertyType({
+        apiName: "reqSpt",
+        type: "string",
+      });
+
+      expect(
+        defineTargeting("reqSpt", {
+          sharedPropertyType: reqSpt,
+          required: true,
+        }),
+      ).toThrowErrorMatchingInlineSnapshot(
+        `[Error: Invariant failed: Schema migration transition "t1" on interface com.palantir.Foo targets property "reqSpt" via addRequiredProperty, but that property is required. Only properties declared required: false may be targeted.]`,
+      );
+    });
+
+    it("rejects a bare SPT, which is required by default", () => {
+      const bareSpt = defineSharedPropertyType({
+        apiName: "bareSpt",
+        type: "string",
+      });
+
+      expect(
+        defineTargeting("bareSpt", bareSpt),
+      ).toThrowErrorMatchingInlineSnapshot(
+        `[Error: Invariant failed: Schema migration transition "t1" on interface com.palantir.Foo targets property "bareSpt" via addRequiredProperty, but that property is required. Only properties declared required: false may be targeted.]`,
+      );
+    });
+  });
+
+  describe("transition ids", () => {
+    it("accepts an id at the 150 character limit", () => {
+      expect(() =>
+        defineWithMigrations([transition({ id: idOfLength(150) })]),
+      ).not.toThrow();
+    });
+
+    it("accepts letters, digits, underscores, and dashes", () => {
+      expect(() =>
+        defineWithMigrations([transition({ id: "Add_owner-V2" })]),
+      ).not.toThrow();
+    });
+
+    it("accepts an id starting with a digit", () => {
+      expect(() =>
+        defineWithMigrations([transition({ id: "1-add-owner" })]),
+      ).not.toThrow();
+    });
+
+    it("rejects an empty id", () => {
+      expect(() =>
+        defineWithMigrations([transition({ id: "" })]),
+      ).toThrowErrorMatchingInlineSnapshot(
+        `[Error: Invariant failed: Schema migration transition id "" on interface com.palantir.Foo must be between 1 and 150 characters, but was 0.]`,
+      );
+    });
+
+    it("rejects an id longer than 150 characters", () => {
+      expect(() =>
+        defineWithMigrations([transition({ id: idOfLength(151) })]),
+      ).toThrowErrorMatchingInlineSnapshot(
+        `[Error: Invariant failed: Schema migration transition id "ttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttttt" on interface com.palantir.Foo must be between 1 and 150 characters, but was 151.]`,
+      );
+    });
+
+    it("rejects an id that does not start with a letter or digit", () => {
+      expect(() =>
+        defineWithMigrations([transition({ id: "-add-owner" })]),
+      ).toThrowErrorMatchingInlineSnapshot(
+        `[Error: Invariant failed: Schema migration transition id "-add-owner" on interface com.palantir.Foo must match ^[a-zA-Z0-9][a-zA-Z0-9_-]*$: a letter or digit followed by letters, digits, underscores, or dashes.]`,
+      );
+    });
+
+    it("rejects an id containing whitespace", () => {
+      expect(() =>
+        defineWithMigrations([transition({ id: "add owner" })]),
+      ).toThrowErrorMatchingInlineSnapshot(
+        `[Error: Invariant failed: Schema migration transition id "add owner" on interface com.palantir.Foo must match ^[a-zA-Z0-9][a-zA-Z0-9_-]*$: a letter or digit followed by letters, digits, underscores, or dashes.]`,
+      );
+    });
+
+    it("rejects an id containing a dot", () => {
+      expect(() =>
+        defineWithMigrations([transition({ id: "add.owner" })]),
+      ).toThrowErrorMatchingInlineSnapshot(
+        `[Error: Invariant failed: Schema migration transition id "add.owner" on interface com.palantir.Foo must match ^[a-zA-Z0-9][a-zA-Z0-9_-]*$: a letter or digit followed by letters, digits, underscores, or dashes.]`,
+      );
+    });
+
+    it("rejects duplicate transition ids", () => {
+      const [first, second] = distinctTransitions(2);
+
+      expect(() =>
+        defineWithMigrations([
+          { ...first, id: "dup" },
+          { ...second, id: "dup" },
+        ]),
+      ).toThrowErrorMatchingInlineSnapshot(
+        `[Error: Invariant failed: Duplicate schema migration transition id "dup" on interface com.palantir.Foo.]`,
+      );
+    });
+  });
+
+  describe("title and description", () => {
+    it("accepts a title at the 500 character limit", () => {
+      expect(() =>
+        defineWithMigrations([transition({ title: "x".repeat(500) })]),
+      ).not.toThrow();
+    });
+
+    it("rejects an empty title", () => {
+      expect(() =>
+        defineWithMigrations([transition({ title: "" })]),
+      ).toThrowErrorMatchingInlineSnapshot(
+        `[Error: Invariant failed: Schema migration transition "t1" on interface com.palantir.Foo must have a title between 1 and 500 characters, but was 0.]`,
+      );
+    });
+
+    it("rejects a title longer than 500 characters", () => {
+      expect(() =>
+        defineWithMigrations([transition({ title: "x".repeat(501) })]),
+      ).toThrowErrorMatchingInlineSnapshot(
+        `[Error: Invariant failed: Schema migration transition "t1" on interface com.palantir.Foo must have a title between 1 and 500 characters, but was 501.]`,
+      );
+    });
+
+    it("accepts a description at the 2000 character limit", () => {
+      expect(() =>
+        defineWithMigrations([transition({ description: "x".repeat(2000) })]),
+      ).not.toThrow();
+    });
+
+    it("rejects a description longer than 2000 characters", () => {
+      expect(() =>
+        defineWithMigrations([transition({ description: "x".repeat(2001) })]),
+      ).toThrowErrorMatchingInlineSnapshot(
+        `[Error: Invariant failed: Schema migration transition "t1" on interface com.palantir.Foo has a description of length 2001, which exceeds the maximum of 2000.]`,
+      );
+    });
+  });
+
+  describe("afterInstall grace period bounds", () => {
+    it("accepts the lower edge (7 days)", () => {
+      expect(() =>
+        defineWithMigrations([
+          transition({ gracePeriod: { type: "afterInstall", days: 7 } }),
+        ]),
+      ).not.toThrow();
+    });
+
+    it("accepts the upper edge (180 days)", () => {
+      expect(() =>
+        defineWithMigrations([
+          transition({ gracePeriod: { type: "afterInstall", days: 180 } }),
+        ]),
+      ).not.toThrow();
+    });
+
+    it("rejects below the lower edge (6 days)", () => {
+      expect(() =>
+        defineWithMigrations([
+          transition({ gracePeriod: { type: "afterInstall", days: 6 } }),
+        ]),
+      ).toThrowErrorMatchingInlineSnapshot(
+        `[Error: Invariant failed: Schema migration transition "t1" on interface com.palantir.Foo has an 'afterInstall' grace period of 6 days, but days must be an integer in [7, 180] (inclusive).]`,
+      );
+    });
+
+    it("rejects above the upper edge (181 days)", () => {
+      expect(() =>
+        defineWithMigrations([
+          transition({ gracePeriod: { type: "afterInstall", days: 181 } }),
+        ]),
+      ).toThrowErrorMatchingInlineSnapshot(
+        `[Error: Invariant failed: Schema migration transition "t1" on interface com.palantir.Foo has an 'afterInstall' grace period of 181 days, but days must be an integer in [7, 180] (inclusive).]`,
+      );
+    });
+
+    it("rejects a non-integer number of days", () => {
+      expect(() =>
+        defineWithMigrations([
+          transition({ gracePeriod: { type: "afterInstall", days: 30.5 } }),
+        ]),
+      ).toThrowErrorMatchingInlineSnapshot(
+        `[Error: Invariant failed: Schema migration transition "t1" on interface com.palantir.Foo has an 'afterInstall' grace period of 30.5 days, but days must be an integer in [7, 180] (inclusive).]`,
+      );
+    });
+  });
+
+  describe("deadline grace period", () => {
+    it("accepts a well-formed deadline", () => {
+      expect(() =>
+        defineWithMigrations([
+          transition({
+            gracePeriod: {
+              type: "deadline",
+              deadline: "2026-01-31T00:00:00.000Z",
+            },
+          }),
+        ]),
+      ).not.toThrow();
+    });
+
+    it("accepts a deadline with zero milliseconds absent", () => {
+      expect(() =>
+        defineWithMigrations([
+          transition({
+            gracePeriod: { type: "deadline", deadline: "2026-01-31T00:00:00Z" },
+          }),
+        ]),
+      ).not.toThrow();
+    });
+
+    it("accepts a deadline with non-zero milliseconds", () => {
+      expect(() =>
+        defineWithMigrations([
+          transition({
+            gracePeriod: {
+              type: "deadline",
+              deadline: "2026-01-31T12:34:56.789Z",
+            },
+          }),
+        ]),
+      ).not.toThrow();
+    });
+
+    // Authoring/generation should not depend on when it runs, so an already-elapsed deadline
+    // is accepted here and instead gets rejected at installation-time.
+    it("accepts a deadline in the past", () => {
+      expect(() =>
+        defineWithMigrations([
+          transition({
+            gracePeriod: {
+              type: "deadline",
+              deadline: "2020-06-01T00:00:00.000Z",
+            },
+          }),
+        ]),
+      ).not.toThrow();
+    });
+
+    it("rejects an invalid date", () => {
+      expect(() =>
+        defineWithMigrations([
+          transition({
+            gracePeriod: { type: "deadline", deadline: "not-a-date" },
+          }),
+        ]),
+      ).toThrowErrorMatchingInlineSnapshot(
+        `[Error: Invariant failed: Schema migration transition "t1" on interface com.palantir.Foo has a 'deadline' grace period of "not-a-date", which is not a canonical ISO-8601 UTC datetime (e.g. "2026-01-31T00:00:00Z").]`,
+      );
+    });
+
+    it("rejects a non-UTC offset", () => {
+      expect(() =>
+        defineWithMigrations([
+          transition({
+            gracePeriod: {
+              type: "deadline",
+              deadline: "2026-01-31T00:00:00.000+05:00",
+            },
+          }),
+        ]),
+      ).toThrowErrorMatchingInlineSnapshot(
+        `[Error: Invariant failed: Schema migration transition "t1" on interface com.palantir.Foo has a 'deadline' grace period of "2026-01-31T00:00:00.000+05:00", which is not a canonical ISO-8601 UTC datetime (e.g. "2026-01-31T00:00:00Z").]`,
+      );
+    });
+
+    it("rejects a date without a time", () => {
+      expect(() =>
+        defineWithMigrations([
+          transition({
+            gracePeriod: { type: "deadline", deadline: "2026-01-31" },
+          }),
+        ]),
+      ).toThrowErrorMatchingInlineSnapshot(
+        `[Error: Invariant failed: Schema migration transition "t1" on interface com.palantir.Foo has a 'deadline' grace period of "2026-01-31", which is not a canonical ISO-8601 UTC datetime (e.g. "2026-01-31T00:00:00Z").]`,
+      );
+    });
+
+    it("rejects a time without an offset", () => {
+      expect(() =>
+        defineWithMigrations([
+          transition({
+            gracePeriod: {
+              type: "deadline",
+              deadline: "2026-01-31T00:00:00",
+            },
+          }),
+        ]),
+      ).toThrowErrorMatchingInlineSnapshot(
+        `[Error: Invariant failed: Schema migration transition "t1" on interface com.palantir.Foo has a 'deadline' grace period of "2026-01-31T00:00:00", which is not a canonical ISO-8601 UTC datetime (e.g. "2026-01-31T00:00:00Z").]`,
+      );
+    });
+
+    it("rejects a locale-formatted date", () => {
+      expect(() =>
+        defineWithMigrations([
+          transition({
+            gracePeriod: { type: "deadline", deadline: "Jan 31 2026" },
+          }),
+        ]),
+      ).toThrowErrorMatchingInlineSnapshot(
+        `[Error: Invariant failed: Schema migration transition "t1" on interface com.palantir.Foo has a 'deadline' grace period of "Jan 31 2026", which is not a canonical ISO-8601 UTC datetime (e.g. "2026-01-31T00:00:00Z").]`,
+      );
+    });
+  });
+
+  describe("instruction count bounds", () => {
+    it("rejects empty instructions", () => {
+      expect(() =>
+        defineWithMigrations([transition({ instructions: [] })]),
+      ).toThrowErrorMatchingInlineSnapshot(
+        `[Error: Invariant failed: Schema migration transition "t1" on interface com.palantir.Foo must have at least one instruction.]`,
+      );
+    });
+
+    it("accepts 500 distinct instructions", () => {
+      expect(() =>
+        defineWithMigrations([
+          transition({ instructions: distinctInstructions(500) }),
+        ]),
+      ).not.toThrow();
+    });
+
+    it("rejects 501 instructions", () => {
+      expect(() =>
+        defineWithMigrations([
+          transition({ instructions: distinctInstructions(501) }),
+        ]),
+      ).toThrowErrorMatchingInlineSnapshot(
+        `[Error: Invariant failed: Schema migration transition "t1" on interface com.palantir.Foo has 501 instructions, which exceeds the maximum of 500.]`,
+      );
+    });
+  });
+
+  describe("transition count bounds", () => {
+    it("accepts 20 transitions", () => {
+      expect(() => defineWithMigrations(distinctTransitions(20))).not.toThrow();
+    });
+
+    it("rejects 21 transitions", () => {
+      expect(() =>
+        defineWithMigrations(distinctTransitions(21)),
+      ).toThrowErrorMatchingInlineSnapshot(
+        `[Error: Invariant failed: Interface com.palantir.Foo has 21 schema migration transitions, which exceeds the maximum of 20.]`,
+      );
+    });
+  });
+});

--- a/packages/maker/src/api/test/links.test.ts
+++ b/packages/maker/src/api/test/links.test.ts
@@ -2137,6 +2137,7 @@ describe("Link Types", () => {
                     "permission": undefined,
                     "propertiesV2": {},
                     "propertiesV3": {},
+                    "schemaMigrations": undefined,
                     "searchable": true,
                     "status": {
                       "active": {},
@@ -2259,6 +2260,7 @@ describe("Link Types", () => {
                     "permission": undefined,
                     "propertiesV2": {},
                     "propertiesV3": {},
+                    "schemaMigrations": undefined,
                     "searchable": true,
                     "status": {
                       "active": {},

--- a/packages/maker/src/conversion/toMarketplace/convertInterface.ts
+++ b/packages/maker/src/conversion/toMarketplace/convertInterface.ts
@@ -23,10 +23,10 @@ import { convertSpt } from "./convertSpt.js";
 export function convertInterface(
   interfaceType: InterfaceType,
 ): OntologyIrMarketplaceInterfaceType {
-  // schema migrations travel in their own block data section rather than on the interface type
-  // directly, so we explicitly exclude it from "other"
   const {
     __type,
+    // schema migrations travel in their own block data section rather than on the interface type
+    // directly, so we explicitly exclude it from "other"
     schemaMigrations: _schemaMigrations,
     ...other
   } = interfaceType;

--- a/packages/maker/src/conversion/toMarketplace/convertInterface.ts
+++ b/packages/maker/src/conversion/toMarketplace/convertInterface.ts
@@ -23,7 +23,13 @@ import { convertSpt } from "./convertSpt.js";
 export function convertInterface(
   interfaceType: InterfaceType,
 ): OntologyIrMarketplaceInterfaceType {
-  const { __type, ...other } = interfaceType;
+  // schema migrations travel in their own block data section rather than on the interface type
+  // directly, so we explicitly exclude it from "other"
+  const {
+    __type,
+    schemaMigrations: _schemaMigrations,
+    ...other
+  } = interfaceType;
   return {
     ...other,
     propertiesV2: Object.fromEntries(

--- a/packages/maker/src/index.ts
+++ b/packages/maker/src/index.ts
@@ -104,6 +104,12 @@ export {
   isInterfacePropertyRequired,
   isInterfaceSharedPropertyType,
 } from "./api/interface/InterfacePropertyType.js";
+export type {
+  InterfaceSchemaGracePeriod,
+  InterfaceSchemaMigrationInstruction,
+  InterfaceSchemaMigrations,
+  InterfaceSchemaTransition,
+} from "./api/interface/InterfaceSchemaMigrations.js";
 export type { InterfaceType } from "./api/interface/InterfaceType.js";
 export type {
   LinkType,


### PR DESCRIPTION
## Targeting https://github.com/palantir/osdk-ts/pull/3968

Adds the interface type schema migration (ITSM) DSL and static validation, but does not yet emit the ITSMs in block-data.