### PR TITLE
[4/5] ITSM OAC DSL: Include ITSMs in ontology block data

### DIFF
--- a/.changeset/itsm-4-emit-schema-transitions-block-data.md
+++ b/.changeset/itsm-4-emit-schema-transitions-block-data.md
@@ -1,0 +1,6 @@
+---
+"@osdk/maker": minor
+"@osdk/maker-experimental": minor
+---
+
+Interface schema migrations are now included in the ontology block data.

--- a/packages/maker-experimental/src/conversion/toMarketplace/convertInterface.ts
+++ b/packages/maker-experimental/src/conversion/toMarketplace/convertInterface.ts
@@ -32,9 +32,7 @@ export function convertInterface(
     __type,
     status,
     linkedInterfaces: _linkedInterfaces,
-    // schema migrations travel in their own block data section rather than on the interface type
-    // directly, so we explicitly exclude it from "other"
-    schemaMigrations: _schemaMigrations,
+    schemaMigrations,
     ...other
   } = interfaceType;
   // Normalize deprecated deadline format to match Java (strip .000 milliseconds)
@@ -50,6 +48,12 @@ export function convertInterface(
       : status;
   return {
     ...other,
+    // schema migrations travel in their own block data section rather than on the interface type
+    // directly; we only use the declared object to determine if the IT is opted in,
+    // but exclude the migrations themselves from the IT definition
+    ...(schemaMigrations !== undefined
+      ? { schemaMigrationsEnabled: true }
+      : {}),
     status: normalizedStatus,
     // TODO: Generate proper RID based on apiName
     rid: ridGenerator.generateRidForInterface(interfaceType.apiName),

--- a/packages/maker-experimental/src/conversion/toMarketplace/convertInterfaceSchemaMigrations.test.ts
+++ b/packages/maker-experimental/src/conversion/toMarketplace/convertInterfaceSchemaMigrations.test.ts
@@ -1,0 +1,212 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type { InterfaceTypeBlockDataV2 } from "@osdk/client.unstable";
+import type { InterfaceSchemaTransition } from "@osdk/maker";
+import {
+  defineInterface,
+  defineOntology,
+  defineSharedPropertyType,
+} from "@osdk/maker";
+import invariant from "tiny-invariant";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { defineOntologyV2 } from "../../api/defineOntologyV2.js";
+
+const DEADLINE = "2026-01-31T12:34:56Z";
+
+async function convertInterfaces(
+  body: () => void,
+): Promise<InterfaceTypeBlockDataV2> {
+  const result = await defineOntologyV2("com.palantir.", body);
+  const blocks = Object.values(result.ontologyIr.ontology.interfaceTypes);
+  invariant(
+    blocks.length === 1,
+    `expected one interface, got ${blocks.length}`,
+  );
+  return blocks[0];
+}
+
+function transition(
+  overrides: Partial<InterfaceSchemaTransition> = {},
+): InterfaceSchemaTransition {
+  return {
+    id: "t1",
+    title: "Some transition",
+    gracePeriod: { type: "afterInstall", days: 30 },
+    instructions: [{ type: "addRequiredProperty", property: "optional" }],
+    ...overrides,
+  };
+}
+
+describe("interface type schema migrations", () => {
+  beforeEach(async () => {
+    await defineOntology("com.palantir.", () => {}, "/tmp/");
+  });
+
+  it("emits an empty migration list when not opted in", async () => {
+    const block = await convertInterfaces(() => {
+      defineInterface({ apiName: "Foo" });
+    });
+
+    expect(block.schemaMigrations).toEqual([]);
+    expect(block.interfaceType).not.toHaveProperty("schemaMigrationsEnabled");
+  });
+
+  it("sets schemaMigrationsEnabled when opted in with no transitions", async () => {
+    const block = await convertInterfaces(() => {
+      defineInterface({
+        apiName: "Foo",
+        schemaMigrations: { transitions: [] },
+      });
+    });
+
+    expect(block.interfaceType.schemaMigrationsEnabled).toBe(true);
+    expect(block.schemaMigrations).toEqual([]);
+  });
+
+  it("translates an afterInstall transition to daysAfterActivation", async () => {
+    const block = await convertInterfaces(() => {
+      defineInterface({
+        apiName: "Foo",
+        properties: { optional: { required: false, type: "string" } },
+        schemaMigrations: {
+          transitions: [
+            transition({
+              id: "add-owner",
+              title: "Require owner",
+              description: "some description",
+              gracePeriod: { type: "afterInstall", days: 30 },
+            }),
+          ],
+        },
+      });
+    });
+
+    expect(block.interfaceType.schemaMigrationsEnabled).toBe(true);
+    expect(block.schemaMigrations).toEqual([
+      {
+        id: "add-owner",
+        title: "Require owner",
+        description: "some description",
+        gracePeriod: { type: "daysAfterActivation", daysAfterActivation: 30 },
+        migrations: [
+          {
+            type: "addRequiredProperty",
+            addRequiredProperty: { propertyTypeRid: expect.any(String) },
+          },
+        ],
+      },
+    ]);
+  });
+
+  it("translates a deadline transition", async () => {
+    const block = await convertInterfaces(() => {
+      defineInterface({
+        apiName: "Foo",
+        properties: { optional: { required: false, type: "string" } },
+        schemaMigrations: {
+          transitions: [
+            transition({
+              gracePeriod: { type: "deadline", deadline: DEADLINE },
+            }),
+          ],
+        },
+      });
+    });
+
+    expect(block.schemaMigrations[0].gracePeriod).toEqual({
+      type: "deadline",
+      deadline: DEADLINE,
+    });
+  });
+
+  it("strips zero milliseconds from a deadline", async () => {
+    const block = await convertInterfaces(() => {
+      defineInterface({
+        apiName: "Foo",
+        properties: { optional: { required: false, type: "string" } },
+        schemaMigrations: {
+          transitions: [
+            transition({
+              gracePeriod: {
+                type: "deadline",
+                deadline: "2026-01-31T12:34:56.000Z",
+              },
+            }),
+          ],
+        },
+      });
+    });
+
+    expect(block.schemaMigrations[0].gracePeriod).toEqual({
+      type: "deadline",
+      deadline: "2026-01-31T12:34:56Z",
+    });
+  });
+
+  it("targets an interface-defined property by its published rid", async () => {
+    const block = await convertInterfaces(() => {
+      defineInterface({
+        apiName: "Foo",
+        properties: { optional: { required: false, type: "string" } },
+        schemaMigrations: { transitions: [transition()] },
+      });
+    });
+
+    const [migration] = block.schemaMigrations[0].migrations;
+    invariant(migration.type === "addRequiredProperty");
+    const { propertyTypeRid } = migration.addRequiredProperty;
+
+    expect(block.interfaceType.propertiesV3[propertyTypeRid]).toMatchObject({
+      type: "interfaceDefinedPropertyType",
+      interfaceDefinedPropertyType: { apiName: "optional" },
+    });
+  });
+
+  it("targets an SPT-backed property by its published rid", async () => {
+    const block = await convertInterfaces(() => {
+      const spt = defineSharedPropertyType({
+        apiName: "ownerSpt",
+        type: "string",
+      });
+      defineInterface({
+        apiName: "Foo",
+        properties: { ownerSpt: { sharedPropertyType: spt, required: false } },
+        schemaMigrations: {
+          transitions: [
+            transition({
+              instructions: [
+                { type: "addRequiredProperty", property: "ownerSpt" },
+              ],
+            }),
+          ],
+        },
+      });
+    });
+
+    const [migration] = block.schemaMigrations[0].migrations;
+    invariant(migration.type === "addRequiredProperty");
+    const { propertyTypeRid } = migration.addRequiredProperty;
+
+    expect(block.interfaceType.propertiesV3[propertyTypeRid]).toMatchObject({
+      type: "sharedPropertyBasedPropertyType",
+      sharedPropertyBasedPropertyType: {
+        sharedPropertyType: { apiName: "com.palantir.ownerSpt" },
+      },
+    });
+  });
+});

--- a/packages/maker-experimental/src/conversion/toMarketplace/convertInterfaceSchemaMigrations.test.ts
+++ b/packages/maker-experimental/src/conversion/toMarketplace/convertInterfaceSchemaMigrations.test.ts
@@ -14,7 +14,10 @@
  * limitations under the License.
  */
 
-import type { InterfaceTypeBlockDataV2 } from "@osdk/client.unstable";
+import type {
+  InterfaceTypeBlockDataV2,
+  InterfaceTypeSchemaTransition,
+} from "@osdk/client.unstable";
 import type { InterfaceSchemaTransition } from "@osdk/maker";
 import {
   defineInterface,
@@ -28,16 +31,28 @@ import { defineOntologyV2 } from "../../api/defineOntologyV2.js";
 
 const DEADLINE = "2026-01-31T12:34:56Z";
 
+async function convertOntology(body: () => void) {
+  const result = await defineOntologyV2("com.palantir.", body);
+  return result.ontologyIr.ontology;
+}
+
 async function convertInterfaces(
   body: () => void,
 ): Promise<InterfaceTypeBlockDataV2> {
-  const result = await defineOntologyV2("com.palantir.", body);
-  const blocks = Object.values(result.ontologyIr.ontology.interfaceTypes);
+  const blocks = Object.values((await convertOntology(body)).interfaceTypes);
   invariant(
     blocks.length === 1,
     `expected one interface, got ${blocks.length}`,
   );
   return blocks[0];
+}
+
+function transitionsOf(
+  block: InterfaceTypeBlockDataV2,
+): Record<string, InterfaceTypeSchemaTransition> {
+  const { schemaMigrations } = block;
+  invariant(schemaMigrations != null, "expected schema migrations");
+  return schemaMigrations.schemaTransitions;
 }
 
 function transition(
@@ -57,12 +72,12 @@ describe("interface type schema migrations", () => {
     await defineOntology("com.palantir.", () => {}, "/tmp/");
   });
 
-  it("emits an empty migration list when not opted in", async () => {
+  it("omits the migration block when not opted in", async () => {
     const block = await convertInterfaces(() => {
       defineInterface({ apiName: "Foo" });
     });
 
-    expect(block.schemaMigrations).toEqual([]);
+    expect(block.schemaMigrations).toBeUndefined();
     expect(block.interfaceType).not.toHaveProperty("schemaMigrationsEnabled");
   });
 
@@ -75,7 +90,56 @@ describe("interface type schema migrations", () => {
     });
 
     expect(block.interfaceType.schemaMigrationsEnabled).toBe(true);
-    expect(block.schemaMigrations).toEqual([]);
+    expect(block.schemaMigrations).toEqual({
+      interfacePropertyTypeRidsToApiNames: {},
+      schemaTransitions: {},
+    });
+  });
+
+  it("records each transition in the block's known identifiers", async () => {
+    const ontology = await convertOntology(() => {
+      defineInterface({
+        apiName: "Foo",
+        properties: {
+          optional: { required: false, type: "string" },
+          other: { required: false, type: "string" },
+        },
+        schemaMigrations: {
+          transitions: [
+            transition({ id: "t1" }),
+            transition({
+              id: "t2",
+              instructions: [
+                { type: "addRequiredProperty", property: "other" },
+              ],
+            }),
+          ],
+        },
+      });
+    });
+
+    const [interfaceRid] = Object.keys(ontology.interfaceTypes);
+    const { interfaceTypeSchemaTransitions } = ontology.knownIdentifiers;
+
+    expect(Object.keys(interfaceTypeSchemaTransitions)).toEqual([interfaceRid]);
+    expect(interfaceTypeSchemaTransitions[interfaceRid]).toEqual({
+      t1: expect.any(String),
+      t2: expect.any(String),
+    });
+    // Each transition gets its own block internal id
+    expect(
+      new Set(Object.values(interfaceTypeSchemaTransitions[interfaceRid])),
+    ).toHaveLength(2);
+  });
+
+  it("records no known identifiers for an interface without migrations", async () => {
+    const ontology = await convertOntology(() => {
+      defineInterface({ apiName: "Foo" });
+    });
+
+    expect(ontology.knownIdentifiers.interfaceTypeSchemaTransitions).toEqual(
+      {},
+    );
   });
 
   it("translates an afterInstall transition to daysAfterActivation", async () => {
@@ -97,8 +161,8 @@ describe("interface type schema migrations", () => {
     });
 
     expect(block.interfaceType.schemaMigrationsEnabled).toBe(true);
-    expect(block.schemaMigrations).toEqual([
-      {
+    expect(transitionsOf(block)).toEqual({
+      "add-owner": {
         id: "add-owner",
         title: "Require owner",
         description: "some description",
@@ -110,7 +174,7 @@ describe("interface type schema migrations", () => {
           },
         ],
       },
-    ]);
+    });
   });
 
   it("translates a deadline transition", async () => {
@@ -128,7 +192,7 @@ describe("interface type schema migrations", () => {
       });
     });
 
-    expect(block.schemaMigrations[0].gracePeriod).toEqual({
+    expect(transitionsOf(block).t1.gracePeriod).toEqual({
       type: "deadline",
       deadline: DEADLINE,
     });
@@ -152,7 +216,7 @@ describe("interface type schema migrations", () => {
       });
     });
 
-    expect(block.schemaMigrations[0].gracePeriod).toEqual({
+    expect(transitionsOf(block).t1.gracePeriod).toEqual({
       type: "deadline",
       deadline: "2026-01-31T12:34:56Z",
     });
@@ -167,7 +231,7 @@ describe("interface type schema migrations", () => {
       });
     });
 
-    const [migration] = block.schemaMigrations[0].migrations;
+    const [migration] = transitionsOf(block).t1.migrations;
     invariant(migration.type === "addRequiredProperty");
     const { propertyTypeRid } = migration.addRequiredProperty;
 
@@ -175,6 +239,9 @@ describe("interface type schema migrations", () => {
       type: "interfaceDefinedPropertyType",
       interfaceDefinedPropertyType: { apiName: "optional" },
     });
+    expect(block.schemaMigrations?.interfacePropertyTypeRidsToApiNames).toEqual(
+      { [propertyTypeRid]: "optional" },
+    );
   });
 
   it("targets an SPT-backed property by its published rid", async () => {
@@ -198,7 +265,7 @@ describe("interface type schema migrations", () => {
       });
     });
 
-    const [migration] = block.schemaMigrations[0].migrations;
+    const [migration] = transitionsOf(block).t1.migrations;
     invariant(migration.type === "addRequiredProperty");
     const { propertyTypeRid } = migration.addRequiredProperty;
 
@@ -208,5 +275,8 @@ describe("interface type schema migrations", () => {
         sharedPropertyType: { apiName: "com.palantir.ownerSpt" },
       },
     });
+    expect(block.schemaMigrations?.interfacePropertyTypeRidsToApiNames).toEqual(
+      { [propertyTypeRid]: "com.palantir.ownerSpt" },
+    );
   });
 });

--- a/packages/maker-experimental/src/conversion/toMarketplace/convertInterfaceSchemaMigrations.ts
+++ b/packages/maker-experimental/src/conversion/toMarketplace/convertInterfaceSchemaMigrations.ts
@@ -40,9 +40,6 @@ export function convertInterfaceSchemaMigrations(
     return undefined;
   }
 
-  // Migrations target properties by rid; this lets the installer resolve those rids back to
-  // the API names the interface publishes them under, which for an SPT-backed property is
-  // the shared property type's namespaced API name rather than the interface-local one.
   const interfacePropertyTypeRidsToApiNames: Record<string, string> = {};
   const schemaTransitions = Object.fromEntries(
     schemaMigrations.transitions.map(

--- a/packages/maker-experimental/src/conversion/toMarketplace/convertInterfaceSchemaMigrations.ts
+++ b/packages/maker-experimental/src/conversion/toMarketplace/convertInterfaceSchemaMigrations.ts
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type {
+  InterfaceTypeSchemaMigrationInstruction,
+  InterfaceTypeSchemaTransition,
+} from "@osdk/client.unstable";
+import type {
+  InterfacePropertyType,
+  InterfaceSchemaMigrationInstruction,
+  InterfaceType,
+} from "@osdk/maker";
+import { convertInterfaceSchemaGracePeriod } from "@osdk/maker";
+import invariant from "tiny-invariant";
+
+import type { OntologyRidGenerator } from "../../util/generateRid.js";
+import { interfacePropertyWireRid } from "./convertInterfacePropertyType.js";
+
+export function convertInterfaceSchemaMigrations(
+  interfaceType: InterfaceType,
+  ridGenerator: OntologyRidGenerator,
+): InterfaceTypeSchemaTransition[] {
+  const { schemaMigrations, propertiesV3 } = interfaceType;
+  if (schemaMigrations === undefined) {
+    return [];
+  }
+
+  return schemaMigrations.transitions.map((transition) => ({
+    id: transition.id,
+    title: transition.title,
+    description: transition.description,
+    gracePeriod: convertInterfaceSchemaGracePeriod(transition.gracePeriod),
+    migrations: transition.instructions.map((instruction) =>
+      convertInstruction(
+        instruction,
+        interfaceType.apiName,
+        propertiesV3,
+        ridGenerator,
+      ),
+    ),
+  }));
+}
+
+function convertInstruction(
+  instruction: InterfaceSchemaMigrationInstruction,
+  interfaceApiName: string,
+  propertiesV3: Record<string, InterfacePropertyType>,
+  ridGenerator: OntologyRidGenerator,
+): InterfaceTypeSchemaMigrationInstruction {
+  switch (instruction.type) {
+    case "addRequiredProperty": {
+      const { property: propertyApiName } = instruction;
+      invariant(
+        Object.hasOwn(propertiesV3, propertyApiName),
+        `Schema migration instruction ${instruction.type} references property "${propertyApiName}", which the interface does not declare.`,
+      );
+
+      return {
+        type: "addRequiredProperty",
+        addRequiredProperty: {
+          propertyTypeRid: interfacePropertyWireRid(
+            propertiesV3[propertyApiName],
+            propertyApiName,
+            interfaceApiName,
+            ridGenerator,
+          ),
+        },
+      };
+    }
+    default:
+      // TODO: add a never exhaustiveness check once there's more than one instruction type
+      throw new Error(
+        `Unknown schema migration instruction type: ${instruction.type}`,
+      );
+  }
+}

--- a/packages/maker-experimental/src/conversion/toMarketplace/convertInterfaceSchemaMigrations.ts
+++ b/packages/maker-experimental/src/conversion/toMarketplace/convertInterfaceSchemaMigrations.ts
@@ -15,15 +15,18 @@
  */
 
 import type {
+  InterfaceTypeSchemaMigrationBlockData,
   InterfaceTypeSchemaMigrationInstruction,
   InterfaceTypeSchemaTransition,
 } from "@osdk/client.unstable";
 import type {
-  InterfacePropertyType,
   InterfaceSchemaMigrationInstruction,
   InterfaceType,
 } from "@osdk/maker";
-import { convertInterfaceSchemaGracePeriod } from "@osdk/maker";
+import {
+  convertInterfaceSchemaGracePeriod,
+  interfacePropertyWireApiName,
+} from "@osdk/maker";
 
 import type { OntologyRidGenerator } from "../../util/generateRid.js";
 import { interfacePropertyWireRid } from "./convertInterfacePropertyType.js";
@@ -31,49 +34,58 @@ import { interfacePropertyWireRid } from "./convertInterfacePropertyType.js";
 export function convertInterfaceSchemaMigrations(
   interfaceType: InterfaceType,
   ridGenerator: OntologyRidGenerator,
-): InterfaceTypeSchemaTransition[] {
+): InterfaceTypeSchemaMigrationBlockData | undefined {
   const { schemaMigrations, propertiesV3 } = interfaceType;
   if (schemaMigrations === undefined) {
-    return [];
+    return undefined;
   }
 
-  return schemaMigrations.transitions.map((transition) => ({
-    id: transition.id,
-    title: transition.title,
-    description: transition.description,
-    gracePeriod: convertInterfaceSchemaGracePeriod(transition.gracePeriod),
-    migrations: transition.instructions.map((instruction) =>
-      convertInstruction(
-        instruction,
-        interfaceType.apiName,
-        propertiesV3,
-        ridGenerator,
-      ),
+  // Migrations target properties by rid; this lets the installer resolve those rids back to
+  // the API names the interface publishes them under, which for an SPT-backed property is
+  // the shared property type's namespaced API name rather than the interface-local one.
+  const interfacePropertyTypeRidsToApiNames: Record<string, string> = {};
+  const schemaTransitions = Object.fromEntries(
+    schemaMigrations.transitions.map(
+      (transition): [string, InterfaceTypeSchemaTransition] => [
+        transition.id,
+        {
+          id: transition.id,
+          title: transition.title,
+          description: transition.description,
+          gracePeriod: convertInterfaceSchemaGracePeriod(
+            transition.gracePeriod,
+          ),
+          migrations: transition.instructions.map((instruction) => {
+            const { property: propertyApiName } = instruction;
+            const property = propertiesV3[propertyApiName];
+            const propertyTypeRid = interfacePropertyWireRid(
+              property,
+              propertyApiName,
+              interfaceType.apiName,
+              ridGenerator,
+            );
+            interfacePropertyTypeRidsToApiNames[propertyTypeRid] =
+              interfacePropertyWireApiName(property, propertyApiName);
+            return convertInstruction(instruction, propertyTypeRid);
+          }),
+        },
+      ],
     ),
-  }));
+  );
+
+  return { interfacePropertyTypeRidsToApiNames, schemaTransitions };
 }
 
 function convertInstruction(
   instruction: InterfaceSchemaMigrationInstruction,
-  interfaceApiName: string,
-  propertiesV3: Record<string, InterfacePropertyType>,
-  ridGenerator: OntologyRidGenerator,
+  propertyTypeRid: string,
 ): InterfaceTypeSchemaMigrationInstruction {
   switch (instruction.type) {
-    case "addRequiredProperty": {
-      const { property: propertyApiName } = instruction;
+    case "addRequiredProperty":
       return {
         type: "addRequiredProperty",
-        addRequiredProperty: {
-          propertyTypeRid: interfacePropertyWireRid(
-            propertiesV3[propertyApiName],
-            propertyApiName,
-            interfaceApiName,
-            ridGenerator,
-          ),
-        },
+        addRequiredProperty: { propertyTypeRid },
       };
-    }
     default:
       // TODO: add a never exhaustiveness check once there's more than one instruction type
       throw new Error(

--- a/packages/maker-experimental/src/conversion/toMarketplace/convertInterfaceSchemaMigrations.ts
+++ b/packages/maker-experimental/src/conversion/toMarketplace/convertInterfaceSchemaMigrations.ts
@@ -24,7 +24,6 @@ import type {
   InterfaceType,
 } from "@osdk/maker";
 import { convertInterfaceSchemaGracePeriod } from "@osdk/maker";
-import invariant from "tiny-invariant";
 
 import type { OntologyRidGenerator } from "../../util/generateRid.js";
 import { interfacePropertyWireRid } from "./convertInterfacePropertyType.js";
@@ -63,11 +62,6 @@ function convertInstruction(
   switch (instruction.type) {
     case "addRequiredProperty": {
       const { property: propertyApiName } = instruction;
-      invariant(
-        Object.hasOwn(propertiesV3, propertyApiName),
-        `Schema migration instruction ${instruction.type} references property "${propertyApiName}", which the interface does not declare.`,
-      );
-
       return {
         type: "addRequiredProperty",
         addRequiredProperty: {

--- a/packages/maker-experimental/src/conversion/toMarketplace/convertOntologyDefinitionToWireBlockData.ts
+++ b/packages/maker-experimental/src/conversion/toMarketplace/convertOntologyDefinitionToWireBlockData.ts
@@ -45,6 +45,7 @@ import type { OntologyRidGenerator } from "../../util/generateRid.js";
 import { ReadableIdGenerator } from "../../util/generateRid.js";
 import { convertAction } from "./convertActionHelpers.js";
 import { convertInterface } from "./convertInterface.js";
+import { convertInterfaceSchemaMigrations } from "./convertInterfaceSchemaMigrations.js";
 import { convertLink } from "./convertLink.js";
 import { convertObject } from "./convertObject.js";
 import { convertSpt } from "./convertSpt.js";
@@ -142,6 +143,10 @@ export function convertOntologyDefinitionToWireBlockData(
         ridGenerator.generateRidForInterface(apiName),
         {
           interfaceType: convertInterface(interfaceType, ridGenerator),
+          schemaMigrations: convertInterfaceSchemaMigrations(
+            interfaceType,
+            ridGenerator,
+          ),
         },
       ];
     }),

--- a/packages/maker-experimental/src/conversion/toMarketplace/convertOntologyDefinitionToWireBlockData.ts
+++ b/packages/maker-experimental/src/conversion/toMarketplace/convertOntologyDefinitionToWireBlockData.ts
@@ -139,14 +139,15 @@ export function convertOntologyDefinitionToWireBlockData(
     Object.entries(ontology[OntologyEntityTypeEnum.INTERFACE_TYPE]).map<
       [string, InterfaceTypeBlockDataV2]
     >(([apiName, interfaceType]) => {
+      const schemaMigrations = convertInterfaceSchemaMigrations(
+        interfaceType,
+        ridGenerator,
+      );
       return [
         ridGenerator.generateRidForInterface(apiName),
         {
           interfaceType: convertInterface(interfaceType, ridGenerator),
-          schemaMigrations: convertInterfaceSchemaMigrations(
-            interfaceType,
-            ridGenerator,
-          ),
+          ...(schemaMigrations !== undefined ? { schemaMigrations } : {}),
         },
       ];
     }),
@@ -318,6 +319,26 @@ function buildKnownIdentifiers(
       rid,
       ridGenerator.toBlockInternalId(readableId),
     ]),
+  );
+
+  // Interface type schema transitions: InterfaceTypeRid -> TransitionId -> BlockInternalId
+  const interfaceSchemaTransitionMappings = Object.fromEntries(
+    Object.entries(ontology[OntologyEntityTypeEnum.INTERFACE_TYPE])
+      .filter(([_, interfaceType]) => interfaceType.schemaMigrations != null)
+      .map(([apiName, interfaceType]) => [
+        ridGenerator.generateRidForInterface(apiName),
+        Object.fromEntries(
+          interfaceType.schemaMigrations!.transitions.map((transition) => [
+            transition.id,
+            ridGenerator.toBlockInternalId(
+              ReadableIdGenerator.getForInterfaceSchemaTransition(
+                apiName,
+                transition.id,
+              ),
+            ),
+          ]),
+        ),
+      ]),
   );
 
   // Interface link types: InterfaceLinkTypeRid -> BlockInternalId
@@ -632,8 +653,7 @@ function buildKnownIdentifiers(
     interfaceParameterConstraints: interfaceParameterConstraintMappings,
     interfacePropertyTypes: interfacePropertyMappings,
     interfaceTypes: interfaceMappings,
-    // Cannot yet author interface type schema migrations.
-    interfaceTypeSchemaTransitions: {},
+    interfaceTypeSchemaTransitions: interfaceSchemaTransitionMappings,
     linkTypeIds,
     linkTypes: linkTypeRids,
     markings: markingsMappings,

--- a/packages/maker-experimental/src/conversion/toMarketplace/convertOntologyDefinitionToWireBlockData.ts
+++ b/packages/maker-experimental/src/conversion/toMarketplace/convertOntologyDefinitionToWireBlockData.ts
@@ -325,18 +325,20 @@ function buildKnownIdentifiers(
   const interfaceSchemaTransitionMappings = Object.fromEntries(
     Object.entries(ontology[OntologyEntityTypeEnum.INTERFACE_TYPE])
       .filter(([_, interfaceType]) => interfaceType.schemaMigrations != null)
-      .map(([apiName, interfaceType]) => [
+      .map<[string, Record<string, string>]>(([apiName, interfaceType]) => [
         ridGenerator.generateRidForInterface(apiName),
         Object.fromEntries(
-          interfaceType.schemaMigrations!.transitions.map((transition) => [
-            transition.id,
-            ridGenerator.toBlockInternalId(
-              ReadableIdGenerator.getForInterfaceSchemaTransition(
-                apiName,
-                transition.id,
+          interfaceType.schemaMigrations!.transitions.map<[string, string]>(
+            (transition) => [
+              transition.id,
+              ridGenerator.toBlockInternalId(
+                ReadableIdGenerator.getForInterfaceSchemaTransition(
+                  apiName,
+                  transition.id,
+                ),
               ),
-            ),
-          ]),
+            ],
+          ),
         ),
       ]),
   );

--- a/packages/maker-experimental/src/util/generateRid.ts
+++ b/packages/maker-experimental/src/util/generateRid.ts
@@ -378,6 +378,13 @@ export class ReadableIdGenerator {
     return `interface-action-type-constraint-${interfaceApiName}-${constraintApiName}` as ReadableId;
   }
 
+  static getForInterfaceSchemaTransition(
+    interfaceApiName: string,
+    transitionId: string,
+  ): ReadableId {
+    return `interface-schema-transition-${interfaceApiName}-${transitionId}` as ReadableId;
+  }
+
   static getForInterfaceParameterConstraint(
     interfaceApiName: string,
     constraintApiName: string,

--- a/packages/maker/src/api/test/interfaceSchemaMigrations.test.ts
+++ b/packages/maker/src/api/test/interfaceSchemaMigrations.test.ts
@@ -609,6 +609,130 @@ describe("Interface schema migrations", () => {
     });
   });
 
+  describe("conversion to wire block data", () => {
+    function blockData() {
+      return dumpOntologyFullMetadata().ontology.interfaceTypes[
+        "com.palantir.Foo"
+      ];
+    }
+
+    it("emits an empty migration list when not opted in", () => {
+      defineInterface({ apiName: "Foo" });
+
+      expect(blockData().schemaMigrations).toEqual([]);
+      expect(blockData().interfaceType).not.toHaveProperty(
+        "schemaMigrationsEnabled",
+      );
+    });
+
+    it("sets schemaMigrationsEnabled when opted in with no transitions", () => {
+      defineInterface({
+        apiName: "Foo",
+        schemaMigrations: { transitions: [] },
+      });
+
+      expect(blockData().interfaceType.schemaMigrationsEnabled).toBe(true);
+      expect(blockData().schemaMigrations).toEqual([]);
+    });
+
+    it("translates an afterInstall transition to daysAfterActivation", () => {
+      defineWithMigrations([
+        transition({
+          id: "add-owner",
+          title: "Require owner",
+          description: "some description",
+          gracePeriod: { type: "afterInstall", days: 30 },
+        }),
+      ]);
+
+      expect(blockData().schemaMigrations).toEqual([
+        {
+          id: "add-owner",
+          title: "Require owner",
+          description: "some description",
+          gracePeriod: { type: "daysAfterActivation", daysAfterActivation: 30 },
+          migrations: [
+            {
+              type: "addRequiredProperty",
+              addRequiredProperty: { propertyTypeRid: "optional0" },
+            },
+          ],
+        },
+      ]);
+    });
+
+    it("translates a deadline transition", () => {
+      defineWithMigrations([
+        transition({
+          gracePeriod: { type: "deadline", deadline: "2026-01-31T12:34:56Z" },
+        }),
+      ]);
+
+      expect(blockData().schemaMigrations[0].gracePeriod).toEqual({
+        type: "deadline",
+        deadline: "2026-01-31T12:34:56Z",
+      });
+    });
+
+    it("strips zero milliseconds from a deadline", () => {
+      defineWithMigrations([
+        transition({
+          gracePeriod: {
+            type: "deadline",
+            deadline: "2026-01-31T12:34:56.000Z",
+          },
+        }),
+      ]);
+
+      expect(blockData().schemaMigrations[0].gracePeriod).toEqual({
+        type: "deadline",
+        deadline: "2026-01-31T12:34:56Z",
+      });
+    });
+
+    it("preserves non-zero milliseconds on a deadline", () => {
+      defineWithMigrations([
+        transition({
+          gracePeriod: {
+            type: "deadline",
+            deadline: "2026-01-31T12:34:56.789Z",
+          },
+        }),
+      ]);
+
+      expect(blockData().schemaMigrations[0].gracePeriod).toEqual({
+        type: "deadline",
+        deadline: "2026-01-31T12:34:56.789Z",
+      });
+    });
+
+    it("resolves an SPT-backed property to the shared property type's api name", () => {
+      const spt = defineSharedPropertyType({
+        apiName: "ownerSpt",
+        type: "string",
+      });
+
+      defineInterface({
+        apiName: "Foo",
+        properties: { ownerSpt: { sharedPropertyType: spt, required: false } },
+        schemaMigrations: {
+          transitions: [
+            transition({
+              instructions: [addRequiredProperty("ownerSpt")],
+            }),
+          ],
+        },
+      });
+
+      expect(blockData().schemaMigrations[0].migrations).toEqual([
+        {
+          type: "addRequiredProperty",
+          addRequiredProperty: { propertyTypeRid: "com.palantir.ownerSpt" },
+        },
+      ]);
+    });
+  });
+
   describe("transition count bounds", () => {
     it("accepts 20 transitions", () => {
       expect(() => defineWithMigrations(distinctTransitions(20))).not.toThrow();

--- a/packages/maker/src/api/test/interfaceSchemaMigrations.test.ts
+++ b/packages/maker/src/api/test/interfaceSchemaMigrations.test.ts
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 
+import invariant from "tiny-invariant";
 import { beforeEach, describe, expect, it } from "vitest";
 
 import type { InterfaceTypeDefinition } from "../defineInterface.js";
@@ -616,10 +617,16 @@ describe("Interface schema migrations", () => {
       ];
     }
 
-    it("emits an empty migration list when not opted in", () => {
+    function transitions() {
+      const { schemaMigrations } = blockData();
+      invariant(schemaMigrations != null, "expected schema migrations");
+      return schemaMigrations.schemaTransitions;
+    }
+
+    it("omits the migration block when not opted in", () => {
       defineInterface({ apiName: "Foo" });
 
-      expect(blockData().schemaMigrations).toEqual([]);
+      expect(blockData().schemaMigrations).toBeUndefined();
       expect(blockData().interfaceType).not.toHaveProperty(
         "schemaMigrationsEnabled",
       );
@@ -632,7 +639,51 @@ describe("Interface schema migrations", () => {
       });
 
       expect(blockData().interfaceType.schemaMigrationsEnabled).toBe(true);
-      expect(blockData().schemaMigrations).toEqual([]);
+      expect(blockData().schemaMigrations).toEqual({
+        interfacePropertyTypeRidsToApiNames: {},
+        schemaTransitions: {},
+      });
+    });
+
+    it("keys transitions by their id", () => {
+      defineWithMigrations([
+        transition({ id: "t0", instructions: [addRequiredProperty("a")] }),
+        transition({ id: "t1", instructions: [addRequiredProperty("b")] }),
+      ]);
+
+      expect(Object.keys(transitions())).toEqual(["t0", "t1"]);
+    });
+
+    it("maps each targeted property to its published api name", () => {
+      const spt = defineSharedPropertyType({
+        apiName: "ownerSpt",
+        type: "string",
+      });
+
+      defineInterface({
+        apiName: "Foo",
+        properties: {
+          optional0: OPTIONAL_STRING,
+          ownerSpt: { sharedPropertyType: spt, required: false },
+        },
+        schemaMigrations: {
+          transitions: [
+            transition({
+              instructions: [
+                addRequiredProperty("optional0"),
+                addRequiredProperty("ownerSpt"),
+              ],
+            }),
+          ],
+        },
+      });
+
+      expect(
+        blockData().schemaMigrations?.interfacePropertyTypeRidsToApiNames,
+      ).toEqual({
+        optional0: "optional0",
+        "com.palantir.ownerSpt": "com.palantir.ownerSpt",
+      });
     });
 
     it("translates an afterInstall transition to daysAfterActivation", () => {
@@ -645,8 +696,8 @@ describe("Interface schema migrations", () => {
         }),
       ]);
 
-      expect(blockData().schemaMigrations).toEqual([
-        {
+      expect(transitions()).toEqual({
+        "add-owner": {
           id: "add-owner",
           title: "Require owner",
           description: "some description",
@@ -658,7 +709,7 @@ describe("Interface schema migrations", () => {
             },
           ],
         },
-      ]);
+      });
     });
 
     it("translates a deadline transition", () => {
@@ -668,7 +719,7 @@ describe("Interface schema migrations", () => {
         }),
       ]);
 
-      expect(blockData().schemaMigrations[0].gracePeriod).toEqual({
+      expect(transitions().t1.gracePeriod).toEqual({
         type: "deadline",
         deadline: "2026-01-31T12:34:56Z",
       });
@@ -684,7 +735,7 @@ describe("Interface schema migrations", () => {
         }),
       ]);
 
-      expect(blockData().schemaMigrations[0].gracePeriod).toEqual({
+      expect(transitions().t1.gracePeriod).toEqual({
         type: "deadline",
         deadline: "2026-01-31T12:34:56Z",
       });
@@ -700,7 +751,7 @@ describe("Interface schema migrations", () => {
         }),
       ]);
 
-      expect(blockData().schemaMigrations[0].gracePeriod).toEqual({
+      expect(transitions().t1.gracePeriod).toEqual({
         type: "deadline",
         deadline: "2026-01-31T12:34:56.789Z",
       });
@@ -724,7 +775,7 @@ describe("Interface schema migrations", () => {
         },
       });
 
-      expect(blockData().schemaMigrations[0].migrations).toEqual([
+      expect(transitions().t1.migrations).toEqual([
         {
           type: "addRequiredProperty",
           addRequiredProperty: { propertyTypeRid: "com.palantir.ownerSpt" },

--- a/packages/maker/src/conversion/toMarketplace/convertInterface.ts
+++ b/packages/maker/src/conversion/toMarketplace/convertInterface.ts
@@ -23,15 +23,15 @@ import { convertSpt } from "./convertSpt.js";
 export function convertInterface(
   interfaceType: InterfaceType,
 ): OntologyIrMarketplaceInterfaceType {
-  const {
-    __type,
-    // schema migrations travel in their own block data section rather than on the interface type
-    // directly, so we explicitly exclude it from "other"
-    schemaMigrations: _schemaMigrations,
-    ...other
-  } = interfaceType;
+  const { __type, schemaMigrations, ...other } = interfaceType;
   return {
     ...other,
+    // schema migrations travel in their own block data section rather than on the interface type
+    // directly; we only use the declared object to determine if the IT is opted in,
+    // but exclude the migrations themselves from the IT definition
+    ...(schemaMigrations !== undefined
+      ? { schemaMigrationsEnabled: true }
+      : {}),
     propertiesV2: Object.fromEntries(
       Object.values(interfaceType.propertiesV2).map((spt) => [
         spt.sharedPropertyType.apiName,

--- a/packages/maker/src/conversion/toMarketplace/convertInterfaceSchemaMigrations.ts
+++ b/packages/maker/src/conversion/toMarketplace/convertInterfaceSchemaMigrations.ts
@@ -19,7 +19,6 @@ import type {
   OntologyIrInterfaceTypeSchemaMigrationInstruction,
   OntologyIrInterfaceTypeSchemaTransition,
 } from "@osdk/client.unstable";
-import invariant from "tiny-invariant";
 
 import {
   type InterfacePropertyType,
@@ -83,11 +82,6 @@ function convertInstruction(
   switch (instruction.type) {
     case "addRequiredProperty": {
       const { property: propertyApiName } = instruction;
-      invariant(
-        Object.hasOwn(propertiesV3, propertyApiName),
-        `Schema migration instruction ${instruction.type} references property "${propertyApiName}", which the interface does not declare.`,
-      );
-
       return {
         type: "addRequiredProperty",
         addRequiredProperty: {

--- a/packages/maker/src/conversion/toMarketplace/convertInterfaceSchemaMigrations.ts
+++ b/packages/maker/src/conversion/toMarketplace/convertInterfaceSchemaMigrations.ts
@@ -16,14 +16,12 @@
 
 import type {
   GracePeriod as WireGracePeriod,
+  OntologyIrInterfaceTypeSchemaMigrationBlockData,
   OntologyIrInterfaceTypeSchemaMigrationInstruction,
   OntologyIrInterfaceTypeSchemaTransition,
 } from "@osdk/client.unstable";
 
-import {
-  type InterfacePropertyType,
-  interfacePropertyWireApiName,
-} from "../../api/interface/InterfacePropertyType.js";
+import { interfacePropertyWireApiName } from "../../api/interface/InterfacePropertyType.js";
 import type {
   InterfaceSchemaGracePeriod,
   InterfaceSchemaMigrationInstruction,
@@ -32,21 +30,40 @@ import type { InterfaceType } from "../../api/interface/InterfaceType.js";
 
 export function convertInterfaceSchemaMigrations(
   interfaceType: InterfaceType,
-): OntologyIrInterfaceTypeSchemaTransition[] {
+): OntologyIrInterfaceTypeSchemaMigrationBlockData | undefined {
   const { schemaMigrations, propertiesV3 } = interfaceType;
   if (schemaMigrations === undefined) {
-    return [];
+    return undefined;
   }
 
-  return schemaMigrations.transitions.map((transition) => ({
-    id: transition.id,
-    title: transition.title,
-    description: transition.description,
-    gracePeriod: convertInterfaceSchemaGracePeriod(transition.gracePeriod),
-    migrations: transition.instructions.map((instruction) =>
-      convertInstruction(instruction, propertiesV3),
+  // NB: Ontology-ir identifies interface property types by API name rather than rid
+  const interfacePropertyTypeRidsToApiNames: Record<string, string> = {};
+  const schemaTransitions = Object.fromEntries(
+    schemaMigrations.transitions.map(
+      (transition): [string, OntologyIrInterfaceTypeSchemaTransition] => [
+        transition.id,
+        {
+          id: transition.id,
+          title: transition.title,
+          description: transition.description,
+          gracePeriod: convertInterfaceSchemaGracePeriod(
+            transition.gracePeriod,
+          ),
+          migrations: transition.instructions.map((instruction) => {
+            const propertyApiName = interfacePropertyWireApiName(
+              propertiesV3[instruction.property],
+              instruction.property,
+            );
+            interfacePropertyTypeRidsToApiNames[propertyApiName] =
+              propertyApiName;
+            return convertInstruction(instruction, propertyApiName);
+          }),
+        },
+      ],
     ),
-  }));
+  );
+
+  return { interfacePropertyTypeRidsToApiNames, schemaTransitions };
 }
 
 export function convertInterfaceSchemaGracePeriod(
@@ -77,22 +94,17 @@ export function convertInterfaceSchemaGracePeriod(
 
 function convertInstruction(
   instruction: InterfaceSchemaMigrationInstruction,
-  propertiesV3: Record<string, InterfacePropertyType>,
+  propertyApiName: string,
 ): OntologyIrInterfaceTypeSchemaMigrationInstruction {
   switch (instruction.type) {
-    case "addRequiredProperty": {
-      const { property: propertyApiName } = instruction;
+    case "addRequiredProperty":
       return {
         type: "addRequiredProperty",
         addRequiredProperty: {
           // For ontology-ir, this carries an API name, not a rid, despite its name
-          propertyTypeRid: interfacePropertyWireApiName(
-            propertiesV3[propertyApiName],
-            propertyApiName,
-          ),
+          propertyTypeRid: propertyApiName,
         },
       };
-    }
     default:
       // TODO: add a never exhaustiveness check once there's more than one instruction type
       throw new Error(

--- a/packages/maker/src/conversion/toMarketplace/convertInterfaceSchemaMigrations.ts
+++ b/packages/maker/src/conversion/toMarketplace/convertInterfaceSchemaMigrations.ts
@@ -1,0 +1,108 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type {
+  GracePeriod as WireGracePeriod,
+  OntologyIrInterfaceTypeSchemaMigrationInstruction,
+  OntologyIrInterfaceTypeSchemaTransition,
+} from "@osdk/client.unstable";
+import invariant from "tiny-invariant";
+
+import {
+  type InterfacePropertyType,
+  interfacePropertyWireApiName,
+} from "../../api/interface/InterfacePropertyType.js";
+import type {
+  InterfaceSchemaGracePeriod,
+  InterfaceSchemaMigrationInstruction,
+} from "../../api/interface/InterfaceSchemaMigrations.js";
+import type { InterfaceType } from "../../api/interface/InterfaceType.js";
+
+export function convertInterfaceSchemaMigrations(
+  interfaceType: InterfaceType,
+): OntologyIrInterfaceTypeSchemaTransition[] {
+  const { schemaMigrations, propertiesV3 } = interfaceType;
+  if (schemaMigrations === undefined) {
+    return [];
+  }
+
+  return schemaMigrations.transitions.map((transition) => ({
+    id: transition.id,
+    title: transition.title,
+    description: transition.description,
+    gracePeriod: convertInterfaceSchemaGracePeriod(transition.gracePeriod),
+    migrations: transition.instructions.map((instruction) =>
+      convertInstruction(instruction, propertiesV3),
+    ),
+  }));
+}
+
+export function convertInterfaceSchemaGracePeriod(
+  gracePeriod: InterfaceSchemaGracePeriod,
+): WireGracePeriod {
+  switch (gracePeriod.type) {
+    case "afterInstall":
+      return {
+        type: "daysAfterActivation",
+        daysAfterActivation: gracePeriod.days,
+      };
+    case "deadline":
+      // Normalize deadline format to match Java (strip .000 milliseconds)
+      return {
+        type: "deadline",
+        deadline: gracePeriod.deadline.replace(/\.000Z$/u, "Z"),
+      };
+    default: {
+      const unhandled: never = gracePeriod;
+      throw new Error(
+        `Unknown schema migration grace period type: ${
+          (unhandled as InterfaceSchemaGracePeriod).type
+        }`,
+      );
+    }
+  }
+}
+
+function convertInstruction(
+  instruction: InterfaceSchemaMigrationInstruction,
+  propertiesV3: Record<string, InterfacePropertyType>,
+): OntologyIrInterfaceTypeSchemaMigrationInstruction {
+  switch (instruction.type) {
+    case "addRequiredProperty": {
+      const { property: propertyApiName } = instruction;
+      invariant(
+        Object.hasOwn(propertiesV3, propertyApiName),
+        `Schema migration instruction ${instruction.type} references property "${propertyApiName}", which the interface does not declare.`,
+      );
+
+      return {
+        type: "addRequiredProperty",
+        addRequiredProperty: {
+          // For ontology-ir, this carries an API name, not a rid, despite its name
+          propertyTypeRid: interfacePropertyWireApiName(
+            propertiesV3[propertyApiName],
+            propertyApiName,
+          ),
+        },
+      };
+    }
+    default:
+      // TODO: add a never exhaustiveness check once there's more than one instruction type
+      throw new Error(
+        `Unknown schema migration instruction type: ${instruction.type}`,
+      );
+  }
+}

--- a/packages/maker/src/conversion/toMarketplace/convertOntologyDefinitionToWireBlockData.ts
+++ b/packages/maker/src/conversion/toMarketplace/convertOntologyDefinitionToWireBlockData.ts
@@ -116,11 +116,13 @@ export function convertOntologyDefinitionToWireBlockData(
       Object.entries(ontology[OntologyEntityTypeEnum.INTERFACE_TYPE]).map<
         [string, OntologyIrInterfaceTypeBlockDataV2]
       >(([apiName, interfaceType]) => {
+        const schemaMigrations =
+          convertInterfaceSchemaMigrations(interfaceType);
         return [
           apiName,
           {
             interfaceType: convertInterface(interfaceType),
-            schemaMigrations: convertInterfaceSchemaMigrations(interfaceType),
+            ...(schemaMigrations !== undefined ? { schemaMigrations } : {}),
           },
         ];
       }),

--- a/packages/maker/src/conversion/toMarketplace/convertOntologyDefinitionToWireBlockData.ts
+++ b/packages/maker/src/conversion/toMarketplace/convertOntologyDefinitionToWireBlockData.ts
@@ -41,6 +41,7 @@ import {
   convertAction,
 } from "../../api/defineOntology.js";
 import { convertInterface } from "./convertInterface.js";
+import { convertInterfaceSchemaMigrations } from "./convertInterfaceSchemaMigrations.js";
 import { convertLink } from "./convertLink.js";
 import { convertObject } from "./convertObject.js";
 import { convertSpt } from "./convertSpt.js";
@@ -119,6 +120,7 @@ export function convertOntologyDefinitionToWireBlockData(
           apiName,
           {
             interfaceType: convertInterface(interfaceType),
+            schemaMigrations: convertInterfaceSchemaMigrations(interfaceType),
           },
         ];
       }),

--- a/packages/maker/src/index.ts
+++ b/packages/maker/src/index.ts
@@ -146,4 +146,5 @@ export {
 export type { ValueTypeDefinitionVersion } from "./api/values/ValueTypeDefinitionVersion.js";
 export { wrapWithProxy } from "./api/wrapWithProxy.js";
 export { default } from "./cli/main.js";
+export { convertInterfaceSchemaGracePeriod } from "./conversion/toMarketplace/convertInterfaceSchemaMigrations.js";
 export { propertyTypeTypeToOntologyIrType as convertType } from "./conversion/toMarketplace/propertyTypeTypeToOntologyIrType.js";

--- a/packages/maker/src/index.ts
+++ b/packages/maker/src/index.ts
@@ -101,6 +101,7 @@ export type {
   InterfacePropertyType,
 } from "./api/interface/InterfacePropertyType.js";
 export {
+  interfacePropertyWireApiName,
   isInterfacePropertyRequired,
   isInterfaceSharedPropertyType,
 } from "./api/interface/InterfacePropertyType.js";


### PR DESCRIPTION
## Targeting https://github.com/palantir/osdk-ts/pull/3969

ITSMs authored in the OAC DSL are now included in the emitted ontology-ir and ontology block data.