### PR TITLE
Support version ranges for functions

### DIFF
--- a/packages/client/src/ontology/loadQueryMetadata.test.ts
+++ b/packages/client/src/ontology/loadQueryMetadata.test.ts
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as QueryTypes from "@osdk/foundry.ontologies/QueryType";
+import { beforeEach, expect, it, vi } from "vitest";
+
+import type { MinimalClient } from "../MinimalClientContext.js";
+import { loadQueryMetadata } from "./loadQueryMetadata.js";
+
+vi.mock("@osdk/foundry.ontologies/QueryType", () => ({
+  get: vi.fn(),
+}));
+
+beforeEach(() => {
+  vi.mocked(QueryTypes.get).mockResolvedValue({
+    apiName: "getEmployees",
+    output: { type: "integer" },
+    parameters: {},
+    rid: "ri.function-registry.main.function.get-employees",
+    version: "1.4.0",
+  });
+});
+
+it("loads a version range on the client's branch", async () => {
+  const client = {
+    branch: "ri.branch.main.branch.sdk-branch",
+    ontologyRid: "ri.ontology.main.ontology.sdk-ontology",
+  } as MinimalClient;
+
+  const metadata = await loadQueryMetadata(client, "getEmployees:1.x");
+
+  expect(QueryTypes.get).toHaveBeenCalledWith(
+    client,
+    "ri.ontology.main.ontology.sdk-ontology",
+    "getEmployees",
+    {
+      branch: "ri.branch.main.branch.sdk-branch",
+      version: "1.x",
+    }
+  );
+  expect(metadata).toEqual({
+    apiName: "getEmployees",
+    output: { nullable: false, type: "integer" },
+    parameters: {},
+    rid: "ri.function-registry.main.function.get-employees",
+    type: "query",
+    typeReferences: undefined,
+    version: "1.4.0",
+  });
+});

--- a/packages/client/src/ontology/loadQueryMetadata.ts
+++ b/packages/client/src/ontology/loadQueryMetadata.ts
@@ -23,10 +23,28 @@ export async function loadQueryMetadata(
   client: MinimalClient,
   queryTypeApiNameAndVersion: string
 ): Promise<QueryMetadata> {
-  const [apiName, version] = queryTypeApiNameAndVersion.split(":");
-  const r = await QueryTypes.get(client, await client.ontologyRid, apiName, {
+  const separatorIndex = queryTypeApiNameAndVersion.lastIndexOf(":");
+  const apiName =
+    separatorIndex === -1
+      ? queryTypeApiNameAndVersion
+      : queryTypeApiNameAndVersion.slice(0, separatorIndex);
+  const version =
+    separatorIndex === -1
+      ? undefined
+      : queryTypeApiNameAndVersion.slice(separatorIndex + 1);
+
+  // `branch` is part of the API Gateway contract but has not yet been
+  // published in @osdk/foundry.ontologies.
+  const queryParameters = {
     version,
-  });
+    branch: client.branch,
+  } as Parameters<typeof QueryTypes.get>[3] & { branch?: string };
+  const r = await QueryTypes.get(
+    client,
+    await client.ontologyRid,
+    apiName,
+    queryParameters
+  );
 
   const { wireQueryTypeV2ToSdkQueryMetadata } =
     await import("@osdk/generator-converters");

--- a/packages/foundry-sdk-generator/src/generate/betaClient/generatePackage.ts
+++ b/packages/foundry-sdk-generator/src/generate/betaClient/generatePackage.ts
@@ -90,7 +90,7 @@ export async function generatePackage(
     ontologyInfo.externalInterfaces,
     new Map(),
     false,
-    ontologyInfo.fixedVersionQueryTypes,
+    ontologyInfo.queryVersionReferences,
   );
 
   // actually write file plus save contents

--- a/packages/foundry-sdk-generator/src/ontologyMetadata/__snapshots__/metadataResolver.test.ts.snap
+++ b/packages/foundry-sdk-generator/src/ontologyMetadata/__snapshots__/metadataResolver.test.ts.snap
@@ -4,7 +4,7 @@ exports[`Load Ontologies Metadata > Loads action types with media refs, interfac
 {
   "externalInterfaces": Map {},
   "externalObjects": Map {},
-  "fixedVersionQueryTypes": [],
+  "queryVersionReferences": Map {},
   "requestedMetadata": {
     "actionTypes": {
       "actionTakesMedia": {
@@ -533,7 +533,7 @@ exports[`Load Ontologies Metadata > Loads object and action types using only spe
 {
   "externalInterfaces": Map {},
   "externalObjects": Map {},
-  "fixedVersionQueryTypes": [],
+  "queryVersionReferences": Map {},
   "requestedMetadata": {
     "actionTypes": {
       "promoteEmployee": {
@@ -877,7 +877,7 @@ exports[`Load Ontologies Metadata > Loads object, action, interface types withou
 {
   "externalInterfaces": Map {},
   "externalObjects": Map {},
-  "fixedVersionQueryTypes": [],
+  "queryVersionReferences": Map {},
   "requestedMetadata": {
     "actionTypes": {
       "promoteEmployee": {

--- a/packages/foundry-sdk-generator/src/ontologyMetadata/metadataResolver.test.ts
+++ b/packages/foundry-sdk-generator/src/ontologyMetadata/metadataResolver.test.ts
@@ -66,7 +66,7 @@ describe("Load Ontologies Metadata", () => {
       {
         "externalInterfaces": Map {},
         "externalObjects": Map {},
-        "fixedVersionQueryTypes": [],
+        "queryVersionReferences": Map {},
         "requestedMetadata": {
           "actionTypes": {},
           "interfaceTypes": {},
@@ -361,9 +361,9 @@ describe("Load Ontologies Metadata", () => {
         throw new Error(ontologyDefinitions.error.join("\n"));
       }
 
-      expect(ontologyDefinitions.value.fixedVersionQueryTypes).toEqual([
-        "addOne",
-      ]);
+      expect(ontologyDefinitions.value.queryVersionReferences).toEqual(
+        new Map([["addOne", "0.0.9"]]),
+      );
       expect(
         ontologyDefinitions.value.requestedMetadata.queryTypes,
       ).toMatchInlineSnapshot(`
@@ -406,8 +406,8 @@ describe("Load Ontologies Metadata", () => {
         throw new Error(ontologyDefinitions.error.join("\n"));
       }
 
-      expect(ontologyDefinitions.value.fixedVersionQueryTypes.length).toEqual(
-        0,
+      expect(ontologyDefinitions.value.queryVersionReferences).toEqual(
+        new Map(),
       );
       expect(
         ontologyDefinitions.value.requestedMetadata.queryTypes,
@@ -433,6 +433,23 @@ describe("Load Ontologies Metadata", () => {
           },
         }
       `);
+    });
+
+    it("rejects multiple version references for the same query", async () => {
+      const ontologyDefinitions = await ontologyMetadataResolver
+        .getWireOntologyDefinition(
+          "ri.ontology.main.ontology.698267cc-6b48-4d98-beff-29beb24e9361",
+          {
+            queryTypesApiNamesToLoad: ["addOne", "addOne:2.x"],
+          },
+        );
+
+      if (ontologyDefinitions.isOk()) {
+        throw new Error("Expected duplicate query references to be rejected");
+      }
+      expect(ontologyDefinitions.error).toEqual([
+        "Query type addOne was specified multiple times.",
+      ]);
     });
   });
 });

--- a/packages/foundry-sdk-generator/src/ontologyMetadata/ontologyMetadataResolver.ts
+++ b/packages/foundry-sdk-generator/src/ontologyMetadata/ontologyMetadataResolver.ts
@@ -62,7 +62,7 @@ export interface OntologyInfo {
   requestedMetadata: OntologyFullMetadata;
   externalInterfaces: Map<string, string>;
   externalObjects: Map<string, string>;
-  fixedVersionQueryTypes: string[];
+  queryVersionReferences: ReadonlyMap<string, string>;
 }
 
 export class OntologyMetadataResolver {
@@ -333,7 +333,7 @@ export class OntologyMetadataResolver {
         requestedMetadata: filteredFullMetadata,
         externalInterfaces,
         externalObjects,
-        fixedVersionQueryTypes: [],
+        queryVersionReferences: new Map(),
       });
     } else {
       const objectTypes = new Set(entities.objectTypesApiNamesToLoad);
@@ -353,19 +353,27 @@ export class OntologyMetadataResolver {
       }
 
       const queryTypes = new Set<string>();
-      const fixedVersionQueryTypes = [];
+      const queryTypeApiNames = new Set<string>();
+      const queryVersionReferences = new Map<string, string>();
 
       for (const queryType of entities.queryTypesApiNamesToLoad ?? []) {
-        if (queryTypes.has(queryType)) {
+        const lastColonIndex = queryType.lastIndexOf(":");
+        const queryTypeApiName = lastColonIndex === -1
+          ? queryType
+          : queryType.substring(0, lastColonIndex);
+
+        if (queryTypeApiNames.has(queryTypeApiName)) {
           return Result.err([
-            `Query type ${queryType} was specified multiple times.`,
+            `Query type ${queryTypeApiName} was specified multiple times.`,
           ]);
         }
-        const lastColonIndex = queryType.lastIndexOf(":");
+        queryTypeApiNames.add(queryTypeApiName);
 
         if (lastColonIndex !== -1) {
-          const queryTypeApiName = queryType.substring(0, lastColonIndex);
-          fixedVersionQueryTypes.push(queryTypeApiName);
+          queryVersionReferences.set(
+            queryTypeApiName,
+            queryType.substring(lastColonIndex + 1),
+          );
         }
         queryTypes.add(queryType);
       }
@@ -408,7 +416,7 @@ export class OntologyMetadataResolver {
         requestedMetadata,
         externalInterfaces: new Map(),
         externalObjects: new Map(),
-        fixedVersionQueryTypes,
+        queryVersionReferences,
       });
     }
   }

--- a/packages/generator/src/GenerateContext/GenerateContext.ts
+++ b/packages/generator/src/GenerateContext/GenerateContext.ts
@@ -24,7 +24,7 @@ export interface GenerateContext {
   fs: MinimalFs;
 
   outDir: string;
-  fixedVersionQueryTypes: string[];
+  queryVersionReferences: ReadonlyMap<string, string>;
   ontologyApiNamespace?: string | undefined;
   apiNamespacePackageMap?: Map<string, string>;
   forInternalUse?: boolean;

--- a/packages/generator/src/v2.0/generateClientSdkVersionTwoPointZero.test.ts
+++ b/packages/generator/src/v2.0/generateClientSdkVersionTwoPointZero.test.ts
@@ -2314,7 +2314,7 @@ describe("generator", () => {
         new Map(),
         new Map(),
         false,
-        ["getCount"],
+        new Map([["getCount", "1.x"]]),
       );
 
       expect(
@@ -2629,14 +2629,14 @@ describe("generator", () => {
           };
           apiName: 'getCount';
           type: 'query';
-          version: '1.1.0';
+          version: '1.x';
           osdkMetadata: typeof $osdkMetadata;
         }
 
         export const getCount: getCount = {
           apiName: 'getCount',
           type: 'query',
-          version: '1.1.0',
+          version: '1.x',
           isFixedVersion: true,
           osdkMetadata: $osdkMetadata,
         };

--- a/packages/generator/src/v2.0/generateClientSdkVersionTwoPointZero.ts
+++ b/packages/generator/src/v2.0/generateClientSdkVersionTwoPointZero.ts
@@ -36,7 +36,7 @@ export async function generateClientSdkVersionTwoPointZero(
   externalInterfaces: Map<string, string> = new Map(),
   externalSpts: Map<string, string> = new Map(),
   forInternalUse: boolean = false,
-  fixedVersionQueryTypes: string[] = [],
+  queryVersionReferences: ReadonlyMap<string, string> = new Map(),
 ): Promise<void> {
   const importExt = ".js"; // turns out you can always use the extension
 
@@ -60,7 +60,7 @@ export async function generateClientSdkVersionTwoPointZero(
     fs,
     outDir,
     forInternalUse,
-    fixedVersionQueryTypes,
+    queryVersionReferences,
   };
 
   await generateRootIndexTsFile(ctx);

--- a/packages/generator/src/v2.0/generatePerQueryDataFiles.test.ts
+++ b/packages/generator/src/v2.0/generatePerQueryDataFiles.test.ts
@@ -39,7 +39,7 @@ describe("generatePerQueryDataFiles", () => {
         outDir: BASE_PATH,
         importExt: ".js",
         forInternalUse: true,
-        fixedVersionQueryTypes: [],
+        queryVersionReferences: new Map(),
       },
       true,
     );
@@ -272,7 +272,7 @@ describe("generatePerQueryDataFiles", () => {
         outDir: BASE_PATH,
         importExt: ".js",
         forInternalUse: true,
-        fixedVersionQueryTypes: [],
+        queryVersionReferences: new Map(),
       },
       true,
     );
@@ -418,7 +418,7 @@ describe("generatePerQueryDataFiles", () => {
         outDir: BASE_PATH,
         importExt: ".js",
         forInternalUse: true,
-        fixedVersionQueryTypes: [],
+        queryVersionReferences: new Map(),
       },
       true,
     );
@@ -678,7 +678,7 @@ describe("generatePerQueryDataFiles", () => {
         outDir: BASE_PATH,
         importExt: ".js",
         forInternalUse: true,
-        fixedVersionQueryTypes: [],
+        queryVersionReferences: new Map(),
       },
       true,
     );
@@ -883,7 +883,7 @@ describe("generatePerQueryDataFiles", () => {
         outDir: BASE_PATH,
         importExt: ".js",
         forInternalUse: true,
-        fixedVersionQueryTypes: [],
+        queryVersionReferences: new Map(),
       },
       true,
     );

--- a/packages/generator/src/v2.0/generatePerQueryDataFiles.ts
+++ b/packages/generator/src/v2.0/generatePerQueryDataFiles.ts
@@ -43,7 +43,7 @@ export async function generatePerQueryDataFilesV2(
     fs,
     outDir: rootOutDir,
     ontology,
-    fixedVersionQueryTypes,
+    queryVersionReferences,
     importExt = "",
     forInternalUse = false,
   }: Pick<
@@ -53,7 +53,7 @@ export async function generatePerQueryDataFilesV2(
     | "importExt"
     | "ontology"
     | "forInternalUse"
-    | "fixedVersionQueryTypes"
+    | "queryVersionReferences"
   >,
   v2: boolean,
 ): Promise<void> {
@@ -70,7 +70,7 @@ export async function generatePerQueryDataFilesV2(
         importExt,
         ontology,
         forInternalUse,
-        fixedVersionQueryTypes,
+        queryVersionReferences,
       );
     }),
   );
@@ -100,7 +100,7 @@ async function generateV2QueryFile(
   importExt: string,
   ontology: EnhancedOntologyDefinition,
   forInternalUse: boolean,
-  fixedVersionQueryTypes: string[],
+  queryVersionReferences: ReadonlyMap<string, string>,
 ) {
   const relFilePath = path.join(relOutDir, `${query.shortApiName}.ts`);
   const objectTypes = getObjectTypeApiNamesFromQuery(query);
@@ -127,9 +127,11 @@ async function generateV2QueryFile(
     wireQueryDataTypeToQueryDataTypeDefinition(query.output),
   );
 
-  const isUsingFixedVersion = fixedVersionQueryTypes.includes(
-    query.fullApiName,
-  );
+  const requestedVersion = queryVersionReferences.get(query.fullApiName);
+  const isUsingFixedVersion = requestedVersion !== undefined;
+  const runtimeProps = requestedVersion === undefined
+    ? baseProps
+    : { ...baseProps, version: requestedVersion };
 
   const typeRefs = query.raw.typeReferences ?? {};
   const customTypesNs = generateCustomTypesNamespace(ontology, typeRefs);
@@ -216,7 +218,7 @@ async function generateV2QueryFile(
             signature: ${query.shortApiName}.Signature;
         },
         ${
-      stringify(baseProps, {
+      stringify(runtimeProps, {
         "description": () => undefined,
         "displayName": () => undefined,
         "rid": () => undefined,
@@ -228,7 +230,7 @@ async function generateV2QueryFile(
         ${getDescriptionIfPresent(query.description)}
         export const ${query.shortApiName}: ${query.definitionIdentifier} = {
             ${
-      stringify(baseProps, {
+      stringify(runtimeProps, {
         "description": () => undefined,
         "displayName": () => undefined,
         "rid": () => undefined,


### PR DESCRIPTION
Adds support for generating an sdk using version ranges, which will:
- Generate bindings based on the function spec returned from gateway, when requesting with a veresion range
- Execute the version range at runtime rather than a concrete version