### PR TITLE
Deprecate legacy CBAC component exports

### DIFF
--- a/.changeset/deprecate-cbac-experimental.md
+++ b/.changeset/deprecate-cbac-experimental.md
@@ -1,0 +1,5 @@
+---
+"@osdk/cbac-components": patch
+---
+
+Deprecate exports from `@osdk/cbac-components/experimental`; migrate to `@osdk/react-components/experimental/cbac-picker`.

--- a/packages/cbac-components/src/public/experimental.ts
+++ b/packages/cbac-components/src/public/experimental.ts
@@ -15,29 +15,38 @@
  */
 
 // CBAC Picker - OSDK-aware components
+/** @deprecated Use `@osdk/react-components/experimental/cbac-picker` instead. */
 export { CbacBanner } from "../cbac-picker/CbacBanner.js";
+/** @deprecated Use `@osdk/react-components/experimental/cbac-picker` instead. */
 export { CbacBannerPopover } from "../cbac-picker/CbacBannerPopover.js";
 import { CbacPicker as _CbacPicker } from "../cbac-picker/CbacPicker.js";
 import { withOsdkMetrics } from "../util/withOsdkMetrics.js";
 
+/** @deprecated Use `@osdk/react-components/experimental/cbac-picker` instead. */
 export const CbacPicker: typeof _CbacPicker = withOsdkMetrics(
   _CbacPicker,
   "CbacPicker",
 );
+/** @deprecated Use `@osdk/react-components/experimental/cbac-picker` instead. */
 export { CbacPickerDialog } from "../cbac-picker/CbacPickerDialog.js";
 
 // CBAC Picker - Base components
+/** @deprecated Use `@osdk/react-components/experimental/cbac-picker` instead. */
 export { BaseCbacBanner } from "../cbac-picker/base/BaseCbacBanner.js";
+/** @deprecated Use `@osdk/react-components/experimental/cbac-picker` instead. */
 export { BaseCbacPicker } from "../cbac-picker/base/BaseCbacPicker.js";
+/** @deprecated Use `@osdk/react-components/experimental/cbac-picker` instead. */
 export { BaseCbacPickerDialog } from "../cbac-picker/base/BaseCbacPickerDialog.js";
 
 // CBAC Picker - Selection logic utilities
+/** @deprecated Use `@osdk/react-components/experimental/cbac-picker` instead. */
 export {
   computeMarkingStates,
   groupMarkingsByCategory,
   toggleMarking,
 } from "../cbac-picker/utils/selectionLogic.js";
 // CBAC Picker - Types
+/** @deprecated Use `@osdk/react-components/experimental/cbac-picker` instead. */
 export type {
   CategoryMarkingGroup,
   CbacBannerData,
@@ -49,5 +58,7 @@ export type {
 } from "../cbac-picker/types.js";
 
 // CBAC Picker - MaxClassificationField
+/** @deprecated Use `@osdk/react-components/experimental/cbac-picker` instead. */
 export { MaxClassificationField } from "../cbac-picker/base/MaxClassificationField.js";
+/** @deprecated Use `@osdk/react-components/experimental/cbac-picker` instead. */
 export type { MaxClassificationFieldProps } from "../cbac-picker/base/MaxClassificationField.js";


### PR DESCRIPTION
## Summary

Deprecate the legacy `@osdk/cbac-components/experimental` exports before removing the package in a follow-up change. The runtime API remains unchanged.

## Changes

- Add deprecation annotations only to the public experimental export path.
- Add a patch changeset announcing the deprecation.
- Preserve implementation declarations and the existing runtime export surface.

## Migration guidance

Replace imports from `@osdk/cbac-components/experimental` with `@osdk/react-components/experimental/cbac-picker`.

## Testing

- `pnpm check-mrl`
- `pnpm --filter @osdk/cbac-components typecheck`
- `pnpm --filter @osdk/cbac-components lint` (passes with 4 existing warnings)
- `pnpm vitest run` from `packages/cbac-components` (31 tests passed)
- `pnpm turbo check-api --filter=@osdk/cbac-components --force`
- `pnpm --filter @osdk/cbac-components transpileTypes`
- Confirmed deprecation annotations are emitted only from the public experimental declaration
- `git diff --check`

The aggregate package check is otherwise green but its root cspell task scans the unrelated `.workmux/PROMPT-remove-cbac-package.md` file in this worktree.