### PR TITLE
Fix function discovery for external imports

### DIFF
--- a/.changeset/fuzzy-berries-resolve.md
+++ b/.changeset/fuzzy-berries-resolve.md
@@ -1,0 +1,8 @@
+---
+"@osdk/generator-converters.ontologyir": patch
+"@osdk/generator-converters.preview": patch
+"@osdk/maker-experimental": patch
+"@osdk/maker-import": patch
+---
+
+Fix TypeScript function discovery for functions that edit imported ontology types.

--- a/packages/generator-converters.ontologyir/src/OntologyIrToFullMetadaConvert.test.ts
+++ b/packages/generator-converters.ontologyir/src/OntologyIrToFullMetadaConvert.test.ts
@@ -22,10 +22,22 @@ import {
   OntologyIrToFullMetadataConverter,
 } from "./OntologyIrToFullMetadataConverter.js";
 
-const discoveredFunctions = vi.hoisted<IDiscoveredFunction[]>(() => []);
+const { discoveredFunctions, entityMetadataMappings } = vi.hoisted(() => ({
+  discoveredFunctions: [] as IDiscoveredFunction[],
+  entityMetadataMappings: [] as unknown[],
+}));
 
 vi.mock("@foundry/functions-typescript-osdk-discovery", () => ({
   FunctionDiscoverer: class {
+    constructor(
+      _program: unknown,
+      _entryPointPath: string,
+      _fullFilePath: string,
+      entityMetadataMapping?: unknown,
+    ) {
+      entityMetadataMappings.push(entityMetadataMapping);
+    }
+
     discover() {
       return { discoveredFunctions };
     }
@@ -3631,6 +3643,62 @@ describe(OntologyIrToFullMetadataConverter, () => {
           client: {
             dataType: { type: "string" },
             required: true,
+          },
+        },
+      ]);
+    } finally {
+      createProgramSpy.mockRestore();
+    }
+  });
+
+  it("uses canonical API names in function discovery entity metadata", async () => {
+    const createProgramSpy = vi.spyOn(
+      OntologyIrToFullMetadataConverter,
+      "createProgram",
+    ).mockReturnValue({} as never);
+    const ontologyRid = "ri.ontology.main.ontology.0";
+    const objectApiName = "com.palantir.ontology.pdfPage";
+    const interfaceApiName = "com.palantir.ontology.pdfDocument";
+    const interfaceRid = "ri.ontology.main.interface-type.pdf-document";
+    discoveredFunctions.splice(0);
+    entityMetadataMappings.splice(0);
+
+    try {
+      await OntologyIrToFullMetadataConverter.discoverTypeScriptFunctions(
+        fileURLToPath(new URL(".", import.meta.url)),
+        undefined,
+        undefined,
+        {
+          ontology: { rid: ontologyRid },
+          objectTypes: {
+            PdfPage: {
+              objectType: { apiName: objectApiName },
+              linkTypes: [],
+            },
+          },
+          interfaceTypes: {
+            PdfDocument: {
+              apiName: interfaceApiName,
+              rid: interfaceRid,
+            },
+          },
+        } as never,
+      );
+
+      expect(entityMetadataMappings).toEqual([
+        {
+          ontologies: {
+            [ontologyRid]: {
+              objectTypes: {
+                [objectApiName]: {
+                  objectTypeId: objectApiName,
+                  linkTypes: {},
+                },
+              },
+              interfaceTypes: {
+                [interfaceApiName]: { interfaceTypeRid: interfaceRid },
+              },
+            },
           },
         },
       ]);

--- a/packages/generator-converters.ontologyir/src/OntologyIrToFullMetadataConverter.ts
+++ b/packages/generator-converters.ontologyir/src/OntologyIrToFullMetadataConverter.ts
@@ -375,11 +375,8 @@ export class OntologyIrToFullMetadataConverter {
         }
       > = {};
       if (previewMetadata.objectTypes) {
-        for (
-          const [apiName, objData] of Object.entries(
-            previewMetadata.objectTypes,
-          )
-        ) {
+        for (const objData of Object.values(previewMetadata.objectTypes)) {
+          const apiName = objData.objectType.apiName;
           const linkTypesMap: Record<string, { linkTypeId: string }> = {};
           if (objData.linkTypes) {
             for (const lt of objData.linkTypes) {
@@ -400,10 +397,11 @@ export class OntologyIrToFullMetadataConverter {
       > = {};
       if (previewMetadata.interfaceTypes) {
         for (
-          const [apiName, interfaceType] of Object.entries(
+          const interfaceType of Object.values(
             previewMetadata.interfaceTypes,
           )
         ) {
+          const apiName = interfaceType.apiName;
           interfaceTypesMap[apiName] = {
             interfaceTypeRid: interfaceType.rid,
           };

--- a/packages/generator-converters.preview/src/ActionLogicRuleConverter.ts
+++ b/packages/generator-converters.preview/src/ActionLogicRuleConverter.ts
@@ -335,9 +335,16 @@ export function convertBlockDataLogicRulesToActionLogicRules(
   rules: LogicRule[],
   action: ActionTypeBlockDataV2,
   blockdata?: OntologyBlockDataV2,
+  importedTypes?: Ontologies.OntologyFullMetadata,
 ): Ontologies.ActionLogicRule[] {
-  const objectLookup = buildBlockDataObjectTypeLookup(blockdata);
-  const interfaceLookup = buildBlockDataInterfaceTypeLookup(blockdata);
+  const objectLookup = buildBlockDataObjectTypeLookup(
+    blockdata,
+    importedTypes,
+  );
+  const interfaceLookup = buildBlockDataInterfaceTypeLookup(
+    blockdata,
+    importedTypes,
+  );
   const interfaceLinkLookup = buildBlockDataInterfaceLinkTypeLookup(blockdata);
 
   return rules.map(rule =>

--- a/packages/generator-converters.preview/src/PreviewOntologyIrConverter.ts
+++ b/packages/generator-converters.preview/src/PreviewOntologyIrConverter.ts
@@ -55,6 +55,7 @@ export class PreviewOntologyIrConverter {
     const actionTypes = this.convertActionTypesWithFullLogicRulesFromBlockData(
       blockdata.actionTypes,
       blockdata,
+      importedTypes,
     );
     // Post-process object types to use UUID-based RIDs
     const objectTypes = this.convertObjectTypesWithUuidRids(
@@ -122,9 +123,16 @@ export class PreviewOntologyIrConverter {
   private static convertActionTypesWithFullLogicRulesFromBlockData(
     actions: Record<string, ActionTypeBlockDataV2>,
     blockdata: OntologyBlockDataV2,
+    importedTypes?: Ontologies.OntologyFullMetadata,
   ): Record<string, Ontologies.ActionTypeFullMetadata> {
-    const objectTypeLookup = buildBlockDataObjectTypeLookup(blockdata);
-    const interfaceTypeLookup = buildBlockDataInterfaceTypeLookup(blockdata);
+    const objectTypeLookup = buildBlockDataObjectTypeLookup(
+      blockdata,
+      importedTypes,
+    );
+    const interfaceTypeLookup = buildBlockDataInterfaceTypeLookup(
+      blockdata,
+      importedTypes,
+    );
     const baseActionTypes = OntologyBlockDataToFullMetadataConverter
       .getOsdkActionTypesFromBlockData(
         blockdata,
@@ -147,6 +155,7 @@ export class PreviewOntologyIrConverter {
           action.actionType.actionTypeLogic.logic.rules,
           action,
           blockdata,
+          importedTypes,
         ),
       };
     }

--- a/packages/maker-experimental/package.json
+++ b/packages/maker-experimental/package.json
@@ -46,6 +46,7 @@
     "@osdk/generator-converters.ontologyir": "workspace:~",
     "@osdk/generator-converters.preview": "workspace:~",
     "@osdk/maker": "workspace:~",
+    "@osdk/maker-import": "workspace:~",
     "consola": "^3.4.2",
     "jiti": "^2.5.1",
     "tiny-invariant": "^1.3.3",

--- a/packages/maker-experimental/src/api/defineOntologyV2.ts
+++ b/packages/maker-experimental/src/api/defineOntologyV2.ts
@@ -18,16 +18,19 @@ import * as fs from "fs";
 
 import type { OntologyIrV2 } from "@osdk/client.unstable";
 import type { InputPreset } from "@osdk/client.unstable/api";
+import type { OntologyFullMetadata } from "@osdk/foundry.ontologies";
 import type { IDiscoveredFunction } from "@osdk/generator-converters.ontologyir";
 import type { LinkType, ObjectType } from "@osdk/maker";
 import {
   getImportedTypes,
   getOntologyDefinition,
+  importOntologyEntity,
   initializeOntologyState,
   OntologyEntityTypeEnum,
   writeDependencyFile,
   writeStaticObjects,
 } from "@osdk/maker";
+import { convertOntologyFullMetadata } from "@osdk/maker-import";
 
 import { convertOntologyDefinition } from "../conversion/toMarketplace/convertOntologyDefinition.js";
 import {
@@ -62,6 +65,7 @@ export async function defineOntologyV2(
   functionsIrFile?: string,
   randomnessKey?: string,
   importedLinkTypeIdsByApiName?: LinkTypeIdsByApiName,
+  externalImportedMetadata?: OntologyFullMetadata,
 ): Promise<OntologyV2Result> {
   initializeOntologyState(ns);
 
@@ -74,6 +78,22 @@ export async function defineOntologyV2(
       e,
     );
     throw e;
+  }
+
+  if (externalImportedMetadata) {
+    const importedOntology = convertOntologyFullMetadata(
+      externalImportedMetadata,
+    );
+    for (const entityType of [
+      OntologyEntityTypeEnum.SHARED_PROPERTY_TYPE,
+      OntologyEntityTypeEnum.INTERFACE_TYPE,
+      OntologyEntityTypeEnum.OBJECT_TYPE,
+      OntologyEntityTypeEnum.ACTION_TYPE,
+    ] as const) {
+      for (const entity of Object.values(importedOntology[entityType])) {
+        importOntologyEntity(entity);
+      }
+    }
   }
 
   const ontologyDefinition = getOntologyDefinition();

--- a/packages/maker-experimental/src/cli/main.ts
+++ b/packages/maker-experimental/src/cli/main.ts
@@ -172,6 +172,13 @@ export default async function main(
     );
   }
 
+  const externalImportedMetadata =
+    commandLineOpts.importJson && fs.existsSync(commandLineOpts.importJson)
+      ? (JSON.parse(
+          await fs.promises.readFile(commandLineOpts.importJson, "utf-8"),
+        ) as ImportedOntologyMetadata)
+      : undefined;
+
   let functionsIrFile;
   if (commandLineOpts.temporaryBlockDataFile) {
     consola.info(
@@ -195,6 +202,7 @@ export default async function main(
         blockDataJson as Parameters<
           typeof PreviewOntologyIrConverter.getPreviewFullMetadataFromBlockData
         >[0],
+        externalImportedMetadata,
       );
     invariant(
       commandLineOpts.functionsDir && commandLineOpts.nodeModulesDir,
@@ -225,14 +233,9 @@ export default async function main(
     await fs.promises.mkdir(commandLineOpts.buildDir, { recursive: true });
   }
 
-  const importedLinkTypeIdsByApiName =
-    commandLineOpts.importJson && fs.existsSync(commandLineOpts.importJson)
-      ? getImportedLinkTypeIdsByApiName(
-          JSON.parse(
-            await fs.promises.readFile(commandLineOpts.importJson, "utf-8"),
-          ) as ImportedOntologyMetadata,
-        )
-      : undefined;
+  const importedLinkTypeIdsByApiName = externalImportedMetadata
+    ? getImportedLinkTypeIdsByApiName(externalImportedMetadata)
+    : undefined;
 
   const {
     ontologyIr,
@@ -249,6 +252,7 @@ export default async function main(
     functionsIrFile,
     commandLineOpts.randomnessKey,
     importedLinkTypeIdsByApiName,
+    externalImportedMetadata,
   );
 
   // Create temp directory for block data
@@ -529,6 +533,7 @@ async function loadOntology(
   functionsIrFile?: string,
   randomnessKey?: string,
   importedLinkTypeIdsByApiName?: LinkTypeIdsByApiName,
+  externalImportedMetadata?: ImportedOntologyMetadata,
 ) {
   const result = await defineOntologyV2(
     apiNamespace,
@@ -538,6 +543,7 @@ async function loadOntology(
     functionsIrFile,
     randomnessKey,
     importedLinkTypeIdsByApiName,
+    externalImportedMetadata,
   );
   return result;
 }

--- a/packages/maker-import/src/generate/writeImportedOntology.ts
+++ b/packages/maker-import/src/generate/writeImportedOntology.ts
@@ -18,6 +18,7 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 
 import type * as Ontologies from "@osdk/foundry.ontologies";
+import type { OntologyDefinition } from "@osdk/maker";
 import { OntologyEntityTypeEnum } from "@osdk/maker";
 
 import { convertActionType } from "./convertActionType.js";
@@ -44,6 +45,42 @@ interface EntityEntry {
   apiName: string;
   entityType: OntologyEntityTypeEnum;
   entity: unknown;
+}
+
+export function convertOntologyFullMetadata(
+  metadata: Ontologies.OntologyFullMetadata,
+): OntologyDefinition {
+  const result: OntologyDefinition = {
+    [OntologyEntityTypeEnum.OBJECT_TYPE]: {},
+    [OntologyEntityTypeEnum.ACTION_TYPE]: {},
+    [OntologyEntityTypeEnum.LINK_TYPE]: {},
+    [OntologyEntityTypeEnum.INTERFACE_TYPE]: {},
+    [OntologyEntityTypeEnum.SHARED_PROPERTY_TYPE]: {},
+    [OntologyEntityTypeEnum.VALUE_TYPE]: {},
+  };
+
+  for (const spt of Object.values(metadata.sharedPropertyTypes)) {
+    const converted = convertSharedPropertyType(spt);
+    if (converted) {
+      result[OntologyEntityTypeEnum.SHARED_PROPERTY_TYPE][converted.apiName] =
+        converted;
+    }
+  }
+  for (const iface of Object.values(metadata.interfaceTypes)) {
+    const converted = convertInterfaceType(iface, metadata.interfaceTypes);
+    result[OntologyEntityTypeEnum.INTERFACE_TYPE][converted.apiName] =
+      converted;
+  }
+  for (const objectType of Object.values(metadata.objectTypes)) {
+    const converted = convertObjectType(objectType);
+    result[OntologyEntityTypeEnum.OBJECT_TYPE][converted.apiName] = converted;
+  }
+  for (const action of Object.values(metadata.actionTypes)) {
+    const converted = convertActionType(action);
+    result[OntologyEntityTypeEnum.ACTION_TYPE][converted.apiName] = converted;
+  }
+
+  return result;
 }
 
 /**
@@ -107,43 +144,21 @@ export function writeImportedOntology(
 
   // Pass 1: Convert all entities
   const entries: EntityEntry[] = [];
+  const convertedOntology = convertOntologyFullMetadata(metadata);
 
-  for (const [_apiName, spt] of Object.entries(metadata.sharedPropertyTypes)) {
-    const converted = convertSharedPropertyType(spt);
-    if (converted) {
+  for (const entityType of [
+    OntologyEntityTypeEnum.SHARED_PROPERTY_TYPE,
+    OntologyEntityTypeEnum.INTERFACE_TYPE,
+    OntologyEntityTypeEnum.OBJECT_TYPE,
+    OntologyEntityTypeEnum.ACTION_TYPE,
+  ] as const) {
+    for (const entity of Object.values(convertedOntology[entityType])) {
       entries.push({
-        apiName: converted.apiName,
-        entityType: OntologyEntityTypeEnum.SHARED_PROPERTY_TYPE,
-        entity: converted,
+        apiName: entity.apiName,
+        entityType,
+        entity,
       });
     }
-  }
-
-  for (const [_apiName, iface] of Object.entries(metadata.interfaceTypes)) {
-    const converted = convertInterfaceType(iface, metadata.interfaceTypes);
-    entries.push({
-      apiName: converted.apiName,
-      entityType: OntologyEntityTypeEnum.INTERFACE_TYPE,
-      entity: converted,
-    });
-  }
-
-  for (const [_apiName, objFull] of Object.entries(metadata.objectTypes)) {
-    const converted = convertObjectType(objFull);
-    entries.push({
-      apiName: converted.apiName,
-      entityType: OntologyEntityTypeEnum.OBJECT_TYPE,
-      entity: converted,
-    });
-  }
-
-  for (const [_apiName, action] of Object.entries(metadata.actionTypes)) {
-    const converted = convertActionType(action);
-    entries.push({
-      apiName: converted.apiName,
-      entityType: OntologyEntityTypeEnum.ACTION_TYPE,
-      entity: converted,
-    });
   }
 
   // Pass 2: Resolve unique variable names across all entities

--- a/packages/maker-import/src/index.ts
+++ b/packages/maker-import/src/index.ts
@@ -15,4 +15,7 @@
  */
 
 export { default as default } from "./cli/main.js";
-export { writeImportedOntology } from "./generate/writeImportedOntology.js";
+export {
+  convertOntologyFullMetadata,
+  writeImportedOntology,
+} from "./generate/writeImportedOntology.js";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4420,6 +4420,9 @@ importers:
       '@osdk/maker':
         specifier: workspace:~
         version: link:../maker
+      '@osdk/maker-import':
+        specifier: workspace:~
+        version: link:../maker-import
       consola:
         specifier: ^3.4.2
         version: 3.4.2


### PR DESCRIPTION
- We now load import-json before function discovery so that they are registered as valid types
- Generate inputs and presets for all import-json entities. Imports only used in FBAs failed since we still relied on lazy proxy. Note that cross-oac imports are still kept lazy