### PR TITLE
Make Foundry CLI installation nonfatal

### DIFF
--- a/.changeset/friendly-clis-warn.md
+++ b/.changeset/friendly-clis-warn.md
@@ -1,0 +1,5 @@
+---
+"@osdk/integration-testing": patch
+---
+
+Warn instead of failing package installation when automatic Foundry CLI installation fails, and validate that it is installed when creating an integration client.

--- a/packages/integration-testing/src/createIntegrationClient.ts
+++ b/packages/integration-testing/src/createIntegrationClient.ts
@@ -25,9 +25,11 @@ import type {
 import type { Experiment } from "@osdk/api/unstable";
 import { createClient, type Client } from "@osdk/client";
 import { createMockClient } from "@osdk/unit-testing";
+import invariant from "tiny-invariant";
 import { fetch as undiciFetch, Agent } from "undici";
 
 import type { IntegrationClient, IntegrationClientConfig } from "./types.js";
+import { checkFoundryCliVersion } from "./utils/foundry-cli.js";
 
 /** The definition kinds accepted by {@link Client}'s call signatures. */
 type ClientArg =
@@ -39,6 +41,17 @@ type ClientArg =
   | Experiment<any>;
 
 export async function createIntegrationClient(
+  config: IntegrationClientConfig,
+): Promise<IntegrationClient> {
+  const foundryCli = await checkFoundryCliVersion();
+  invariant(
+    foundryCli.type !== "not-found",
+    "Foundry CLI must be installed before creating an integration client.",
+  );
+  return createIntegrationClientForRunningServer(config);
+}
+
+export async function createIntegrationClientForRunningServer(
   config: IntegrationClientConfig,
 ): Promise<IntegrationClient> {
   const { baseUrl, metadata, caCertPath } = config;

--- a/packages/integration-testing/src/createIntegrationServer.ts
+++ b/packages/integration-testing/src/createIntegrationServer.ts
@@ -25,7 +25,7 @@ import { Agent, fetch as undiciFetch } from "undici";
 
 import { CliServiceLauncher } from "./cli-service/CliServiceLauncher.js";
 import { OntologyServer } from "./cli-service/OntologyServer.js";
-import { createIntegrationClient } from "./createIntegrationClient.js";
+import { createIntegrationClientForRunningServer } from "./createIntegrationClient.js";
 import { createSeedClient } from "./createSeedClient.js";
 import type {
   IntegrationClient,
@@ -127,7 +127,7 @@ export async function createIntegrationServer(
       if (client !== undefined) return client;
       const baseUrl = ontology.getUrl();
       invariant(baseUrl, "Ontology server is not ready");
-      return (client = await createIntegrationClient({
+      return (client = await createIntegrationClientForRunningServer({
         baseUrl,
         metadata,
         caCertPath: ontology.getCaCertPath(),

--- a/packages/integration-testing/src/scripts/postinstall.ts
+++ b/packages/integration-testing/src/scripts/postinstall.ts
@@ -53,7 +53,14 @@ export const postinstall = async (): Promise<void> => {
       return;
     case "not-found":
       consola.info(`Foundry CLI not found locally, attempting to install...`);
-      await installFoundryCli();
+      try {
+        await installFoundryCli();
+      } catch (error) {
+        consola.warn(
+          `Failed to install Foundry CLI. It must be installed before creating an integration client.`,
+          error,
+        );
+      }
       return;
   }
 };

--- a/packages/integration-testing/src/test/createIntegrationClient.test.ts
+++ b/packages/integration-testing/src/test/createIntegrationClient.test.ts
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { expect, it, vi } from "vitest";
+
+import { createIntegrationClient } from "../createIntegrationClient.js";
+import { checkFoundryCliVersion } from "../utils/foundry-cli.js";
+import { EMPTY_ONTOLOGY_METADATA } from "./emptyOntologyMetadata.js";
+
+vi.mock("../utils/foundry-cli.js", () => ({
+  checkFoundryCliVersion: vi.fn(),
+}));
+
+it("throws when Foundry CLI is not installed", async () => {
+  vi.mocked(checkFoundryCliVersion).mockResolvedValue({ type: "not-found" });
+
+  await expect(
+    createIntegrationClient({
+      baseUrl: "https://localhost",
+      metadata: EMPTY_ONTOLOGY_METADATA,
+    }),
+  ).rejects.toThrow(
+    "Foundry CLI must be installed before creating an integration client.",
+  );
+});

--- a/packages/integration-testing/src/test/postinstall.test.ts
+++ b/packages/integration-testing/src/test/postinstall.test.ts
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import consola from "consola";
+import { beforeEach, expect, it, vi } from "vitest";
+
+import { installFoundryCli } from "../scripts/download.js";
+import { readGitRemoteUrl } from "../scripts/gitRemote.js";
+import { postinstall } from "../scripts/postinstall.js";
+import { checkFoundryCliVersion } from "../utils/foundry-cli.js";
+
+vi.mock("consola", () => ({
+  default: {
+    info: vi.fn(),
+    warn: vi.fn(),
+  },
+}));
+vi.mock("../utils/foundry-cli.js", () => ({
+  checkFoundryCliVersion: vi.fn(),
+  MIN_FOUNDRY_CLI_VERSION: "0.224.0",
+}));
+vi.mock("../scripts/gitRemote.js", () => ({
+  readGitRemoteUrl: vi.fn(),
+}));
+vi.mock("../scripts/download.js", () => ({
+  installFoundryCli: vi.fn(),
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(readGitRemoteUrl).mockResolvedValue(undefined);
+});
+
+it("warns without failing when Foundry CLI installation fails", async () => {
+  const error = new Error("installation failed");
+  vi.mocked(checkFoundryCliVersion).mockResolvedValue({ type: "not-found" });
+  vi.mocked(installFoundryCli).mockRejectedValue(error);
+
+  await expect(postinstall()).resolves.toBeUndefined();
+
+  expect(installFoundryCli).toHaveBeenCalledOnce();
+  expect(consola.warn).toHaveBeenCalledWith(
+    "Failed to install Foundry CLI. It must be installed before creating an integration client.",
+    error,
+  );
+});

--- a/packages/integration-testing/src/utils/foundry-cli.ts
+++ b/packages/integration-testing/src/utils/foundry-cli.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { exec } from "node:child_process";
+import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 
 import { gte, valid } from "semver";
@@ -46,11 +46,10 @@ const parseFoundryVersion = (stdout: string): string | undefined =>
 const versionIsAtMinimum = (version: string, min: string): boolean =>
   valid(version) != null && valid(min) != null && gte(version, min);
 
-const execAsync = promisify(exec);
+const execFileAsync = promisify(execFile);
 
 export const checkFoundryCliVersion = (): Promise<FoundryProbeResult> => {
-  return execAsync("which foundry")
-    .then(() => execAsync("foundry --version"))
+  return execFileAsync("foundry", ["--version"])
     .then<FoundryProbeResult>(({ stdout }) => {
       const version = parseFoundryVersion(stdout);
       if (!version) return { type: "version-error" };


### PR DESCRIPTION
## Summary
- catch automatic Foundry CLI installation failures during postinstall and warn instead of failing package installation
- require the Foundry CLI when creating an integration client directly
- probe the CLI executable directly and add regression coverage

## Testing
- `pnpm --filter @osdk/integration-testing test`
- `pnpm --filter @osdk/integration-testing typecheck`
- `pnpm --filter @osdk/integration-testing lint`
- `pnpm exec turbo run check-api --filter @osdk/integration-testing`
- `git diff --check`