### PR TITLE
Fix: Honor expected value of $isNull in client-side where matching

### DIFF
--- a/.changeset/tired-cats-dream.md
+++ b/.changeset/tired-cats-dream.md
@@ -1,0 +1,5 @@
+---
+"@osdk/client": patch
+---
+
+Honor expected value of $isNull in client-side where matching

--- a/packages/client/src/observable/internal/evaluateFilter.test.ts
+++ b/packages/client/src/observable/internal/evaluateFilter.test.ts
@@ -127,6 +127,17 @@ describe("evaluateFilter", () => {
       expect(evaluateFilter("$isNull", "value", true, true)).toBe(false);
       expect(evaluateFilter("$isNull", 0, true, true)).toBe(false);
     });
+
+    it("$isNull: false matches non-null values", () => {
+      expect(evaluateFilter("$isNull", "value", false, true)).toBe(true);
+      expect(evaluateFilter("$isNull", 0, false, true)).toBe(true);
+      expect(evaluateFilter("$isNull", false, false, true)).toBe(true);
+    });
+
+    it("$isNull: false does not match null values", () => {
+      expect(evaluateFilter("$isNull", null, false, true)).toBe(false);
+      expect(evaluateFilter("$isNull", undefined, false, true)).toBe(false);
+    });
   });
 
   describe("strict vs loose mode", () => {

--- a/packages/client/src/observable/internal/evaluateFilter.ts
+++ b/packages/client/src/observable/internal/evaluateFilter.ts
@@ -43,7 +43,7 @@ export function evaluateFilter(
     case "$in":
       return Array.isArray(expected) && expected.includes(realValue);
     case "$isNull":
-      return realValue == null;
+      return expected ? realValue == null : realValue != null;
     case "$startsWith":
       return typeof realValue === "string" && realValue.startsWith(expected);
     case "$contains":


### PR DESCRIPTION
Bug:
`evaluateFilter` ignored `$isNull`'s expected value:

```
case "$isNull":
  return realValue == null;   // `expected` never read
```

So `{ prop: { $isNull: false } } `("not null") was evaluated as "is null", returning false for every valid object.

Impact:
Objects silently disappear from observed lists. This bug was found when testing React OSDK with multiple components using a where clause that had `$isNull: false`.

Testing:
4 new evaluateFilter cases for $isNull: false
