### PR TITLE
[ScenariosV2] Add optional expireAfter when creating scenarios

### DIFF
--- a/.changeset/scenario-expire-after.md
+++ b/.changeset/scenario-expire-after.md
@@ -1,0 +1,5 @@
+---
+"@osdk/client": minor
+---
+
+Allow `createScenario` to accept an optional `expireAfter` timestamp

--- a/packages/client/src/scenarios/createScenario.test.ts
+++ b/packages/client/src/scenarios/createScenario.test.ts
@@ -75,6 +75,51 @@ describe("createScenario", () => {
     expect(url.searchParams.get("scenarioRid")).toBe(newScenarioRid);
   });
 
+  it("creates scenario with expireAfter", async () => {
+    const expireAfter = "2026-09-20T12:00:00.000Z";
+    const createResponse: CreateOntologyScenarioResponse = {
+      scenarioRid: "ri.actions..scenario.new",
+    };
+    mockFetchResponse(fetchFunction, createResponse);
+
+    await createScenario(client, { expireAfter });
+
+    expect(fetchFunction).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(fetchFunction.mock.calls[0][1]?.body as string)).toEqual({
+      expireAfter,
+    });
+  });
+
+  it("creates scenario with branch and expireAfter", async () => {
+    const branch = "my-branch";
+    const expireAfter = "2026-09-20T12:00:00.000Z";
+    const newScenarioRid = "ri.actions..scenario.new";
+
+    client = createClient(
+      "https://mock.com",
+      ontologyRid,
+      () => "Token",
+      { UNSTABLE_DO_NOT_USE_BRANCH: branch },
+      fetchFunction,
+    );
+
+    const createResponse: CreateOntologyScenarioResponse = {
+      scenarioRid: newScenarioRid,
+    };
+    mockFetchResponse(fetchFunction, createResponse);
+
+    await createScenario(client, { expireAfter });
+
+    expect(fetchFunction).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(fetchFunction.mock.calls[0][1]?.body as string)).toEqual({
+      base: {
+        type: "branch",
+        branch,
+      },
+      expireAfter,
+    });
+  });
+
   it("warns and ignores an active transaction, scoping to the new scenario", async () => {
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     const txClient = createClientWithTransaction(

--- a/packages/client/src/scenarios/createScenario.test.ts
+++ b/packages/client/src/scenarios/createScenario.test.ts
@@ -76,7 +76,7 @@ describe("createScenario", () => {
   });
 
   it("creates scenario with expireAfter", async () => {
-    const expireAfter = "2026-09-20T12:00:00.000Z";
+    const expireAfter = new Date("2026-09-20T12:00:00.000Z");
     const createResponse: CreateOntologyScenarioResponse = {
       scenarioRid: "ri.actions..scenario.new",
     };
@@ -86,13 +86,13 @@ describe("createScenario", () => {
 
     expect(fetchFunction).toHaveBeenCalledTimes(1);
     expect(JSON.parse(fetchFunction.mock.calls[0][1]?.body as string)).toEqual({
-      expireAfter,
+      expireAfter: expireAfter.toISOString(),
     });
   });
 
   it("creates scenario with branch and expireAfter", async () => {
     const branch = "my-branch";
-    const expireAfter = "2026-09-20T12:00:00.000Z";
+    const expireAfter = new Date("2026-09-20T12:00:00.000Z");
     const newScenarioRid = "ri.actions..scenario.new";
 
     client = createClient(
@@ -116,7 +116,7 @@ describe("createScenario", () => {
         type: "branch",
         branch,
       },
-      expireAfter,
+      expireAfter: expireAfter.toISOString(),
     });
   });
 

--- a/packages/client/src/scenarios/createScenario.ts
+++ b/packages/client/src/scenarios/createScenario.ts
@@ -42,7 +42,7 @@ import {
  * ```ts
  * import { createScenario } from "@osdk/client/unstable-do-not-use";
  *
- * const expireAfter = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+ * const expireAfter = new Date(Date.now() + 60 * 60 * 1000);
  * const scenario = await createScenario(client, { expireAfter });
  * const scenarioRid = scenario.getScenarioReference();
  * ```
@@ -50,7 +50,7 @@ import {
 export async function createScenario(
   client: Client,
   options?: {
-    expireAfter?: string;
+    expireAfter?: Date;
   },
 ): Promise<EXPERIMENTAL_ScenarioClient> {
   const ctx: MinimalClient = client[additionalContext];
@@ -68,7 +68,7 @@ export async function createScenario(
   }
 
   if (options?.expireAfter != null) {
-    request.expireAfter = options.expireAfter;
+    request.expireAfter = options.expireAfter.toISOString();
   }
 
   const response = await OntologyScenarios.createScenario(

--- a/packages/client/src/scenarios/createScenario.ts
+++ b/packages/client/src/scenarios/createScenario.ts
@@ -14,7 +14,10 @@
  * limitations under the License.
  */
 
-import { OntologyScenarios } from "@osdk/foundry.ontologies";
+import {
+  type CreateOntologyScenarioRequest,
+  OntologyScenarios,
+} from "@osdk/foundry.ontologies";
 
 import { additionalContext, type Client } from "../Client.js";
 import type { MinimalClient } from "../MinimalClientContext.js";
@@ -30,6 +33,7 @@ import {
  *   from. Throws at runtime if the client is already scoped to a scenario. If the client has an active transaction,
  *   the transaction is ignored (a warning is logged) and the client is scoped to the new scenario. When the base
  *   client has a branch set, the newly minted scenario uses that branch as its base.
+ * @param options - Optional settings for the new scenario.
  * @returns a {@link EXPERIMENTAL_ScenarioClient} bound to the freshly minted scenario RID.
  *
  * @beta This is an experimental, unstable feature subject to change.
@@ -38,12 +42,16 @@ import {
  * ```ts
  * import { createScenario } from "@osdk/client/unstable-do-not-use";
  *
- * const scenario = await createScenario(client);
+ * const expireAfter = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+ * const scenario = await createScenario(client, { expireAfter });
  * const scenarioRid = scenario.getScenarioReference();
  * ```
  */
 export async function createScenario(
   client: Client,
+  options?: {
+    expireAfter?: string;
+  },
 ): Promise<EXPERIMENTAL_ScenarioClient> {
   const ctx: MinimalClient = client[additionalContext];
 
@@ -53,10 +61,20 @@ export async function createScenario(
     );
   }
 
+  const request: CreateOntologyScenarioRequest = {};
+
+  if (ctx.branch != null) {
+    request.base = { type: "branch", branch: ctx.branch };
+  }
+
+  if (options?.expireAfter != null) {
+    request.expireAfter = options.expireAfter;
+  }
+
   const response = await OntologyScenarios.createScenario(
     ctx,
     await ctx.ontologyRid,
-    ctx.branch != null ? { base: { type: "branch", branch: ctx.branch } } : {},
+    request,
     { preview: true },
   );
 


### PR DESCRIPTION
# Description

Adds a `expireAfter` optional property when creating scenarios. Feature has been recently established in the backend, wiring it through here for end-to-end support.

# Tests

- Added a test for creating a scenario with `expireAfter`.
- Added a test confirming `expireAfter` works alongside a branch.