### PR TITLE
Have `branchPlugin` and `createClient` utilize the window for branch env var

### DIFF
--- a/.changeset/fresh-branches-refresh.md
+++ b/.changeset/fresh-branches-refresh.md
@@ -3,4 +3,4 @@
 "@osdk/vite-plugin-branch": patch
 ---
 
-Inject the current Foundry branch into application HTML so switching git branches cannot reuse a stale branch from Vite's optimized dependency cache. The client now reads this runtime value from `window`, while the Vite plugin accepts the server-only `FOUNDRY_BRANCH_RID` override during development and production builds. Replace any `VITE_FOUNDRY_BRANCH_RID` override with `FOUNDRY_BRANCH_RID`.
+Inject the current Foundry branch into a CSP-safe HTML meta tag so switching git branches cannot reuse a stale branch from Vite's optimized dependency cache. The client reads this runtime value from the document, while the Vite plugin accepts the server-only `FOUNDRY_BRANCH_RID` override during development and production builds. Replace any `VITE_FOUNDRY_BRANCH_RID` override with `FOUNDRY_BRANCH_RID`.

--- a/.changeset/fresh-branches-refresh.md
+++ b/.changeset/fresh-branches-refresh.md
@@ -1,0 +1,6 @@
+---
+"@osdk/client": patch
+"@osdk/vite-plugin-branch": patch
+---
+
+Inject the current Foundry branch into application HTML so switching git branches cannot reuse a stale branch from Vite's optimized dependency cache. The client now reads this runtime value from `window`, while the Vite plugin accepts the server-only `FOUNDRY_BRANCH_RID` override during development and production builds. Replace any `VITE_FOUNDRY_BRANCH_RID` override with `FOUNDRY_BRANCH_RID`.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,6 @@ on:
       - main
       - release/*
       - next
-      - ading/window
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
@@ -77,7 +76,7 @@ jobs:
         run: pnpm exec turbo run build
 
       - name: Update versions for snapshots
-        run: pnpm exec changeset version --snapshot ${GITHUB_REF_NAME//\//-}
+        run: pnpm exec changeset version --snapshot ${GITHUB_REF_NAME//\//__}
 
       - name: Make sure code is up to date
         run: pnpm exec turbo run postVersioning
@@ -86,4 +85,4 @@ jobs:
         run: pnpm exec turbo run build
 
       - name: Publish results
-        run: pnpm exec changeset publish --no-git-tag --tag next-${GITHUB_REF_NAME//\//-}
+        run: pnpm exec changeset publish --no-git-tag --tag next-${GITHUB_REF_NAME//\//__}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ on:
       - main
       - release/*
       - next
+      - ading/window
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 
@@ -76,7 +77,7 @@ jobs:
         run: pnpm exec turbo run build
 
       - name: Update versions for snapshots
-        run: pnpm exec changeset version --snapshot ${GITHUB_REF_NAME//\//__}
+        run: pnpm exec changeset version --snapshot ${GITHUB_REF_NAME//\//-}
 
       - name: Make sure code is up to date
         run: pnpm exec turbo run postVersioning
@@ -85,4 +86,4 @@ jobs:
         run: pnpm exec turbo run build
 
       - name: Publish results
-        run: pnpm exec changeset publish --no-git-tag --tag next-${GITHUB_REF_NAME//\//__}
+        run: pnpm exec changeset publish --no-git-tag --tag next-${GITHUB_REF_NAME//\//-}

--- a/packages/client/src/createClient.ts
+++ b/packages/client/src/createClient.ts
@@ -414,11 +414,10 @@ export function createClientFromContext(clientCtx: MinimalClient) {
  * @param options - Optional client configuration: a custom `logger`, an experimental `UNSTABLE_DO_NOT_USE_BRANCH`
  *   for branch-aware requests, and additional `headers` to include on every request.
  *
- *   The client is branch-aware without configuration. If `UNSTABLE_DO_NOT_USE_BRANCH` is not supplied, the
- *   branch is read from the `VITE_FOUNDRY_BRANCH_RID` environment variable, which Foundry runtimes set to
- *   the branch the application is checked out on; objects, actions, and queries then read and write on that
- *   branch. An explicitly supplied branch always takes precedence, and `null` pins the client to the default
- *   branch even while checked out on a branch.
+ *   The client is branch-aware without configuration. If `UNSTABLE_DO_NOT_USE_BRANCH` is not supplied, build
+ *   tooling can inject the branch into the application HTML; objects, actions, and queries then read and write
+ *   on that branch. An explicitly supplied branch always takes precedence, and `null` pins the client to the
+ *   default branch even while checked out on a branch.
  * @param fetchFn - An optional `fetch` implementation to use for all requests. Defaults to the global `fetch`.
  * @example
  * ```ts
@@ -450,10 +449,10 @@ export const createClient: (
         /**
          * The Foundry branch to scope every request to.
          *
-         * When omitted (or `undefined`), the branch is read from the
-         * `VITE_FOUNDRY_BRANCH_RID` environment variable, which Foundry runtimes
-         * set to the branch the application is checked out on. Pass `null` to
-         * ignore the environment and use the default branch.
+         * When omitted (or `undefined`), the branch is read from runtime
+         * configuration injected into the application HTML by OSDK build
+         * tooling. Pass `null` to ignore the injected branch and use the
+         * default branch.
          *
          * @beta This is an experimental feature subject to change
          */

--- a/packages/client/src/util/resolveBranch.test.ts
+++ b/packages/client/src/util/resolveBranch.test.ts
@@ -20,6 +20,7 @@ import { resolveBranch } from "./resolveBranch.js";
 
 const INJECTED_BRANCH = "ri.foundry.main.branch.from-html";
 const EXPLICIT_BRANCH = "ri.foundry.main.branch.from-code";
+const META_SELECTOR = 'meta[name="osdk-foundry-branch-rid"]';
 
 afterEach(() => {
   vi.unstubAllGlobals();
@@ -82,25 +83,31 @@ describe(resolveBranch, () => {
     expect(resolveBranch(explicitBranch, injectedBranch)).toBe(expected);
   });
 
-  it("reads the branch from window by default", () => {
-    vi.stubGlobal("window", {
-      __OSDK_FOUNDRY_BRANCH_RID__: INJECTED_BRANCH,
+  it("reads the branch from HTML metadata by default", () => {
+    const getAttribute = vi.fn(() => INJECTED_BRANCH);
+    const querySelector = vi.fn(() => ({ getAttribute }));
+    vi.stubGlobal("document", {
+      querySelector,
     });
 
     expect(resolveBranch(undefined)).toBe(INJECTED_BRANCH);
+    expect(querySelector).toHaveBeenCalledWith(META_SELECTOR);
+    expect(getAttribute).toHaveBeenCalledWith("content");
   });
 
-  it("uses the default branch when window is missing", () => {
-    vi.stubGlobal("window", undefined);
+  it("uses the default branch when document is missing", () => {
+    vi.stubGlobal("document", undefined);
 
     expect(resolveBranch(undefined)).toBeUndefined();
   });
 
-  it("uses the default branch when the window property is missing or null", () => {
-    vi.stubGlobal("window", {});
+  it("uses the default branch when the meta tag or content is missing", () => {
+    vi.stubGlobal("document", { querySelector: () => null });
     expect(resolveBranch(undefined)).toBeUndefined();
 
-    vi.stubGlobal("window", { __OSDK_FOUNDRY_BRANCH_RID__: null });
+    vi.stubGlobal("document", {
+      querySelector: () => ({ getAttribute: () => null }),
+    });
     expect(resolveBranch(undefined)).toBeUndefined();
   });
 });

--- a/packages/client/src/util/resolveBranch.test.ts
+++ b/packages/client/src/util/resolveBranch.test.ts
@@ -14,79 +14,93 @@
  * limitations under the License.
  */
 
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
-import { FOUNDRY_BRANCH_RID_ENV_VAR, resolveBranch } from "./resolveBranch.js";
+import { resolveBranch } from "./resolveBranch.js";
 
-const ENV_BRANCH = "ri.foundry.main.branch.from-environment";
+const INJECTED_BRANCH = "ri.foundry.main.branch.from-html";
 const EXPLICIT_BRANCH = "ri.foundry.main.branch.from-code";
 
-type Env = Record<string, string | undefined> | undefined;
-
-/**
- * The environment is injected rather than stubbed: Vite substitutes
- * `import.meta.env` with a snapshot taken when the bundler (or, here, Vitest)
- * starts, so `vi.stubEnv` cannot reach the value a source module reads.
- */
-function envWith(branch: string | undefined): Env {
-  return { [FOUNDRY_BRANCH_RID_ENV_VAR]: branch };
-}
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
 
 describe(resolveBranch, () => {
-  it.each<[string, string | null | undefined, Env, string | undefined]>([
+  it.each<
     [
-      "falls back to the environment",
+      string,
+      string | null | undefined,
+      string | null | undefined,
+      string | undefined,
+    ]
+  >([
+    [
+      "falls back to the injected branch",
       undefined,
-      envWith(ENV_BRANCH),
-      ENV_BRANCH,
+      INJECTED_BRANCH,
+      INJECTED_BRANCH,
     ],
     [
-      "prefers an explicit branch over the environment",
+      "prefers an explicit branch over the injected branch",
       EXPLICIT_BRANCH,
-      envWith(ENV_BRANCH),
+      INJECTED_BRANCH,
       EXPLICIT_BRANCH,
     ],
     [
       "treats null as pinning to the default branch",
       null,
-      envWith(ENV_BRANCH),
+      INJECTED_BRANCH,
       undefined,
     ],
     [
       "does not fall back for a blank explicit branch",
       "  ",
-      envWith(ENV_BRANCH),
+      INJECTED_BRANCH,
       undefined,
     ],
     [
-      "trims the environment value",
+      "trims the injected value",
       undefined,
-      envWith(`  ${ENV_BRANCH}\n`),
-      ENV_BRANCH,
+      `  ${INJECTED_BRANCH}\n`,
+      INJECTED_BRANCH,
     ],
+    ["treats a blank injected value as unset", undefined, "   ", undefined],
     [
-      "treats a blank environment value as unset",
-      undefined,
-      envWith("   "),
-      undefined,
-    ],
-    [
-      // Local development passes a branch name for the backend to resolve, so a
-      // rid-only check would break it.
       "accepts a branch name that is not a rid",
       undefined,
-      envWith("my-feature-branch"),
+      "my-feature-branch",
       "my-feature-branch",
     ],
-    ["returns undefined when the variable is unset", undefined, {}, undefined],
-    // No `import.meta.env` at all: the CJS build and plain Node ESM.
+    ["returns undefined for injected null", undefined, null, undefined],
     [
-      "returns undefined when there is no environment",
+      "returns undefined when no branch was injected",
       undefined,
       undefined,
       undefined,
     ],
-  ])("%s", (_description, explicitBranch, env, expected) => {
-    expect(resolveBranch(explicitBranch, env)).toBe(expected);
+  ])("%s", (_description, explicitBranch, injectedBranch, expected) => {
+    expect(resolveBranch(explicitBranch, injectedBranch)).toBe(expected);
+  });
+
+  it("reads the branch from window by default", () => {
+    vi.stubGlobal("window", {
+      __OSDK_FOUNDRY_BRANCH_RID__: INJECTED_BRANCH,
+    });
+
+    expect(resolveBranch(undefined)).toBe(INJECTED_BRANCH);
+  });
+
+  it("uses the default branch when window is missing", () => {
+    vi.stubGlobal("window", undefined);
+
+    expect(resolveBranch(undefined)).toBeUndefined();
+  });
+
+  it("uses the default branch when the window property is missing or null", () => {
+    vi.stubGlobal("window", {});
+    expect(resolveBranch(undefined)).toBeUndefined();
+
+    vi.stubGlobal("window", { __OSDK_FOUNDRY_BRANCH_RID__: null });
+    expect(resolveBranch(undefined)).toBeUndefined();
   });
 });

--- a/packages/client/src/util/resolveBranch.ts
+++ b/packages/client/src/util/resolveBranch.ts
@@ -14,18 +14,15 @@
  * limitations under the License.
  */
 
-declare global {
-  interface Window {
-    /** The branch injected into application HTML by OSDK build tooling. */
-    __OSDK_FOUNDRY_BRANCH_RID__?: string | null;
-  }
-}
+const FOUNDRY_BRANCH_META_SELECTOR = 'meta[name="osdk-foundry-branch-rid"]';
 
 /** Reads the injected branch without requiring a browser environment. */
 function getInjectedBranch(): string | null | undefined {
-  return typeof window === "undefined"
+  return typeof document === "undefined"
     ? undefined
-    : window.__OSDK_FOUNDRY_BRANCH_RID__;
+    : document
+        .querySelector(FOUNDRY_BRANCH_META_SELECTOR)
+        ?.getAttribute("content");
 }
 
 /**
@@ -58,7 +55,8 @@ function normalizeBranch(
  *
  * @param explicitBranch - the branch supplied by the caller, if any
  * @param injectedBranch - the branch injected by build tooling. Defaults to
- *   the value on `window`; supply it to test without a browser environment.
+ *   the value in the OSDK branch meta tag; supply it to test without a browser
+ *   environment.
  */
 export function resolveBranch(
   explicitBranch: string | null | undefined,

--- a/packages/client/src/util/resolveBranch.ts
+++ b/packages/client/src/util/resolveBranch.ts
@@ -14,24 +14,18 @@
  * limitations under the License.
  */
 
-/**
- * The environment variable that a Foundry runtime sets to the RID of the branch
- * the application is currently checked out on.
- *
- * It is set by the in-platform dev server, by CI when building a pull request
- * preview, and by local tooling. When it is absent the application is running
- * against the default (`main`) branch.
- */
-export const FOUNDRY_BRANCH_RID_ENV_VAR: string = "VITE_FOUNDRY_BRANCH_RID";
+declare global {
+  interface Window {
+    /** The branch injected into application HTML by OSDK build tooling. */
+    __OSDK_FOUNDRY_BRANCH_RID__?: string | null;
+  }
+}
 
-/**
- * Reads the whole `import.meta.env` object so builds without it safely return
- * `undefined`. A direct member access would fail in the CommonJS build.
- */
-function getImportMetaEnv(): Record<string, string | undefined> | undefined {
-  return (
-    import.meta as ImportMeta & { env?: Record<string, string | undefined> }
-  ).env;
+/** Reads the injected branch without requiring a browser environment. */
+function getInjectedBranch(): string | null | undefined {
+  return typeof window === "undefined"
+    ? undefined
+    : window.__OSDK_FOUNDRY_BRANCH_RID__;
 }
 
 /**
@@ -58,19 +52,19 @@ function normalizeBranch(
  *
  * `undefined` — including the `undefined` that a generated SDK's `$branch`
  * export carries when the SDK was generated against the default branch — falls
- * back to {@link FOUNDRY_BRANCH_RID_ENV_VAR}. That fallback is the point: a
- * repository checked out on a branch reads that branch's data even if its
- * generated SDK predates the checkout.
+ * back to the branch injected into the application HTML. That fallback is the
+ * point: a repository checked out on a branch reads that branch's data even if
+ * its generated SDK predates the checkout.
  *
  * @param explicitBranch - the branch supplied by the caller, if any
- * @param env - the environment to read from. Defaults to `import.meta.env`;
- *   supply it to test without depending on the ambient environment.
+ * @param injectedBranch - the branch injected by build tooling. Defaults to
+ *   the value on `window`; supply it to test without a browser environment.
  */
 export function resolveBranch(
   explicitBranch: string | null | undefined,
-  env: Record<string, string | undefined> | undefined = getImportMetaEnv(),
+  injectedBranch: string | null | undefined = getInjectedBranch(),
 ): string | undefined {
   return explicitBranch !== undefined
     ? normalizeBranch(explicitBranch)
-    : normalizeBranch(env?.[FOUNDRY_BRANCH_RID_ENV_VAR]);
+    : normalizeBranch(injectedBranch);
 }

--- a/packages/vite-plugin-branch/src/branchPlugin.test.ts
+++ b/packages/vite-plugin-branch/src/branchPlugin.test.ts
@@ -17,25 +17,29 @@
 import {
   mkdirSync,
   mkdtempSync,
+  readFileSync,
+  readdirSync,
   realpathSync,
   rmSync,
   writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
+import { runInNewContext } from "node:vm";
 
 import {
+  build,
   createServer,
-  type ConfigEnv,
+  type IndexHtmlTransformContext,
   type Plugin,
   type ResolvedConfig,
-  type UserConfig,
 } from "vite";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { branchPlugin, FOUNDRY_BRANCH_ENV_VAR } from "./branchPlugin.js";
 
 const GIT_BRANCH = "zka/my-branch";
+const WINDOW_PROPERTY = "__OSDK_FOUNDRY_BRANCH_RID__";
 
 const tempDirs: string[] = [];
 
@@ -50,39 +54,52 @@ function makeProjectDir(envFiles: Record<string, string> = {}): string {
   return dir;
 }
 
-async function runConfigHook(
+function configurePlugin(
   plugin: Plugin,
-  config: UserConfig,
-  mode = "development",
-): Promise<void> {
-  const hook = plugin.config;
-  if (typeof hook !== "function") {
-    throw new TypeError("expected config to be a function hook");
-  }
-  const env: ConfigEnv = {
-    command: "serve",
-    mode,
-    isSsrBuild: false,
-    isPreview: false,
-  };
-  await hook(config, env);
-}
-
-function runConfigResolvedHook(plugin: Plugin): string[] {
+  root: string,
+  options: { envDir?: string | false; mode?: string } = {},
+): string[] {
   const hook = plugin.configResolved;
   if (typeof hook !== "function") {
     throw new TypeError("expected configResolved to be a function hook");
   }
   const messages: string[] = [];
   hook({
-    logger: { info: (msg: string) => messages.push(msg) },
+    root,
+    envDir: options.envDir ?? root,
+    mode: options.mode ?? "development",
+    logger: { info: (message: string) => messages.push(message) },
   } as unknown as ResolvedConfig);
   return messages;
+}
+
+async function readInjectedScript(plugin: Plugin): Promise<string> {
+  const hook = plugin.transformIndexHtml;
+  if (typeof hook !== "function") {
+    throw new TypeError("expected transformIndexHtml to be a function hook");
+  }
+  const result = await hook("", {} as unknown as IndexHtmlTransformContext);
+  if (!Array.isArray(result) || result.length !== 1) {
+    throw new TypeError("expected one injected HTML tag");
+  }
+  const [tag] = result;
+  if (
+    tag.tag !== "script" ||
+    tag.injectTo !== "head-prepend" ||
+    typeof tag.children !== "string"
+  ) {
+    throw new TypeError("expected a head-prepend script");
+  }
+  return tag.children;
 }
 
 function pluginOn(gitBranch: string | undefined): Plugin {
   return branchPlugin({ readGitBranch: () => Promise.resolve(gitBranch) });
 }
+
+beforeEach(() => {
+  Reflect.deleteProperty(process.env, FOUNDRY_BRANCH_ENV_VAR);
+});
 
 afterEach(() => {
   Reflect.deleteProperty(process.env, FOUNDRY_BRANCH_ENV_VAR);
@@ -92,100 +109,147 @@ afterEach(() => {
 });
 
 describe(branchPlugin, () => {
-  it("only applies to the dev server", () => {
-    expect(branchPlugin().apply).toBe("serve");
+  it("applies during development and production builds", () => {
+    expect(branchPlugin().apply).toBeUndefined();
   });
 
-  it("injects the current git branch", async () => {
-    await runConfigHook(pluginOn(GIT_BRANCH), { root: makeProjectDir() });
+  it("injects the current git branch into HTML", async () => {
+    const plugin = pluginOn(GIT_BRANCH);
+    configurePlugin(plugin, makeProjectDir());
 
-    expect(process.env[FOUNDRY_BRANCH_ENV_VAR]).toBe(GIT_BRANCH);
+    expect(await readInjectedScript(plugin)).toBe(
+      `window.${WINDOW_PROPERTY} = "${GIT_BRANCH}";`,
+    );
   });
 
-  it("injects nothing on main", async () => {
-    await runConfigHook(pluginOn("main"), { root: makeProjectDir() });
+  it.each(["main", "master", "HEAD", undefined])(
+    "injects null for the default branch state %s",
+    async (gitBranch) => {
+      const plugin = pluginOn(gitBranch);
+      configurePlugin(plugin, makeProjectDir());
 
-    expect(process.env[FOUNDRY_BRANCH_ENV_VAR]).toBeUndefined();
-  });
+      expect(await readInjectedScript(plugin)).toBe(
+        `window.${WINDOW_PROPERTY} = null;`,
+      );
+    },
+  );
 
-  it("injects nothing when the directory is not a repository", async () => {
-    await runConfigHook(pluginOn(undefined), { root: makeProjectDir() });
-
-    expect(process.env[FOUNDRY_BRANCH_ENV_VAR]).toBeUndefined();
-  });
-
-  it("does not overwrite a branch pinned in a .env file", async () => {
+  it("uses a branch from a .env file instead of git", async () => {
+    const configuredBranch = "ri.foundry.main.branch.pinned";
     const root = makeProjectDir({
-      ".env.development": `${FOUNDRY_BRANCH_ENV_VAR}=ri.foundry.main.branch.pinned\n`,
+      ".env.development": `${FOUNDRY_BRANCH_ENV_VAR}=${configuredBranch}\n`,
     });
+    const readGitBranch = vi.fn(() => Promise.resolve(GIT_BRANCH));
+    const plugin = branchPlugin({ readGitBranch });
+    configurePlugin(plugin, root);
 
-    await runConfigHook(pluginOn(GIT_BRANCH), { root });
-
-    expect(process.env[FOUNDRY_BRANCH_ENV_VAR]).toBeUndefined();
+    expect(await readInjectedScript(plugin)).toContain(
+      JSON.stringify(configuredBranch),
+    );
+    expect(readGitBranch).not.toHaveBeenCalled();
   });
 
-  it("does not overwrite a blank value in a .env file", async () => {
+  it("treats a blank .env override as the default branch", async () => {
     const root = makeProjectDir({
       ".env.development": `${FOUNDRY_BRANCH_ENV_VAR}=   \n`,
     });
+    const readGitBranch = vi.fn(() => Promise.resolve(GIT_BRANCH));
+    const plugin = branchPlugin({ readGitBranch });
+    configurePlugin(plugin, root);
 
-    await runConfigHook(pluginOn(GIT_BRANCH), { root });
-
-    expect(process.env[FOUNDRY_BRANCH_ENV_VAR]).toBeUndefined();
-  });
-
-  it("does not overwrite a branch already in process.env", async () => {
-    process.env[FOUNDRY_BRANCH_ENV_VAR] = "ri.foundry.main.branch.from-ci";
-
-    await runConfigHook(pluginOn(GIT_BRANCH), { root: makeProjectDir() });
-
-    expect(process.env[FOUNDRY_BRANCH_ENV_VAR]).toBe(
-      "ri.foundry.main.branch.from-ci",
+    expect(await readInjectedScript(plugin)).toBe(
+      `window.${WINDOW_PROPERTY} = null;`,
     );
+    expect(readGitBranch).not.toHaveBeenCalled();
   });
 
-  it("reads .env files from a relative envDir", async () => {
+  it("gives process.env precedence over .env files and git", async () => {
+    const processBranch = "ri.foundry.main.branch.from-ci";
+    process.env[FOUNDRY_BRANCH_ENV_VAR] = processBranch;
+    const root = makeProjectDir({
+      ".env.development": `${FOUNDRY_BRANCH_ENV_VAR}=from-file\n`,
+    });
+    const readGitBranch = vi.fn(() => Promise.resolve(GIT_BRANCH));
+    const plugin = branchPlugin({ readGitBranch });
+    configurePlugin(plugin, root);
+
+    expect(await readInjectedScript(plugin)).toContain(
+      JSON.stringify(processBranch),
+    );
+    expect(readGitBranch).not.toHaveBeenCalled();
+  });
+
+  it("reads .env files from the resolved envDir", async () => {
+    const configuredBranch = "ri.foundry.main.branch.pinned";
     const root = makeProjectDir();
-    mkdirSync(path.join(root, "config"));
+    const envDir = path.join(root, "config");
+    mkdirSync(envDir);
     writeFileSync(
-      path.join(root, "config", ".env.development"),
-      `${FOUNDRY_BRANCH_ENV_VAR}=ri.foundry.main.branch.pinned\n`,
+      path.join(envDir, ".env.development"),
+      `${FOUNDRY_BRANCH_ENV_VAR}=${configuredBranch}\n`,
     );
+    const plugin = pluginOn(GIT_BRANCH);
+    configurePlugin(plugin, root, { envDir });
 
-    await runConfigHook(pluginOn(GIT_BRANCH), { root, envDir: "config" });
-
-    expect(process.env[FOUNDRY_BRANCH_ENV_VAR]).toBeUndefined();
+    expect(await readInjectedScript(plugin)).toContain(
+      JSON.stringify(configuredBranch),
+    );
   });
 
-  it("reports the injected branch through Vite's logger", async () => {
-    const plugin = pluginOn(GIT_BRANCH);
-    await runConfigHook(plugin, { root: makeProjectDir() });
+  it("resolves git again for every HTML transformation", async () => {
+    let gitBranch = "first-branch";
+    const plugin = branchPlugin({
+      readGitBranch: () => Promise.resolve(gitBranch),
+    });
+    configurePlugin(plugin, makeProjectDir());
 
-    expect(runConfigResolvedHook(plugin)).toEqual([
-      expect.stringContaining(GIT_BRANCH),
+    expect(await readInjectedScript(plugin)).toContain('"first-branch"');
+    gitBranch = "second-branch";
+    expect(await readInjectedScript(plugin)).toContain('"second-branch"');
+  });
+
+  it("reports each newly resolved feature branch through Vite's logger", async () => {
+    let gitBranch = "first-branch";
+    const plugin = branchPlugin({
+      readGitBranch: () => Promise.resolve(gitBranch),
+    });
+    const messages = configurePlugin(plugin, makeProjectDir());
+
+    await readInjectedScript(plugin);
+    await readInjectedScript(plugin);
+    gitBranch = "second-branch";
+    await readInjectedScript(plugin);
+
+    expect(messages).toEqual([
+      expect.stringContaining("first-branch"),
+      expect.stringContaining("second-branch"),
     ]);
   });
 
-  it("stays quiet when nothing is injected", async () => {
-    const plugin = pluginOn("main");
-    await runConfigHook(plugin, { root: makeProjectDir() });
+  it("serializes hostile branch names without terminating the script", async () => {
+    const gitBranch =
+      'feature/"quote"\n</script><script>bad()</script>\u2028\u2029suffix';
+    const plugin = pluginOn(gitBranch);
+    configurePlugin(plugin, makeProjectDir());
 
-    expect(runConfigResolvedHook(plugin)).toEqual([]);
+    const script = await readInjectedScript(plugin);
+    expect(script).not.toContain("</script>");
+    expect(script).toContain("\\u003c/script>");
+    expect(script).toContain("\\n");
+    expect(script).toContain("\\u2028");
+    expect(script).toContain("\\u2029");
+
+    const context = { window: {} as Record<string, unknown> };
+    runInNewContext(script, context);
+    expect(context.window).toEqual({ [WINDOW_PROPERTY]: gitBranch });
   });
 });
 
-describe("injection reaches import.meta.env", () => {
-  it("substitutes the branch into a served module", async () => {
+describe("Vite integration", () => {
+  it("prepends the branch script to served HTML", async () => {
     const root = makeProjectDir();
-    writeFileSync(
-      path.join(root, "read.js"),
-      [
-        `const KEY = ${JSON.stringify(FOUNDRY_BRANCH_ENV_VAR)};`,
-        `function getEnv() { return import.meta.env; }`,
-        `export const branch = getEnv()?.[KEY];`,
-      ].join("\n"),
-    );
-
+    const html =
+      '<html><head></head><body><script type="module" src="/main.js"></script></body></html>';
     const server = await createServer({
       root,
       configFile: false,
@@ -193,14 +257,45 @@ describe("injection reaches import.meta.env", () => {
       plugins: [pluginOn(GIT_BRANCH)],
     });
     try {
-      const result =
-        await server.environments.client.transformRequest("/read.js");
-
-      expect(result?.code).toContain(
-        `"${FOUNDRY_BRANCH_ENV_VAR}": "${GIT_BRANCH}"`,
+      const transformed = await server.transformIndexHtml("/", html);
+      expect(transformed.indexOf(WINDOW_PROPERTY)).toBeLessThan(
+        transformed.indexOf('src="/main.js"'),
       );
+      expect(transformed).toContain(JSON.stringify(GIT_BRANCH));
     } finally {
       await server.close();
     }
+  });
+
+  it("writes the branch to built HTML instead of JavaScript chunks", async () => {
+    const buildBranch = "feature/build-branch";
+    const root = makeProjectDir();
+    writeFileSync(
+      path.join(root, "index.html"),
+      '<html><head></head><body><script type="module" src="/main.js"></script></body></html>',
+    );
+    writeFileSync(path.join(root, "main.js"), "globalThis.appStarted = true;");
+
+    await build({
+      root,
+      configFile: false,
+      logLevel: "silent",
+      plugins: [pluginOn(buildBranch)],
+      build: { minify: false },
+    });
+
+    const builtHtml = readFileSync(path.join(root, "dist/index.html"), "utf-8");
+    expect(builtHtml).toContain(JSON.stringify(buildBranch));
+    expect(builtHtml.indexOf(WINDOW_PROPERTY)).toBeLessThan(
+      builtHtml.indexOf('type="module"'),
+    );
+
+    const builtJavaScript = readdirSync(path.join(root, "dist/assets"))
+      .filter((file) => file.endsWith(".js"))
+      .map((file) =>
+        readFileSync(path.join(root, "dist/assets", file), "utf-8"),
+      )
+      .join("\n");
+    expect(builtJavaScript).not.toContain(buildBranch);
   });
 });

--- a/packages/vite-plugin-branch/src/branchPlugin.test.ts
+++ b/packages/vite-plugin-branch/src/branchPlugin.test.ts
@@ -25,7 +25,6 @@ import {
 } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { runInNewContext } from "node:vm";
 
 import {
   build,
@@ -39,7 +38,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { branchPlugin, FOUNDRY_BRANCH_ENV_VAR } from "./branchPlugin.js";
 
 const GIT_BRANCH = "zka/my-branch";
-const WINDOW_PROPERTY = "__OSDK_FOUNDRY_BRANCH_RID__";
+const META_NAME = "osdk-foundry-branch-rid";
 
 const tempDirs: string[] = [];
 
@@ -73,7 +72,7 @@ function configurePlugin(
   return messages;
 }
 
-async function readInjectedScript(plugin: Plugin): Promise<string> {
+async function readInjectedMetaContent(plugin: Plugin): Promise<string> {
   const hook = plugin.transformIndexHtml;
   if (typeof hook !== "function") {
     throw new TypeError("expected transformIndexHtml to be a function hook");
@@ -84,13 +83,14 @@ async function readInjectedScript(plugin: Plugin): Promise<string> {
   }
   const [tag] = result;
   if (
-    tag.tag !== "script" ||
+    tag.tag !== "meta" ||
     tag.injectTo !== "head-prepend" ||
-    typeof tag.children !== "string"
+    tag.attrs?.name !== META_NAME ||
+    typeof tag.attrs.content !== "string"
   ) {
-    throw new TypeError("expected a head-prepend script");
+    throw new TypeError("expected a head-prepend branch meta tag");
   }
-  return tag.children;
+  return tag.attrs.content;
 }
 
 function pluginOn(gitBranch: string | undefined): Plugin {
@@ -117,20 +117,16 @@ describe(branchPlugin, () => {
     const plugin = pluginOn(GIT_BRANCH);
     configurePlugin(plugin, makeProjectDir());
 
-    expect(await readInjectedScript(plugin)).toBe(
-      `window.${WINDOW_PROPERTY} = "${GIT_BRANCH}";`,
-    );
+    expect(await readInjectedMetaContent(plugin)).toBe(GIT_BRANCH);
   });
 
   it.each(["main", "master", "HEAD", undefined])(
-    "injects null for the default branch state %s",
+    "injects an empty value for the default branch state %s",
     async (gitBranch) => {
       const plugin = pluginOn(gitBranch);
       configurePlugin(plugin, makeProjectDir());
 
-      expect(await readInjectedScript(plugin)).toBe(
-        `window.${WINDOW_PROPERTY} = null;`,
-      );
+      expect(await readInjectedMetaContent(plugin)).toBe("");
     },
   );
 
@@ -143,9 +139,7 @@ describe(branchPlugin, () => {
     const plugin = branchPlugin({ readGitBranch });
     configurePlugin(plugin, root);
 
-    expect(await readInjectedScript(plugin)).toContain(
-      JSON.stringify(configuredBranch),
-    );
+    expect(await readInjectedMetaContent(plugin)).toBe(configuredBranch);
     expect(readGitBranch).not.toHaveBeenCalled();
   });
 
@@ -157,9 +151,7 @@ describe(branchPlugin, () => {
     const plugin = branchPlugin({ readGitBranch });
     configurePlugin(plugin, root);
 
-    expect(await readInjectedScript(plugin)).toBe(
-      `window.${WINDOW_PROPERTY} = null;`,
-    );
+    expect(await readInjectedMetaContent(plugin)).toBe("");
     expect(readGitBranch).not.toHaveBeenCalled();
   });
 
@@ -173,9 +165,7 @@ describe(branchPlugin, () => {
     const plugin = branchPlugin({ readGitBranch });
     configurePlugin(plugin, root);
 
-    expect(await readInjectedScript(plugin)).toContain(
-      JSON.stringify(processBranch),
-    );
+    expect(await readInjectedMetaContent(plugin)).toBe(processBranch);
     expect(readGitBranch).not.toHaveBeenCalled();
   });
 
@@ -191,9 +181,7 @@ describe(branchPlugin, () => {
     const plugin = pluginOn(GIT_BRANCH);
     configurePlugin(plugin, root, { envDir });
 
-    expect(await readInjectedScript(plugin)).toContain(
-      JSON.stringify(configuredBranch),
-    );
+    expect(await readInjectedMetaContent(plugin)).toBe(configuredBranch);
   });
 
   it("resolves git again for every HTML transformation", async () => {
@@ -203,9 +191,9 @@ describe(branchPlugin, () => {
     });
     configurePlugin(plugin, makeProjectDir());
 
-    expect(await readInjectedScript(plugin)).toContain('"first-branch"');
+    expect(await readInjectedMetaContent(plugin)).toBe("first-branch");
     gitBranch = "second-branch";
-    expect(await readInjectedScript(plugin)).toContain('"second-branch"');
+    expect(await readInjectedMetaContent(plugin)).toBe("second-branch");
   });
 
   it("reports each newly resolved feature branch through Vite's logger", async () => {
@@ -215,10 +203,10 @@ describe(branchPlugin, () => {
     });
     const messages = configurePlugin(plugin, makeProjectDir());
 
-    await readInjectedScript(plugin);
-    await readInjectedScript(plugin);
+    await readInjectedMetaContent(plugin);
+    await readInjectedMetaContent(plugin);
     gitBranch = "second-branch";
-    await readInjectedScript(plugin);
+    await readInjectedMetaContent(plugin);
 
     expect(messages).toEqual([
       expect.stringContaining("first-branch"),
@@ -226,27 +214,17 @@ describe(branchPlugin, () => {
     ]);
   });
 
-  it("serializes hostile branch names without terminating the script", async () => {
-    const gitBranch =
-      'feature/"quote"\n</script><script>bad()</script>\u2028\u2029suffix';
+  it("preserves branch names for Vite to serialize as HTML attributes", async () => {
+    const gitBranch = 'feature/"quote"><script>bad()</script>&suffix';
     const plugin = pluginOn(gitBranch);
     configurePlugin(plugin, makeProjectDir());
 
-    const script = await readInjectedScript(plugin);
-    expect(script).not.toContain("</script>");
-    expect(script).toContain("\\u003c/script>");
-    expect(script).toContain("\\n");
-    expect(script).toContain("\\u2028");
-    expect(script).toContain("\\u2029");
-
-    const context = { window: {} as Record<string, unknown> };
-    runInNewContext(script, context);
-    expect(context.window).toEqual({ [WINDOW_PROPERTY]: gitBranch });
+    expect(await readInjectedMetaContent(plugin)).toBe(gitBranch);
   });
 });
 
 describe("Vite integration", () => {
-  it("prepends the branch script to served HTML", async () => {
+  it("prepends the branch meta tag to served HTML", async () => {
     const root = makeProjectDir();
     const html =
       '<html><head></head><body><script type="module" src="/main.js"></script></body></html>';
@@ -258,10 +236,32 @@ describe("Vite integration", () => {
     });
     try {
       const transformed = await server.transformIndexHtml("/", html);
-      expect(transformed.indexOf(WINDOW_PROPERTY)).toBeLessThan(
+      expect(transformed.indexOf(`name="${META_NAME}"`)).toBeLessThan(
         transformed.indexOf('src="/main.js"'),
       );
-      expect(transformed).toContain(JSON.stringify(GIT_BRANCH));
+      expect(transformed).toContain(`content="${GIT_BRANCH}"`);
+    } finally {
+      await server.close();
+    }
+  });
+
+  it("escapes the branch as inert HTML metadata", async () => {
+    const gitBranch = 'feature/"quote"><script>bad()</script>&suffix';
+    const root = makeProjectDir();
+    const html =
+      '<html><head></head><body><script type="module" src="/main.js"></script></body></html>';
+    const server = await createServer({
+      root,
+      configFile: false,
+      logLevel: "silent",
+      plugins: [pluginOn(gitBranch)],
+    });
+    try {
+      const transformed = await server.transformIndexHtml("/", html);
+      expect(transformed).toContain(
+        'content="feature/&quot;quote&quot;&gt;&lt;script&gt;bad()&lt;/script&gt;&amp;suffix"',
+      );
+      expect(transformed).not.toContain("<script>bad()</script>");
     } finally {
       await server.close();
     }
@@ -285,8 +285,8 @@ describe("Vite integration", () => {
     });
 
     const builtHtml = readFileSync(path.join(root, "dist/index.html"), "utf-8");
-    expect(builtHtml).toContain(JSON.stringify(buildBranch));
-    expect(builtHtml.indexOf(WINDOW_PROPERTY)).toBeLessThan(
+    expect(builtHtml).toContain(`content="${buildBranch}"`);
+    expect(builtHtml.indexOf(`name="${META_NAME}"`)).toBeLessThan(
       builtHtml.indexOf('type="module"'),
     );
 

--- a/packages/vite-plugin-branch/src/branchPlugin.ts
+++ b/packages/vite-plugin-branch/src/branchPlugin.ts
@@ -14,18 +14,18 @@
  * limitations under the License.
  */
 
-import path from "node:path";
-
-import { loadEnv, type Plugin } from "vite";
+import { loadEnv, type Plugin, type ResolvedConfig } from "vite";
 
 import { getGitBranch } from "./getGitBranch.js";
 import { normalizeGitBranch } from "./normalizeGitBranch.js";
 
 /**
- * The environment variable used to expose either a Foundry branch RID or a
- * local git branch name to `@osdk/client`.
+ * The server-only environment variable used to override the Foundry branch
+ * injected into the application HTML.
  */
-export const FOUNDRY_BRANCH_ENV_VAR: string = "VITE_FOUNDRY_BRANCH_RID";
+export const FOUNDRY_BRANCH_ENV_VAR: string = "FOUNDRY_BRANCH_RID";
+
+const FOUNDRY_BRANCH_WINDOW_PROPERTY = "__OSDK_FOUNDRY_BRANCH_RID__";
 
 export interface BranchPluginOptions {
   /**
@@ -38,12 +38,13 @@ export interface BranchPluginOptions {
 }
 
 /**
- * Makes the current global Foundry branch available to `@osdk/client` through
- * `import.meta.env.VITE_FOUNDRY_BRANCH_RID` during local development.
+ * Makes the current global Foundry branch available to `@osdk/client` by
+ * injecting it into the application HTML.
  *
- * An existing environment value takes precedence. Otherwise, the plugin uses
- * the checked-out git branch, except for `main`, `master`, a detached HEAD, or
- * a directory outside a git repository, which use the default Foundry branch.
+ * A server-side {@link FOUNDRY_BRANCH_ENV_VAR} value takes precedence.
+ * Otherwise, the plugin uses the checked-out git branch. `main`, `master`, a
+ * detached HEAD, and a directory outside a git repository use the default
+ * Foundry branch.
  *
  * @example
  * ```ts
@@ -52,40 +53,60 @@ export interface BranchPluginOptions {
  */
 export function branchPlugin(options: BranchPluginOptions = {}): Plugin {
   const readGitBranch = options.readGitBranch ?? getGitBranch;
-  let injectedBranch: string | undefined;
+  let root = process.cwd();
+  let mode = "development";
+  let envDir: string | false = root;
+  let logger: ResolvedConfig["logger"] | undefined;
+  let lastReportedBranch: string | null | undefined;
 
   return {
     name: "osdk-branch",
-    apply: "serve",
-
-    async config(config, { mode }) {
-      const root = path.resolve(config.root ?? process.cwd());
-      const envDir =
-        config.envDir === false
-          ? false
-          : path.resolve(root, config.envDir ?? ".");
-
-      const configuredBranch = loadEnv(mode, envDir, "VITE_")[
-        FOUNDRY_BRANCH_ENV_VAR
-      ];
-      if (configuredBranch?.trim() != null) {
-        return;
-      }
-
-      injectedBranch = normalizeGitBranch(await readGitBranch(root));
-      if (injectedBranch == null) {
-        return;
-      }
-
-      process.env[FOUNDRY_BRANCH_ENV_VAR] = injectedBranch;
-    },
 
     configResolved(config) {
-      if (injectedBranch != null) {
-        config.logger.info(
-          `Using Foundry branch "${injectedBranch}". Set ${FOUNDRY_BRANCH_ENV_VAR} to override.`,
-        );
+      root = config.root;
+      mode = config.mode;
+      envDir = config.envDir;
+      logger = config.logger;
+    },
+
+    async transformIndexHtml() {
+      const configuredBranch = loadEnv(mode, envDir, FOUNDRY_BRANCH_ENV_VAR)[
+        FOUNDRY_BRANCH_ENV_VAR
+      ];
+      const branch =
+        (configuredBranch === undefined
+          ? normalizeGitBranch(await readGitBranch(root))
+          : normalizeGitBranch(configuredBranch)) ?? null;
+
+      if (branch !== lastReportedBranch) {
+        lastReportedBranch = branch;
+        if (branch != null) {
+          logger?.info(
+            `Using Foundry branch "${branch}". Set ${FOUNDRY_BRANCH_ENV_VAR} to override.`,
+          );
+        }
       }
+
+      return [
+        {
+          tag: "script",
+          children: `window.${FOUNDRY_BRANCH_WINDOW_PROPERTY} = ${serializeForInlineScript(branch)};`,
+          injectTo: "head-prepend",
+        },
+      ];
     },
   };
+}
+
+/** Serializes data without allowing a value to terminate the script element. */
+function serializeForInlineScript(branch: string | null): string {
+  return (
+    (JSON.stringify(branch) ?? "null")
+      // Prevent a branch containing `</script>` from terminating the HTML element.
+      .replaceAll("<", "\\u003c")
+      // Escape line separators that older JavaScript parsers reject in string literals.
+      .replaceAll("\u2028", "\\u2028")
+      // Escape paragraph separators for the same cross-parser compatibility.
+      .replaceAll("\u2029", "\\u2029")
+  );
 }

--- a/packages/vite-plugin-branch/src/branchPlugin.ts
+++ b/packages/vite-plugin-branch/src/branchPlugin.ts
@@ -25,7 +25,7 @@ import { normalizeGitBranch } from "./normalizeGitBranch.js";
  */
 export const FOUNDRY_BRANCH_ENV_VAR: string = "FOUNDRY_BRANCH_RID";
 
-const FOUNDRY_BRANCH_WINDOW_PROPERTY = "__OSDK_FOUNDRY_BRANCH_RID__";
+const FOUNDRY_BRANCH_META_NAME = "osdk-foundry-branch-rid";
 
 export interface BranchPluginOptions {
   /**
@@ -89,24 +89,14 @@ export function branchPlugin(options: BranchPluginOptions = {}): Plugin {
 
       return [
         {
-          tag: "script",
-          children: `window.${FOUNDRY_BRANCH_WINDOW_PROPERTY} = ${serializeForInlineScript(branch)};`,
+          tag: "meta",
+          attrs: {
+            name: FOUNDRY_BRANCH_META_NAME,
+            content: branch ?? "",
+          },
           injectTo: "head-prepend",
         },
       ];
     },
   };
-}
-
-/** Serializes data without allowing a value to terminate the script element. */
-function serializeForInlineScript(branch: string | null): string {
-  return (
-    (JSON.stringify(branch) ?? "null")
-      // Prevent a branch containing `</script>` from terminating the HTML element.
-      .replaceAll("<", "\\u003c")
-      // Escape line separators that older JavaScript parsers reject in string literals.
-      .replaceAll("\u2028", "\\u2028")
-      // Escape paragraph separators for the same cross-parser compatibility.
-      .replaceAll("\u2029", "\\u2029")
-  );
 }


### PR DESCRIPTION
We had some issues with Vite chunk caching that would make it so stale branches would be read. Specifically, the issue was that:
- With the current Vite setup, Vite would resolve the global branch on dev server startup, write that to a chunk on the local machine, and then serve that chunk when the browser requests it.
- However, the browser is optimized to not refetch chunks if the hash of the chunk has not changed. Changing the Git branch (and subsequently, what the exported meta.env global branch variable would resolve to) does not cause the chunk to be recomputed, nor does Vite recompute the cached chunk when a new dev server instance starts
- The result is that you would have a stale global branch value that was being served via Vite, that could diverge with what the environment variable actually is.

We would instead like to ensure that the branch that is passed to the client is not subject to such caching concerns. We also wanted this to not live in the user code. The new approach is:
- Utilize Vite's `transformIndexHtml` to inject a meta tag with a `osdk-foundry-branch-rid` attribute into the HTML. The branch is resolved by first reading the Node env's `FOUNDRY_BRANCH_RID`, which is set by in-platform Jemma CI/CD to support PR previews. If that Node envvar is not set, then we read the Git branch.
- Vite by default tells the browser to not cache HTML, meaning that the browser will always fetch the HTML from the Vite server, and Vite always injects the branch on request to fetch the HTML. Note that this is just a nicety but we only request HTML on a page refresh, meaning that a user that does not refresh the page after switch branches may still technically have a page with a "stale branch". We've separately enforced restarting the dev server whenever the branch changes, which then trivially solves this problem.
- The client then reads the `osdk-foundry-branch-rid` from the meta tag.

