### PR TITLE
preserve block result identities

### DIFF
--- a/.changeset/preserve-block-result-identities.md
+++ b/.changeset/preserve-block-result-identities.md
@@ -1,0 +1,5 @@
+---
+"@osdk/maker-experimental": patch
+---
+
+Preserve readable-to-internal block identities in generated ontology and value type block results.

--- a/packages/maker-experimental/src/api/defineOntologyV2.ts
+++ b/packages/maker-experimental/src/api/defineOntologyV2.ts
@@ -29,6 +29,7 @@ import {
   writeStaticObjects,
 } from "@osdk/maker";
 
+import type { BlockDataAddOn } from "../cli/marketplaceSerialization/BlockGeneratorResult.js";
 import { convertOntologyDefinition } from "../conversion/toMarketplace/convertOntologyDefinition.js";
 import {
   getImportedShapes,
@@ -44,6 +45,7 @@ import {
 export interface OntologyV2Result {
   ontologyIr: OntologyIrV2;
   shapes: BlockShapes;
+  blockDataAddOn: BlockDataAddOn;
   importedInputPresets: Map<ReadableId, InputPreset>;
   backingDatasourceApiNames: string[];
   backingDatasourceLinkApiNames: string[];
@@ -166,9 +168,25 @@ export async function defineOntologyV2(
     writeDependencyFile(dependencyFile);
   }
 
+  const readableIds = new Set([
+    ...shapes.inputShapes.keys(),
+    ...shapes.outputShapes.keys(),
+  ]);
+  const blockDataAddOn: BlockDataAddOn = {
+    idToBlockShapeId: Object.fromEntries(
+      Array.from(readableIds, (readableId) => [
+        readableId,
+        ridGenerator.toBlockInternalId(readableId),
+      ]),
+    ),
+    idToInputGroupId: {},
+    outputToLocationInput: {},
+  };
+
   return {
     ontologyIr: ontDef,
     shapes,
+    blockDataAddOn,
     importedInputPresets: importedShapes.inputPresets,
     backingDatasourceApiNames,
     backingDatasourceLinkApiNames,

--- a/packages/maker-experimental/src/api/overall.test.ts
+++ b/packages/maker-experimental/src/api/overall.test.ts
@@ -911,6 +911,67 @@ describe("Experimental Test Suite", () => {
     ).toBe("The imported employee identifier");
   });
 
+  it.each([undefined, "123e4567-e89b-12d3-a456-426614174000"])(
+    "materializes consumed value type identities with randomness key %s",
+    async (randomnessKey) => {
+      const result = await defineOntologyV2(
+        "com.palantir.",
+        () => {
+          const classification = defineValueType({
+            apiName: "classification",
+            displayName: "Classification",
+            type: { type: "string" },
+            version: "1.0.0",
+          });
+
+          defineObject({
+            apiName: "classifiedObject",
+            displayName: "Classified Object",
+            pluralDisplayName: "Classified Objects",
+            titlePropertyApiName: "id",
+            primaryKeyPropertyApiName: "id",
+            properties: {
+              id: { type: "string" },
+              classification: {
+                type: "string",
+                valueType: classification,
+              },
+            },
+          });
+        },
+        undefined,
+        undefined,
+        undefined,
+        randomnessKey,
+      );
+
+      const objectType = Object.values(
+        result.ontologyIr.ontology.objectTypes,
+      )[0].objectType;
+      const classificationProperty = Object.values(
+        objectType.propertyTypes,
+      ).find((property) => property.apiName === "classification");
+      invariant(
+        classificationProperty?.valueType != null,
+        "Classification value type reference is missing",
+      );
+      const { rid, versionId } = classificationProperty.valueType;
+      const internalId =
+        result.ontologyIr.ontology.knownIdentifiers.valueTypes[rid]?.[
+          versionId
+        ];
+      const consumedId = ReadableIdGenerator.getForConsumedValueType(
+        "classification",
+        "1.0.0",
+      );
+
+      expect(internalId).toBeDefined();
+      expect(result.blockDataAddOn.idToBlockShapeId[consumedId]).toBe(
+        internalId,
+      );
+    },
+  );
+
   it("preserves required nullability for value-typed object properties", async () => {
     const result = await defineOntologyV2("com.palantir.", () => {
       const classification = defineValueType({

--- a/packages/maker-experimental/src/cli/generateValueTypeBlockResults.test.ts
+++ b/packages/maker-experimental/src/cli/generateValueTypeBlockResults.test.ts
@@ -27,6 +27,7 @@ import {
   generateValueTypeBlockResults,
   getValueTypeInternalMappings,
 } from "./generateValueTypeBlockResults.js";
+import { toBlockShapeId } from "./marketplaceSerialization/CodeBlockSpec.js";
 
 function makeEntry(apiName: string, versions: string[]): ValueTypeBlockData {
   return {
@@ -108,6 +109,36 @@ describe("generateValueTypeBlockResults", () => {
     expect(results[0].external_recommendations).toEqual([]);
     expect(results[0].input_shape_metadata).toEqual({});
   });
+
+  it.each([undefined, "123e4567-e89b-12d3-a456-426614174000"])(
+    "materializes produced value type identities with randomness key %s",
+    async (randomnessKey) => {
+      const entry = makeEntry("enumerated", ["0.0.1", "0.0.2"]);
+
+      const [result] = await generateValueTypeBlockResults(
+        [entry],
+        buildDir,
+        randomnessKey,
+      );
+
+      const firstOutput = ReadableIdGenerator.getForProducedValueType(
+        "enumerated",
+        "0.0.1",
+      );
+      const secondOutput = ReadableIdGenerator.getForProducedValueType(
+        "enumerated",
+        "0.0.2",
+      );
+      expect(result.add_on_override).toEqual({
+        idToBlockShapeId: {
+          [firstOutput]: toBlockShapeId(firstOutput, randomnessKey),
+          [secondOutput]: toBlockShapeId(secondOutput, randomnessKey),
+        },
+        idToInputGroupId: {},
+        outputToLocationInput: {},
+      });
+    },
+  );
 
   it("writes value-types.json with latest version baseType in metadata", async () => {
     const entry = makeEntry("enumerated", ["0.0.1", "0.0.2"]);

--- a/packages/maker-experimental/src/cli/generateValueTypeBlockResults.ts
+++ b/packages/maker-experimental/src/cli/generateValueTypeBlockResults.ts
@@ -23,6 +23,7 @@ import type { InputShape, OutputShape } from "@osdk/client.unstable/api";
 import { typeToMarketplaceBaseType } from "../conversion/toMarketplace/typeVisitors.js";
 import { ReadableIdGenerator } from "../util/generateRid.js";
 import type { BlockGeneratorResult } from "./marketplaceSerialization/BlockGeneratorResult.js";
+import { toBlockShapeId } from "./marketplaceSerialization/CodeBlockSpec.js";
 import type { InputMappingEntry } from "./marketplaceSerialization/supportingTypes.js";
 
 /**
@@ -32,6 +33,7 @@ import type { InputMappingEntry } from "./marketplaceSerialization/supportingTyp
 export async function generateValueTypeBlockResults(
   bulkValueTypeBlockData: ValueTypeBlockData[],
   buildDir: string,
+  randomnessKey?: string,
 ): Promise<BlockGeneratorResult[]> {
   const results: BlockGeneratorResult[] = [];
 
@@ -49,6 +51,12 @@ export async function generateValueTypeBlockResults(
     );
 
     const outputs = buildOutputShapes(entry);
+    const idToBlockShapeId = Object.fromEntries(
+      Array.from(outputs.keys(), (readableId) => [
+        readableId,
+        toBlockShapeId(readableId, randomnessKey),
+      ]),
+    );
 
     results.push({
       block_identifier: blockIdentifier,
@@ -59,7 +67,11 @@ export async function generateValueTypeBlockResults(
       outputs: Object.fromEntries(outputs),
       input_mapping_entries: [],
       external_recommendations: [],
-      add_on_override: undefined,
+      add_on_override: {
+        idToBlockShapeId,
+        idToInputGroupId: {},
+        outputToLocationInput: {},
+      },
       input_shape_metadata: {},
       block_type: "VALUE_TYPE",
     });

--- a/packages/maker-experimental/src/cli/main.ts
+++ b/packages/maker-experimental/src/cli/main.ts
@@ -237,6 +237,7 @@ export default async function main(
   const {
     ontologyIr,
     shapes,
+    blockDataAddOn,
     importedInputPresets,
     backingDatasourceApiNames,
     backingDatasourceLinkApiNames,
@@ -291,6 +292,7 @@ export default async function main(
     valueTypeResults = await generateValueTypeBlockResults(
       ontologyIr.valueTypes,
       commandLineOpts.buildDir,
+      commandLineOpts.randomnessKey,
     );
   }
 
@@ -487,7 +489,7 @@ export default async function main(
       ontologyIr.importedValueTypes,
       shapes.inputShapes,
     ),
-    add_on_override: undefined,
+    add_on_override: blockDataAddOn,
     input_shape_metadata: Object.fromEntries(shapes.inputShapeMetadata),
     block_type: "ONTOLOGY",
   };

--- a/packages/maker-experimental/src/cli/marketplaceSerialization/BlockGeneratorResult.ts
+++ b/packages/maker-experimental/src/cli/marketplaceSerialization/BlockGeneratorResult.ts
@@ -28,6 +28,12 @@ import type {
   InputMappingEntry,
 } from "./supportingTypes.js";
 
+export interface BlockDataAddOn {
+  idToBlockShapeId: Record<string, string>;
+  idToInputGroupId: Record<string, string>;
+  outputToLocationInput: Record<string, string>;
+}
+
 /**
  * Result from generating a block.
  * This matches the Rust BlockGeneratorResult interface and Java's BlockGeneratorResult.


### PR DESCRIPTION
We want generate-sdk to preserve value types. To do that, it needs to match an ontology property’s value type reference to the VALUE_TYPE block containing its definition.

The problem is that ontology data uses generated IDs, while block connections use readable names. Maker knows how these correspond, but does not save that mapping in the raw block results. Marketplace packaging reconstructs it later, but `generate-sdk` needs it before packaging.

This PR saves that mapping in the existing `add_on_override` metadata (let me know if I'm abusing this):
- include the readable-to-generated ID map in the ONTOLOGY block result
- include the map for every produced value type version (let me know if this is overkill / not required)
- derive IDs using the existing optional randomnessKey

**Alternatives considered**

- Recompute the IDs in `generate-sdk`: would duplicate Maker’s hashing logic but require the same `randomnessKey` to avoid extraneous diffs.
- Add a separate output file or mapping field: spoke with @aparson and we don't want to add an additional output file, also the existing block metadata can carry the mapping.

This PR does not change generate-sdk itself. The follow-up, #4006, uses these mappings to read the connected value type blocks and populate `valueTypes` in the existing `ontology-metadata.json` output, which is currently empty.