### PR TITLE
Fix CBAC marking generation

### DIFF
--- a/.changeset/itchy-emus-fix.md
+++ b/.changeset/itchy-emus-fix.md
@@ -1,0 +1,5 @@
+---
+"@osdk/maker-experimental": minor
+---
+
+Fix CBAC marking generation

--- a/packages/maker-experimental/src/cli/generateBackingDataset.test.ts
+++ b/packages/maker-experimental/src/cli/generateBackingDataset.test.ts
@@ -466,6 +466,73 @@ describe("generateBackingDatasetBlockResult", () => {
     expect(zipBuffer[3]).toBe(0x06);
   });
 
+  it.each(["CBAC", "MANDATORY"] as const)(
+    "generates backing columns for scalar and array %s markings",
+    async (markingType) => {
+      const type: Type = { type: "marking", marking: { markingType } };
+      const blockData = createObjectTypeBlockData({
+        properties: [
+          { apiName: "id", type: STRING_PROPERTY_TYPE },
+          { apiName: "marking", type },
+          { apiName: "markings", type: makeArrayType(type) },
+        ],
+      });
+
+      const result = await generateBackingDatasetBlockResult(
+        blockData,
+        buildDir,
+      );
+      const schema = JSON.parse(
+        await fs.promises.readFile(
+          path.join(result.block_data_directory, "schema.json"),
+          "utf-8",
+        ),
+      );
+      expect(schema.fieldSchemaList).toMatchObject([
+        { name: "id", type: "STRING", arraySubtype: null },
+        { name: "marking", type: "STRING", arraySubtype: null },
+        { name: "markings", type: "ARRAY", arraySubtype: { type: "STRING" } },
+      ]);
+      expect(
+        result.outputs[
+          ReadableIdGenerator.getForDatasetColumnOutput("TestObject", "marking")
+        ],
+      ).toMatchObject({
+        type: "datasourceColumn",
+        datasourceColumn: {
+          type: {
+            type: "concrete",
+            concrete: { type: "primitive", primitive: { type: "string" } },
+          },
+        },
+      });
+      expect(
+        result.outputs[
+          ReadableIdGenerator.getForDatasetColumnOutput(
+            "TestObject",
+            "markings",
+          )
+        ],
+      ).toMatchObject({
+        type: "datasourceColumn",
+        datasourceColumn: {
+          type: {
+            type: "concrete",
+            concrete: {
+              type: "array",
+              array: {
+                elementType: {
+                  type: "primitive",
+                  primitive: { type: "string" },
+                },
+              },
+            },
+          },
+        },
+      });
+    },
+  );
+
   it("excludes editOnly properties from outputs and files", async () => {
     const blockData = createObjectTypeBlockData({
       properties: [

--- a/packages/maker-experimental/src/cli/generateBackingDataset.ts
+++ b/packages/maker-experimental/src/cli/generateBackingDataset.ts
@@ -44,6 +44,7 @@ export function propertyTypeToSchemaType(
 ): string {
   const typeStr = typeof propType === "string" ? propType : propType.type;
   switch (typeStr) {
+    case "marking":
     case "string":
       return "STRING";
     case "boolean":


### PR DESCRIPTION
Maker already generated a `marking` type but then it didn't handle it in `packages/maker-experimental/src/cli/generateBackingDataset.ts` and instead gave a misleading error 