### PR TITLE
[5/5] ITSM OAC DSL: Adopt latest bindings which include RID

### DIFF
--- a/.changeset/itsm-5-schema-transition-rids.md
+++ b/.changeset/itsm-5-schema-transition-rids.md
@@ -1,0 +1,7 @@
+---
+"@osdk/client.unstable": minor
+"@osdk/maker": patch
+"@osdk/maker-experimental": patch
+---
+
+Interface schema transitions now carry a rid, adopting the latest bindings.

--- a/packages/client.unstable/src/generated/ontology-metadata/api/__components.ts
+++ b/packages/client.unstable/src/generated/ontology-metadata/api/__components.ts
@@ -5214,6 +5214,11 @@ export interface InterfaceTypeSchemaMigrationOnBranchError {
 export type InterfaceTypeSchemaMigrationRid = string;
 
 /**
+ * An immutable, randomly generated identifier for an InterfaceType schema transition.
+ */
+export type InterfaceTypeSchemaTransitionRid = string;
+
+/**
  * The InterfaceTypes were not found.
  */
 export interface InterfaceTypesNotFoundError {

--- a/packages/client.unstable/src/generated/ontology-metadata/api/blockdata/__components.ts
+++ b/packages/client.unstable/src/generated/ontology-metadata/api/blockdata/__components.ts
@@ -55,6 +55,7 @@ import type {
   InterfaceSharedPropertyType as _api_InterfaceSharedPropertyType,
   InterfaceTypeApiName as _api_InterfaceTypeApiName,
   InterfaceTypeRid as _api_InterfaceTypeRid,
+  InterfaceTypeSchemaTransitionRid as _api_InterfaceTypeSchemaTransitionRid,
   LinkedEntityTypeId as _api_LinkedEntityTypeId,
   LinkType as _api_LinkType,
   LinkTypeId as _api_LinkTypeId,
@@ -128,7 +129,6 @@ import type {
 import type { RuleSet as _api_formatting_RuleSet } from "../formatting/__components.js";
 import type {
   InterfaceTypeSchemaTransition as _api_schemamigrations_InterfaceTypeSchemaTransition,
-  InterfaceTypeSchemaTransitionId as _api_schemamigrations_InterfaceTypeSchemaTransitionId,
   OntologyIrInterfaceTypeSchemaTransition as _api_schemamigrations_OntologyIrInterfaceTypeSchemaTransition,
   OntologyIrSchemaTransition as _api_schemamigrations_OntologyIrSchemaTransition,
   SchemaTransition as _api_schemamigrations_SchemaTransition,
@@ -230,7 +230,7 @@ export interface InterfaceTypeSchemaMigrationBlockData {
     _api_InterfacePropertyTypeApiName
   >;
   schemaTransitions: Record<
-    _api_schemamigrations_InterfaceTypeSchemaTransitionId,
+    _api_InterfaceTypeSchemaTransitionRid,
     _api_schemamigrations_InterfaceTypeSchemaTransition
   >;
 }
@@ -272,10 +272,7 @@ export interface KnownMarketplaceIdentifiers {
   interfaceTypes: Record<_api_InterfaceTypeRid, BlockInternalId>;
   interfaceTypeSchemaTransitions: Record<
     _api_InterfaceTypeRid,
-    Record<
-      _api_schemamigrations_InterfaceTypeSchemaTransitionId,
-      BlockInternalId
-    >
+    Record<_api_InterfaceTypeSchemaTransitionRid, BlockInternalId>
   >;
   linkTypeIds: Record<_api_LinkTypeId, BlockInternalId>;
   linkTypes: Record<_api_LinkTypeRid, BlockInternalId>;
@@ -603,7 +600,7 @@ export interface OntologyIrInterfaceTypeSchemaMigrationBlockData {
     _api_InterfacePropertyTypeApiName
   >;
   schemaTransitions: Record<
-    _api_schemamigrations_InterfaceTypeSchemaTransitionId,
+    _api_InterfaceTypeSchemaTransitionRid,
     _api_schemamigrations_OntologyIrInterfaceTypeSchemaTransition
   >;
 }
@@ -639,10 +636,7 @@ export interface OntologyIrKnownMarketplaceIdentifiers {
   interfaceTypes: Record<_api_InterfaceTypeApiName, BlockInternalId>;
   interfaceTypeSchemaTransitions: Record<
     _api_InterfaceTypeApiName,
-    Record<
-      _api_schemamigrations_InterfaceTypeSchemaTransitionId,
-      BlockInternalId
-    >
+    Record<_api_InterfaceTypeSchemaTransitionRid, BlockInternalId>
   >;
   linkTypeIds: Record<_api_LinkTypeId, BlockInternalId>;
   linkTypes: Record<_api_LinkTypeId, BlockInternalId>;

--- a/packages/client.unstable/src/generated/ontology-metadata/api/index.ts
+++ b/packages/client.unstable/src/generated/ontology-metadata/api/index.ts
@@ -521,6 +521,7 @@ export type {
   InterfaceTypesAlreadyExistError,
   InterfaceTypeSchemaMigrationOnBranchError,
   InterfaceTypeSchemaMigrationRid,
+  InterfaceTypeSchemaTransitionRid,
   InterfaceTypesNotFoundError,
   InterfaceTypeStatus,
   InterfaceTypeUpdatedEvent,

--- a/packages/client.unstable/src/generated/ontology-metadata/api/schemamigrations/__components.ts
+++ b/packages/client.unstable/src/generated/ontology-metadata/api/schemamigrations/__components.ts
@@ -21,6 +21,7 @@ import type {
   InterfacePropertyTypeRid as _api_InterfacePropertyTypeRid,
   InterfacePropertyTypeRidOrIdInRequest as _api_InterfacePropertyTypeRidOrIdInRequest,
   InterfaceTypeRid as _api_InterfaceTypeRid,
+  InterfaceTypeSchemaTransitionRid as _api_InterfaceTypeSchemaTransitionRid,
   ObjectTypeApiName as _api_ObjectTypeApiName,
   ObjectTypeFieldApiName as _api_ObjectTypeFieldApiName,
   ObjectTypeRid as _api_ObjectTypeRid,
@@ -225,10 +226,11 @@ export interface InterfaceTypeSchemaTransition {
   gracePeriod: GracePeriod;
   id: InterfaceTypeSchemaTransitionId;
   migrations: Array<InterfaceTypeSchemaMigrationInstruction>;
+  rid: _api_InterfaceTypeSchemaTransitionRid;
   title?: string | null | undefined;
 }
 /**
- * A unique, immutable identifier for an Interface Type schema transition.
+ * A unique, immutable identifier for an Interface Type schema transition. Can be user defined.
  */
 export type InterfaceTypeSchemaTransitionId = string;
 
@@ -442,6 +444,7 @@ export interface OntologyIrInterfaceTypeSchemaTransition {
   gracePeriod: GracePeriod;
   id: InterfaceTypeSchemaTransitionId;
   migrations: Array<OntologyIrInterfaceTypeSchemaMigrationInstruction>;
+  rid: _api_InterfaceTypeSchemaTransitionRid;
   title?: string | null | undefined;
 }
 /**

--- a/packages/maker-experimental/src/conversion/toMarketplace/convertInterfaceSchemaMigrations.test.ts
+++ b/packages/maker-experimental/src/conversion/toMarketplace/convertInterfaceSchemaMigrations.test.ts
@@ -55,6 +55,16 @@ function transitionsOf(
   return schemaMigrations.schemaTransitions;
 }
 
+/** Block data keys transitions by their generated rid, not their authored id. */
+function transitionById(
+  block: InterfaceTypeBlockDataV2,
+  id: string,
+): InterfaceTypeSchemaTransition {
+  const found = Object.values(transitionsOf(block)).find((t) => t.id === id);
+  invariant(found != null, `expected a transition with id ${id}`);
+  return found;
+}
+
 function transition(
   overrides: Partial<InterfaceSchemaTransition> = {},
 ): InterfaceSchemaTransition {
@@ -96,6 +106,23 @@ describe("interface type schema migrations", () => {
     });
   });
 
+  it("keys transitions by their generated rid", async () => {
+    const block = await convertInterfaces(() => {
+      defineInterface({
+        apiName: "Foo",
+        properties: { optional: { required: false, type: "string" } },
+        schemaMigrations: { transitions: [transition({ id: "add-owner" })] },
+      });
+    });
+
+    const [[rid, only]] = Object.entries(transitionsOf(block));
+    expect(rid).toMatch(
+      /^ri\.ontology-metadata\.temp\.interface-schema-transition\./u,
+    );
+    expect(only.rid).toBe(rid);
+    expect(only.id).toBe("add-owner");
+  });
+
   it("records each transition in the block's known identifiers", async () => {
     const ontology = await convertOntology(() => {
       defineInterface({
@@ -120,12 +147,15 @@ describe("interface type schema migrations", () => {
 
     const [interfaceRid] = Object.keys(ontology.interfaceTypes);
     const { interfaceTypeSchemaTransitions } = ontology.knownIdentifiers;
+    const transitionRids = Object.keys(
+      transitionsOf(ontology.interfaceTypes[interfaceRid]),
+    );
 
     expect(Object.keys(interfaceTypeSchemaTransitions)).toEqual([interfaceRid]);
-    expect(interfaceTypeSchemaTransitions[interfaceRid]).toEqual({
-      t1: expect.any(String),
-      t2: expect.any(String),
-    });
+    expect(transitionRids).toHaveLength(2);
+    expect(
+      Object.keys(interfaceTypeSchemaTransitions[interfaceRid]).sort(),
+    ).toEqual([...transitionRids].sort());
     // Each transition gets its own block internal id
     expect(
       new Set(Object.values(interfaceTypeSchemaTransitions[interfaceRid])),
@@ -161,19 +191,18 @@ describe("interface type schema migrations", () => {
     });
 
     expect(block.interfaceType.schemaMigrationsEnabled).toBe(true);
-    expect(transitionsOf(block)).toEqual({
-      "add-owner": {
-        id: "add-owner",
-        title: "Require owner",
-        description: "some description",
-        gracePeriod: { type: "daysAfterActivation", daysAfterActivation: 30 },
-        migrations: [
-          {
-            type: "addRequiredProperty",
-            addRequiredProperty: { propertyTypeRid: expect.any(String) },
-          },
-        ],
-      },
+    expect(transitionById(block, "add-owner")).toEqual({
+      rid: expect.any(String),
+      id: "add-owner",
+      title: "Require owner",
+      description: "some description",
+      gracePeriod: { type: "daysAfterActivation", daysAfterActivation: 30 },
+      migrations: [
+        {
+          type: "addRequiredProperty",
+          addRequiredProperty: { propertyTypeRid: expect.any(String) },
+        },
+      ],
     });
   });
 
@@ -192,7 +221,7 @@ describe("interface type schema migrations", () => {
       });
     });
 
-    expect(transitionsOf(block).t1.gracePeriod).toEqual({
+    expect(transitionById(block, "t1").gracePeriod).toEqual({
       type: "deadline",
       deadline: DEADLINE,
     });
@@ -216,7 +245,7 @@ describe("interface type schema migrations", () => {
       });
     });
 
-    expect(transitionsOf(block).t1.gracePeriod).toEqual({
+    expect(transitionById(block, "t1").gracePeriod).toEqual({
       type: "deadline",
       deadline: "2026-01-31T12:34:56Z",
     });
@@ -231,7 +260,7 @@ describe("interface type schema migrations", () => {
       });
     });
 
-    const [migration] = transitionsOf(block).t1.migrations;
+    const [migration] = transitionById(block, "t1").migrations;
     invariant(migration.type === "addRequiredProperty");
     const { propertyTypeRid } = migration.addRequiredProperty;
 
@@ -265,7 +294,7 @@ describe("interface type schema migrations", () => {
       });
     });
 
-    const [migration] = transitionsOf(block).t1.migrations;
+    const [migration] = transitionById(block, "t1").migrations;
     invariant(migration.type === "addRequiredProperty");
     const { propertyTypeRid } = migration.addRequiredProperty;
 

--- a/packages/maker-experimental/src/conversion/toMarketplace/convertInterfaceSchemaMigrations.test.ts
+++ b/packages/maker-experimental/src/conversion/toMarketplace/convertInterfaceSchemaMigrations.test.ts
@@ -117,7 +117,7 @@ describe("interface type schema migrations", () => {
 
     const [[rid, only]] = Object.entries(transitionsOf(block));
     expect(rid).toMatch(
-      /^ri\.ontology-metadata\.temp\.interface-schema-transition\./u,
+      /^ri\.ontology-metadata\.temp\.interface-type-schema-transition\./u,
     );
     expect(only.rid).toBe(rid);
     expect(only.id).toBe("add-owner");

--- a/packages/maker-experimental/src/conversion/toMarketplace/convertInterfaceSchemaMigrations.test.ts
+++ b/packages/maker-experimental/src/conversion/toMarketplace/convertInterfaceSchemaMigrations.test.ts
@@ -117,7 +117,7 @@ describe("interface type schema migrations", () => {
 
     const [[rid, only]] = Object.entries(transitionsOf(block));
     expect(rid).toMatch(
-      /^ri\.ontology-metadata\.temp\.interface-type-schema-transition\./u,
+      /^ri\.ontology-metadata\.temp\.interface-schema-transition\./u,
     );
     expect(only.rid).toBe(rid);
     expect(only.id).toBe("add-owner");

--- a/packages/maker-experimental/src/conversion/toMarketplace/convertInterfaceSchemaMigrations.ts
+++ b/packages/maker-experimental/src/conversion/toMarketplace/convertInterfaceSchemaMigrations.ts
@@ -43,30 +43,37 @@ export function convertInterfaceSchemaMigrations(
   const interfacePropertyTypeRidsToApiNames: Record<string, string> = {};
   const schemaTransitions = Object.fromEntries(
     schemaMigrations.transitions.map(
-      (transition): [string, InterfaceTypeSchemaTransition] => [
-        transition.id,
-        {
-          id: transition.id,
-          title: transition.title,
-          description: transition.description,
-          gracePeriod: convertInterfaceSchemaGracePeriod(
-            transition.gracePeriod,
-          ),
-          migrations: transition.instructions.map((instruction) => {
-            const { property: propertyApiName } = instruction;
-            const property = propertiesV3[propertyApiName];
-            const propertyTypeRid = interfacePropertyWireRid(
-              property,
-              propertyApiName,
-              interfaceType.apiName,
-              ridGenerator,
-            );
-            interfacePropertyTypeRidsToApiNames[propertyTypeRid] =
-              interfacePropertyWireApiName(property, propertyApiName);
-            return convertInstruction(instruction, propertyTypeRid);
-          }),
-        },
-      ],
+      (transition): [string, InterfaceTypeSchemaTransition] => {
+        const rid = ridGenerator.generateRidForInterfaceSchemaTransition(
+          transition.id,
+          interfaceType.apiName,
+        );
+        return [
+          rid,
+          {
+            rid,
+            id: transition.id,
+            title: transition.title,
+            description: transition.description,
+            gracePeriod: convertInterfaceSchemaGracePeriod(
+              transition.gracePeriod,
+            ),
+            migrations: transition.instructions.map((instruction) => {
+              const { property: propertyApiName } = instruction;
+              const property = propertiesV3[propertyApiName];
+              const propertyTypeRid = interfacePropertyWireRid(
+                property,
+                propertyApiName,
+                interfaceType.apiName,
+                ridGenerator,
+              );
+              interfacePropertyTypeRidsToApiNames[propertyTypeRid] =
+                interfacePropertyWireApiName(property, propertyApiName);
+              return convertInstruction(instruction, propertyTypeRid);
+            }),
+          },
+        ];
+      },
     ),
   );
 

--- a/packages/maker-experimental/src/conversion/toMarketplace/convertOntologyDefinitionToWireBlockData.ts
+++ b/packages/maker-experimental/src/conversion/toMarketplace/convertOntologyDefinitionToWireBlockData.ts
@@ -321,7 +321,7 @@ function buildKnownIdentifiers(
     ]),
   );
 
-  // Interface type schema transitions: InterfaceTypeRid -> TransitionId -> BlockInternalId
+  // Interface type schema transitions: InterfaceTypeRid -> TransitionRid -> BlockInternalId
   const interfaceSchemaTransitionMappings = Object.fromEntries(
     Object.entries(ontology[OntologyEntityTypeEnum.INTERFACE_TYPE])
       .filter(([_, interfaceType]) => interfaceType.schemaMigrations != null)
@@ -330,7 +330,10 @@ function buildKnownIdentifiers(
         Object.fromEntries(
           interfaceType.schemaMigrations!.transitions.map<[string, string]>(
             (transition) => [
-              transition.id,
+              ridGenerator.generateRidForInterfaceSchemaTransition(
+                transition.id,
+                apiName,
+              ),
               ridGenerator.toBlockInternalId(
                 ReadableIdGenerator.getForInterfaceSchemaTransition(
                   apiName,

--- a/packages/maker-experimental/src/conversion/toMarketplace/shapeExtractors/ActionTypeShapeExtractor.test.ts
+++ b/packages/maker-experimental/src/conversion/toMarketplace/shapeExtractors/ActionTypeShapeExtractor.test.ts
@@ -183,8 +183,7 @@ function createMockRidGenerator(
     generateRidForInterfaceSchemaTransition: (
       transitionId: string,
       interfaceTypeApiName: string,
-    ) =>
-      `interface-type-schema-transition.${interfaceTypeApiName}.${transitionId}`,
+    ) => `interface-schema-transition.${interfaceTypeApiName}.${transitionId}`,
     getInterfaceActionTypeConstraintRids: () => new MockBiMap([]) as any,
     getInterfaceParameterConstraintRids: () => new MockBiMap([]) as any,
     ...overrides,

--- a/packages/maker-experimental/src/conversion/toMarketplace/shapeExtractors/ActionTypeShapeExtractor.test.ts
+++ b/packages/maker-experimental/src/conversion/toMarketplace/shapeExtractors/ActionTypeShapeExtractor.test.ts
@@ -180,6 +180,10 @@ function createMockRidGenerator(
       paramApiName: string,
     ) =>
       `interface-parameter-constraint.${interfaceTypeApiName}.${constraintApiName}.${paramApiName}` as any,
+    generateRidForInterfaceSchemaTransition: (
+      transitionId: string,
+      interfaceTypeApiName: string,
+    ) => `interface-schema-transition.${interfaceTypeApiName}.${transitionId}`,
     getInterfaceActionTypeConstraintRids: () => new MockBiMap([]) as any,
     getInterfaceParameterConstraintRids: () => new MockBiMap([]) as any,
     ...overrides,

--- a/packages/maker-experimental/src/conversion/toMarketplace/shapeExtractors/ActionTypeShapeExtractor.test.ts
+++ b/packages/maker-experimental/src/conversion/toMarketplace/shapeExtractors/ActionTypeShapeExtractor.test.ts
@@ -183,7 +183,8 @@ function createMockRidGenerator(
     generateRidForInterfaceSchemaTransition: (
       transitionId: string,
       interfaceTypeApiName: string,
-    ) => `interface-schema-transition.${interfaceTypeApiName}.${transitionId}`,
+    ) =>
+      `interface-type-schema-transition.${interfaceTypeApiName}.${transitionId}`,
     getInterfaceActionTypeConstraintRids: () => new MockBiMap([]) as any,
     getInterfaceParameterConstraintRids: () => new MockBiMap([]) as any,
     ...overrides,

--- a/packages/maker-experimental/src/conversion/toMarketplace/shapeExtractors/ObjectTypeShapeExtractor.test.ts
+++ b/packages/maker-experimental/src/conversion/toMarketplace/shapeExtractors/ObjectTypeShapeExtractor.test.ts
@@ -183,8 +183,7 @@ function createMockRidGenerator(
     generateRidForInterfaceSchemaTransition: (
       transitionId: string,
       interfaceTypeApiName: string,
-    ) =>
-      `interface-type-schema-transition.${interfaceTypeApiName}.${transitionId}`,
+    ) => `interface-schema-transition.${interfaceTypeApiName}.${transitionId}`,
     getInterfaceActionTypeConstraintRids: () => new MockBiMap([]) as any,
     getInterfaceParameterConstraintRids: () => new MockBiMap([]) as any,
     ...overrides,

--- a/packages/maker-experimental/src/conversion/toMarketplace/shapeExtractors/ObjectTypeShapeExtractor.test.ts
+++ b/packages/maker-experimental/src/conversion/toMarketplace/shapeExtractors/ObjectTypeShapeExtractor.test.ts
@@ -180,6 +180,10 @@ function createMockRidGenerator(
       paramApiName: string,
     ) =>
       `interface-parameter-constraint.${interfaceTypeApiName}.${constraintApiName}.${paramApiName}` as any,
+    generateRidForInterfaceSchemaTransition: (
+      transitionId: string,
+      interfaceTypeApiName: string,
+    ) => `interface-schema-transition.${interfaceTypeApiName}.${transitionId}`,
     getInterfaceActionTypeConstraintRids: () => new MockBiMap([]) as any,
     getInterfaceParameterConstraintRids: () => new MockBiMap([]) as any,
     ...overrides,

--- a/packages/maker-experimental/src/conversion/toMarketplace/shapeExtractors/ObjectTypeShapeExtractor.test.ts
+++ b/packages/maker-experimental/src/conversion/toMarketplace/shapeExtractors/ObjectTypeShapeExtractor.test.ts
@@ -183,7 +183,8 @@ function createMockRidGenerator(
     generateRidForInterfaceSchemaTransition: (
       transitionId: string,
       interfaceTypeApiName: string,
-    ) => `interface-schema-transition.${interfaceTypeApiName}.${transitionId}`,
+    ) =>
+      `interface-type-schema-transition.${interfaceTypeApiName}.${transitionId}`,
     getInterfaceActionTypeConstraintRids: () => new MockBiMap([]) as any,
     getInterfaceParameterConstraintRids: () => new MockBiMap([]) as any,
     ...overrides,

--- a/packages/maker-experimental/src/util/generateRid.ts
+++ b/packages/maker-experimental/src/util/generateRid.ts
@@ -389,7 +389,7 @@ export class ReadableIdGenerator {
     interfaceApiName: string,
     transitionId: string,
   ): ReadableId {
-    return `interface-type-schema-transition-${interfaceApiName}-${transitionId}` as ReadableId;
+    return `interface-schema-transition-${interfaceApiName}-${transitionId}` as ReadableId;
   }
 
   static getForInterfaceParameterConstraint(
@@ -772,7 +772,7 @@ export class OntologyRidGeneratorImpl implements OntologyRidGenerator {
       interfaceTypeApiName,
       transitionId,
     );
-    return `ri.ontology-metadata.temp.interface-type-schema-transition.${this.hashString(
+    return `ri.ontology-metadata.temp.interface-schema-transition.${this.hashString(
       readableId,
     )}` as InterfaceTypeSchemaTransitionRid;
   }

--- a/packages/maker-experimental/src/util/generateRid.ts
+++ b/packages/maker-experimental/src/util/generateRid.ts
@@ -389,7 +389,7 @@ export class ReadableIdGenerator {
     interfaceApiName: string,
     transitionId: string,
   ): ReadableId {
-    return `interface-schema-transition-${interfaceApiName}-${transitionId}` as ReadableId;
+    return `interface-type-schema-transition-${interfaceApiName}-${transitionId}` as ReadableId;
   }
 
   static getForInterfaceParameterConstraint(
@@ -772,7 +772,7 @@ export class OntologyRidGeneratorImpl implements OntologyRidGenerator {
       interfaceTypeApiName,
       transitionId,
     );
-    return `ri.ontology-metadata.temp.interface-schema-transition.${this.hashString(
+    return `ri.ontology-metadata.temp.interface-type-schema-transition.${this.hashString(
       readableId,
     )}` as InterfaceTypeSchemaTransitionRid;
   }

--- a/packages/maker-experimental/src/util/generateRid.ts
+++ b/packages/maker-experimental/src/util/generateRid.ts
@@ -14,7 +14,10 @@
  * limitations under the License.
  */
 
-import type { ValueTypeReference } from "@osdk/client.unstable";
+import type {
+  InterfaceTypeSchemaTransitionRid,
+  ValueTypeReference,
+} from "@osdk/client.unstable";
 import type {
   ActionTypeRid,
   DatasourceLocator,
@@ -125,6 +128,10 @@ export interface OntologyRidGenerator {
     interfaceTypeApiName: string,
     paramApiName: string,
   ): InterfaceParameterConstraintRid;
+  generateRidForInterfaceSchemaTransition(
+    transitionId: string,
+    interfaceTypeApiName: string,
+  ): InterfaceTypeSchemaTransitionRid;
   getInterfaceActionTypeConstraintRids(): BiMap<
     ReadableId,
     InterfaceActionTypeConstraintRid
@@ -754,6 +761,20 @@ export class OntologyRidGeneratorImpl implements OntologyRidGenerator {
       )}` as InterfaceParameterConstraintRid;
     this.interfaceParameterConstraintRids.put(readableId, rid);
     return rid;
+  }
+
+  // Interface Schema Transitions
+  generateRidForInterfaceSchemaTransition(
+    transitionId: string,
+    interfaceTypeApiName: string,
+  ): InterfaceTypeSchemaTransitionRid {
+    const readableId = ReadableIdGenerator.getForInterfaceSchemaTransition(
+      interfaceTypeApiName,
+      transitionId,
+    );
+    return `ri.ontology-metadata.temp.interface-schema-transition.${this.hashString(
+      readableId,
+    )}` as InterfaceTypeSchemaTransitionRid;
   }
 
   // Object Types

--- a/packages/maker/src/api/test/interfaceSchemaMigrations.test.ts
+++ b/packages/maker/src/api/test/interfaceSchemaMigrations.test.ts
@@ -698,6 +698,7 @@ describe("Interface schema migrations", () => {
 
       expect(transitions()).toEqual({
         "add-owner": {
+          rid: "add-owner",
           id: "add-owner",
           title: "Require owner",
           description: "some description",

--- a/packages/maker/src/conversion/toMarketplace/convertInterfaceSchemaMigrations.ts
+++ b/packages/maker/src/conversion/toMarketplace/convertInterfaceSchemaMigrations.ts
@@ -36,14 +36,14 @@ export function convertInterfaceSchemaMigrations(
     return undefined;
   }
 
-  // NB: Ontology-ir identifies interface property types by API name rather than rid
+  // NB: Ontology-ir keys by API name rather than rid, making it an identity map
   const interfacePropertyTypeRidsToApiNames: Record<string, string> = {};
   const schemaTransitions = Object.fromEntries(
     schemaMigrations.transitions.map(
       (transition): [string, OntologyIrInterfaceTypeSchemaTransition] => [
         transition.id,
         {
-          // For ontology-ir, this carries the authored id, not a rid, despite its name
+          // Ontology-ir uses the ID for all identifiers (even RID, despite the name)
           rid: transition.id,
           id: transition.id,
           title: transition.title,
@@ -103,7 +103,7 @@ function convertInstruction(
       return {
         type: "addRequiredProperty",
         addRequiredProperty: {
-          // For ontology-ir, this carries an API name, not a rid, despite its name
+          // Ontology-ir types this as an API name despite the field name
           propertyTypeRid: propertyApiName,
         },
       };

--- a/packages/maker/src/conversion/toMarketplace/convertInterfaceSchemaMigrations.ts
+++ b/packages/maker/src/conversion/toMarketplace/convertInterfaceSchemaMigrations.ts
@@ -43,6 +43,8 @@ export function convertInterfaceSchemaMigrations(
       (transition): [string, OntologyIrInterfaceTypeSchemaTransition] => [
         transition.id,
         {
+          // For ontology-ir, this carries the authored id, not a rid, despite its name
+          rid: transition.id,
           id: transition.id,
           title: transition.title,
           description: transition.description,


### PR DESCRIPTION
## Targeting https://github.com/palantir/osdk-ts/pull/3972

Bumps to the latest ITSM bindings which include the RID.