### PR TITLE
preserve value types in generated SDK metadata

### DIFF
--- a/.changeset/read-value-types-in-sdk-metadata.md
+++ b/.changeset/read-value-types-in-sdk-metadata.md
@@ -1,0 +1,6 @@
+---
+"@osdk/generator-converters.preview": patch
+"@osdk/generator-converters.ontologyir": patch
+---
+
+Read connected value type blocks during SDK generation and preserve their definitions in ontology metadata.

--- a/packages/generator-converters.ontologyir/src/OntologyBlockDataToFullMetadataConverter.ts
+++ b/packages/generator-converters.ontologyir/src/OntologyBlockDataToFullMetadataConverter.ts
@@ -99,14 +99,11 @@ export class OntologyBlockDataToFullMetadataConverter {
         displayName: "ontology",
         description: "",
       },
-      valueTypes: {
-        ...Object.fromEntries(
-          valueTypes.map(
-            valueType => [valueType.apiName, convertValueType(valueType)],
-          ),
+      valueTypes: Object.fromEntries(
+        valueTypes.map(
+          valueType => [valueType.apiName, convertValueType(valueType)],
         ),
-        ...importedTypes?.valueTypes,
-      },
+      ),
     };
   }
 

--- a/packages/generator-converters.ontologyir/src/OntologyBlockDataToFullMetadataConverter.ts
+++ b/packages/generator-converters.ontologyir/src/OntologyBlockDataToFullMetadataConverter.ts
@@ -33,6 +33,10 @@ import type * as Ontologies from "@osdk/foundry.ontologies";
 
 import invariant from "tiny-invariant";
 import type { ApiName } from "./ApiName.js";
+import {
+  convertValueType,
+  type ResolvedValueType,
+} from "./convertValueType.js";
 import { toStructFieldRid } from "./ridUtils.js";
 
 export class OntologyBlockDataToFullMetadataConverter {
@@ -40,6 +44,7 @@ export class OntologyBlockDataToFullMetadataConverter {
     blockData: OntologyBlockDataV2,
     importedTypes?: Ontologies.OntologyFullMetadata,
     transitiveImportedBlockData?: OntologyBlockDataV2,
+    valueTypes: readonly ResolvedValueType[] = [],
   ): Ontologies.OntologyFullMetadata {
     const objectTypeLookup = buildBlockDataObjectTypeLookup(
       blockData,
@@ -94,7 +99,14 @@ export class OntologyBlockDataToFullMetadataConverter {
         displayName: "ontology",
         description: "",
       },
-      valueTypes: {},
+      valueTypes: {
+        ...Object.fromEntries(
+          valueTypes.map(
+            valueType => [valueType.apiName, convertValueType(valueType)],
+          ),
+        ),
+        ...importedTypes?.valueTypes,
+      },
     };
   }
 

--- a/packages/generator-converters.ontologyir/src/convertValueType.test.ts
+++ b/packages/generator-converters.ontologyir/src/convertValueType.test.ts
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  convertValueType,
+  type ResolvedValueType,
+} from "./convertValueType.js";
+
+const valueType: ResolvedValueType = {
+  rid: "classification-rid",
+  apiName: "classification",
+  displayMetadata: {
+    displayName: "Classification",
+    description: "A classification",
+  },
+  status: { type: "active", active: {} },
+  version: "1.0.0",
+  baseType: { type: "string", string: {} },
+  constraints: [],
+};
+
+describe("convertValueType", () => {
+  it("converts named metadata and preserves multiple constraints", () => {
+    const result = convertValueType({
+      ...valueType,
+      constraints: [
+        {
+          constraint: {
+            failureMessage: undefined,
+            constraint: {
+              type: "string",
+              string: {
+                type: "oneOf",
+                oneOf: { values: ["A", "B"], useIgnoreCase: false },
+              },
+            },
+          },
+        },
+        {
+          constraint: {
+            failureMessage: undefined,
+            constraint: {
+              type: "string",
+              string: { type: "length", length: { minSize: 1, maxSize: 10 } },
+            },
+          },
+        },
+      ],
+    });
+    expect(result).toEqual({
+      apiName: "classification",
+      rid: "classification-rid",
+      displayName: "Classification",
+      description: "A classification",
+      status: "ACTIVE",
+      version: "1.0.0",
+      fieldType: { type: "string" },
+      constraints: [{ type: "enum", options: ["A", "B"] }, {
+        type: "length",
+        minimumLength: 1,
+        maximumLength: 10,
+      }],
+    });
+  });
+
+  it("converts array types and their element constraints", () => {
+    const result = convertValueType({
+      ...valueType,
+      baseType: {
+        type: "array",
+        array: { elementType: { type: "boolean", boolean: {} } },
+      },
+      constraints: [{
+        constraint: {
+          failureMessage: undefined,
+          constraint: {
+            type: "array",
+            array: {
+              size: { minSize: 1, maxSize: 3 },
+              elementsUnique: false,
+              elementsConstraint: {
+                type: "boolean",
+                boolean: {
+                  allowedValues: ["TRUE_VALUE", "FALSE_VALUE", "NULL_VALUE"],
+                },
+              },
+            },
+          },
+        },
+      }],
+    });
+    expect(result.fieldType).toEqual({
+      type: "array",
+      subType: { type: "boolean" },
+    });
+    expect(result.constraints).toEqual([{
+      type: "array",
+      minimumSize: 1,
+      maximumSize: 3,
+      uniqueValues: false,
+      valueConstraint: { type: "enum", options: [true, false, null] },
+    }]);
+  });
+
+  it("converts numeric ranges and enum options", () => {
+    const result = convertValueType({
+      ...valueType,
+      constraints: [
+        {
+          constraint: {
+            failureMessage: undefined,
+            constraint: {
+              type: "integer",
+              integer: { type: "range", range: { min: 0, max: 10 } },
+            },
+          },
+        },
+        {
+          constraint: {
+            failureMessage: undefined,
+            constraint: {
+              type: "string",
+              string: {
+                type: "oneOf",
+                oneOf: { values: ["A"], useIgnoreCase: true },
+              },
+            },
+          },
+        },
+      ],
+    });
+    expect(result.constraints).toEqual([{
+      type: "range",
+      minimumValue: 0,
+      maximumValue: 10,
+    }, {
+      type: "enum",
+      options: ["A"],
+    }]);
+  });
+});

--- a/packages/generator-converters.ontologyir/src/convertValueType.ts
+++ b/packages/generator-converters.ontologyir/src/convertValueType.ts
@@ -181,12 +181,6 @@ function convertConstraint(
         valueConstraint: constraint.array.elementsConstraint
           && convertConstraint(constraint.array.elementsConstraint),
       };
-    default:
-      return {
-        type: "unsupported",
-        unsupportedType: constraint.type,
-        params: {},
-      };
   }
   return { type: "unsupported", unsupportedType: constraint.type, params: {} };
 }

--- a/packages/generator-converters.ontologyir/src/convertValueType.ts
+++ b/packages/generator-converters.ontologyir/src/convertValueType.ts
@@ -1,0 +1,210 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import type {
+  BaseType,
+  DataConstraint,
+  DecimalTypeDataConstraints,
+  DoubleTypeDataConstraints,
+  FloatTypeDataConstraints,
+  IntegerTypeDataConstraints,
+  LongTypeDataConstraints,
+  ShortTypeDataConstraints,
+  ValueTypeApiName,
+  ValueTypeDataConstraint,
+  ValueTypeDisplayMetadata,
+  ValueTypeRid,
+  ValueTypeStatus,
+  ValueTypeVersion,
+} from "@osdk/client.unstable";
+import type * as Ontologies from "@osdk/foundry.ontologies";
+
+export interface ResolvedValueType {
+  rid: ValueTypeRid;
+  apiName: ValueTypeApiName;
+  displayMetadata: ValueTypeDisplayMetadata;
+  status: ValueTypeStatus;
+  version: ValueTypeVersion;
+  baseType: BaseType;
+  constraints: ValueTypeDataConstraint[];
+}
+
+export function convertValueType(
+  valueType: ResolvedValueType,
+): Ontologies.OntologyValueType {
+  return {
+    apiName: valueType.apiName,
+    rid: valueType.rid,
+    version: valueType.version,
+    displayName: valueType.displayMetadata.displayName,
+    description: valueType.displayMetadata.description,
+    status: valueType.status.type === "active" ? "ACTIVE" : "DEPRECATED",
+    fieldType: convertFieldType(valueType.baseType),
+    constraints: valueType.constraints
+      .map(({ constraint }) => convertConstraint(constraint.constraint))
+      .filter(constraint => constraint.type !== "unsupported"),
+  };
+}
+
+function convertFieldType(baseType: BaseType): Ontologies.ValueTypeFieldType {
+  switch (baseType.type) {
+    case "array":
+      return {
+        type: "array",
+        subType: convertFieldType(baseType.array.elementType),
+      };
+    case "map":
+      return {
+        type: "map",
+        keyType: convertFieldType(baseType.map.keyType),
+        valueType: convertFieldType(baseType.map.valueType),
+      };
+    case "optional":
+      return {
+        type: "optional",
+        wrappedType: convertFieldType(baseType.optional.wrappedType),
+      };
+    case "union":
+      return {
+        type: "union",
+        memberTypes: baseType.union.memberTypes.map(convertFieldType),
+      };
+    case "referenced":
+      return { type: "reference" };
+    case "struct":
+      return {
+        type: "struct",
+        fields: baseType.struct.fields.map(field => ({
+          name: field.name,
+          fieldType: convertFieldType(field.type),
+        })),
+      };
+    case "structV2":
+      return {
+        type: "struct",
+        fields: baseType.structV2.fields.map(field => ({
+          name: field.identifier,
+          fieldType: convertFieldType(field.baseType),
+        })),
+      };
+    default:
+      return { type: baseType.type };
+  }
+}
+
+function convertConstraint(
+  constraint: DataConstraint,
+): Ontologies.ValueTypeConstraint {
+  switch (constraint.type) {
+    case "string": {
+      const value = constraint.string;
+      switch (value.type) {
+        case "oneOf":
+          return { type: "enum", options: value.oneOf.values };
+        case "regex":
+          return {
+            type: "regex",
+            pattern: value.regex.regexPattern,
+            partialMatch: value.regex.usePartialMatch ?? false,
+          };
+        case "length":
+          return {
+            type: "length",
+            minimumLength: value.length.minSize,
+            maximumLength: value.length.maxSize,
+          };
+        case "isRid":
+          return { type: "rid" };
+        case "isUuid":
+          return { type: "uuid" };
+      }
+      break;
+    }
+    case "boolean":
+      return {
+        type: "enum",
+        options: constraint.boolean.allowedValues.map(value =>
+          ({ TRUE_VALUE: true, FALSE_VALUE: false, NULL_VALUE: null })[value]
+        ),
+      };
+    case "integer":
+      return convertNumericConstraint(constraint.integer);
+    case "short":
+      return convertNumericConstraint(constraint.short);
+    case "long":
+      return constraint.long.type === "oneOf"
+        ? { type: "enum", options: constraint.long.oneOf.values.map(String) }
+        : convertNumericConstraint(constraint.long);
+    case "float":
+      return convertNumericConstraint(constraint.float);
+    case "double":
+      return convertNumericConstraint(constraint.double);
+    case "decimal":
+      return convertNumericConstraint(constraint.decimal);
+    case "binary":
+      return {
+        type: "range",
+        minimumValue: constraint.binary.size.minSize,
+        maximumValue: constraint.binary.size.maxSize,
+      };
+    case "date":
+      return {
+        type: "range",
+        minimumValue: constraint.date.range.min,
+        maximumValue: constraint.date.range.max,
+      };
+    case "timestamp":
+      return {
+        type: "range",
+        minimumValue: constraint.timestamp.range.min,
+        maximumValue: constraint.timestamp.range.max,
+      };
+    case "array":
+      return {
+        type: "array",
+        minimumSize: constraint.array.size?.minSize,
+        maximumSize: constraint.array.size?.maxSize,
+        uniqueValues: constraint.array.elementsUnique ?? false,
+        valueConstraint: constraint.array.elementsConstraint
+          && convertConstraint(constraint.array.elementsConstraint),
+      };
+    default:
+      return {
+        type: "unsupported",
+        unsupportedType: constraint.type,
+        params: {},
+      };
+  }
+  return { type: "unsupported", unsupportedType: constraint.type, params: {} };
+}
+
+function convertNumericConstraint(
+  value:
+    | IntegerTypeDataConstraints
+    | ShortTypeDataConstraints
+    | LongTypeDataConstraints
+    | FloatTypeDataConstraints
+    | DoubleTypeDataConstraints
+    | DecimalTypeDataConstraints,
+): Ontologies.ValueTypeConstraint {
+  return value.type === "oneOf"
+    ? { type: "enum", options: value.oneOf.values }
+    : {
+      type: "range",
+      minimumValue: value.range.min,
+      maximumValue: value.range.max,
+    };
+}

--- a/packages/generator-converters.ontologyir/src/index.ts
+++ b/packages/generator-converters.ontologyir/src/index.ts
@@ -27,6 +27,7 @@ export type {
   ISetDataType,
 } from "./convertDataType.js";
 export { isInjectedRuntimeInput } from "./convertDataType.js";
+export type { ResolvedValueType } from "./convertValueType.js";
 export {
   type BlockDataApiNameLookup,
   buildBlockDataInterfaceLinkTypeLookup,

--- a/packages/generator-converters.preview/src/PreviewOntologyIrConverter.ts
+++ b/packages/generator-converters.preview/src/PreviewOntologyIrConverter.ts
@@ -23,6 +23,7 @@ import {
   buildBlockDataInterfaceTypeLookup,
   buildBlockDataObjectTypeLookup,
   OntologyBlockDataToFullMetadataConverter,
+  type ResolvedValueType,
   toUuid,
 } from "@osdk/generator-converters.ontologyir";
 import { convertBlockDataLogicRulesToActionLogicRules } from "./ActionLogicRuleConverter.js";
@@ -48,9 +49,15 @@ export class PreviewOntologyIrConverter {
   static getPreviewFullMetadataFromBlockData(
     blockdata: OntologyBlockDataV2,
     importedTypes?: Ontologies.OntologyFullMetadata,
+    valueTypes: readonly ResolvedValueType[] = [],
   ): PreviewOntologyFullMetadata {
     const baseMetadata = OntologyBlockDataToFullMetadataConverter
-      .getFullMetadataFromBlockData(blockdata, importedTypes);
+      .getFullMetadataFromBlockData(
+        blockdata,
+        importedTypes,
+        undefined,
+        valueTypes,
+      );
 
     const actionTypes = this.convertActionTypesWithFullLogicRulesFromBlockData(
       blockdata.actionTypes,

--- a/packages/generator-converters.preview/src/cli/generate-sdk.ts
+++ b/packages/generator-converters.preview/src/cli/generate-sdk.ts
@@ -34,6 +34,7 @@ import yargs from "yargs";
 import { hideBin } from "yargs/helpers";
 
 import { PreviewOntologyIrConverter } from "../PreviewOntologyIrConverter.js";
+import { loadSdkInput } from "./loadSdkInput.js";
 
 const PYTHON_SDK_PACKAGE_NAME = "ontology_sdk";
 
@@ -153,14 +154,18 @@ async function main(): Promise<void> {
     .help()
     .version(false) // so that we can use --version argument for the package version
     .usage(
-      "$0 --input <path> --package-name <name> --version <ver> --output-dir <dir>",
+      "$0 (--input <path> | --block-results-input <path>) --package-name <name> --version <ver> --output-dir <dir>",
     )
     .options({
       input: {
         describe: "Path to the OntologyIR JSON file",
         type: "string",
-        demandOption: true,
         coerce: path.resolve,
+      },
+      "block-results-input": {
+        describe: "Path to the block result JSON collection",
+        type: "string",
+        coerce: (input: string) => path.resolve(input),
       },
       "package-name": {
         describe: "Name for the generated SDK package",
@@ -222,45 +227,15 @@ async function main(): Promise<void> {
     })
     .parse();
 
-  const inputFile = argv.input;
   const packageName = argv.packageName;
   const packageVersion = argv.version;
   const outputDir = argv.outputDir;
 
-  // Validate input file exists
-  try {
-    await fs.access(inputFile);
-  } catch {
-    consola.error(`Input file does not exist: ${inputFile}`);
-    process.exit(1);
-  }
-
-  consola.info(`Converting ${inputFile}...`);
-
-  const fileContent = await fs.readFile(inputFile, "utf-8");
-  let blockDataJson: unknown;
-  try {
-    const parsed = JSON.parse(fileContent);
-    // Handle both wrapped (ontology.objectTypes) and unwrapped (objectTypes) formats
-    blockDataJson = parsed.ontology ?? parsed;
-  } catch {
-    consola.error(`Failed to parse JSON from ${inputFile}`);
-    process.exit(1);
-  }
-
-  // Basic structural validation before passing to converter
-  const blockData = blockDataJson as Record<string, unknown>;
-  if (
-    !blockData
-    || typeof blockData !== "object"
-    || !("objectTypes" in blockData)
-    || !("actionTypes" in blockData)
-  ) {
-    consola.error(
-      `Invalid Ontology structure in ${inputFile}. Expected objectTypes and actionTypes fields.`,
-    );
-    process.exit(1);
-  }
+  const { ontology, valueTypes } = await loadSdkInput({
+    input: argv.input,
+    blockResultsInput: argv.blockResultsInput,
+  });
+  consola.info(`Converting ${argv.input ?? argv.blockResultsInput}...`);
 
   const importJson = argv.importJson
     ? JSON.parse(await fs.readFile(argv.importJson, "utf-8"))
@@ -268,10 +243,9 @@ async function main(): Promise<void> {
 
   const previewMetadata = PreviewOntologyIrConverter
     .getPreviewFullMetadataFromBlockData(
-      blockDataJson as Parameters<
-        typeof PreviewOntologyIrConverter.getPreviewFullMetadataFromBlockData
-      >[0],
+      ontology,
       importJson,
+      valueTypes,
     );
 
   // Generate the Python SDK before function discovery so that Python functions

--- a/packages/generator-converters.preview/src/cli/loadSdkInput.test.ts
+++ b/packages/generator-converters.preview/src/cli/loadSdkInput.test.ts
@@ -17,6 +17,8 @@
 import * as fs from "node:fs/promises";
 import * as path from "node:path";
 
+import type { OntologyFullMetadata } from "@osdk/foundry.ontologies";
+import { generateClientSdkVersionTwoPointZero } from "@osdk/generator";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { PreviewOntologyIrConverter } from "../PreviewOntologyIrConverter.js";
@@ -169,6 +171,81 @@ describe("loadSdkInput", () => {
       path.resolve("definitions/classification/value-types.json"),
       "utf-8",
     );
+  });
+
+  it("preserves generation for imported properties with multiple value type constraints", async () => {
+    vi.mocked(fs.readFile).mockResolvedValue(JSON.stringify(ontology));
+    const loaded = await loadSdkInput({ input: inputFile });
+    const imported: OntologyFullMetadata = {
+      ...PreviewOntologyIrConverter.getPreviewFullMetadataFromBlockData(
+        loaded.ontology,
+      ),
+      actionTypes: {},
+      objectTypes: {
+        Item: {
+          objectType: {
+            apiName: "Item",
+            rid: "item-rid",
+            displayName: "Item",
+            pluralDisplayName: "Items",
+            primaryKey: "id",
+            titleProperty: "id",
+            status: "ACTIVE",
+            aliases: [],
+            datasources: [],
+            icon: { type: "blueprint", name: "cube", color: "blue" },
+            properties: {
+              id: {
+                rid: "id-rid",
+                dataType: { type: "string" },
+                valueTypeApiName: "classification",
+                typeClasses: [],
+              },
+            },
+          },
+          linkTypes: [],
+          implementsInterfaces: [],
+          implementsInterfaces2: {},
+          sharedPropertyTypeMapping: {},
+        },
+      },
+      valueTypes: {
+        classification: {
+          apiName: "classification",
+          rid: "value-type-rid",
+          displayName: "Classification",
+          version: "1.0.0",
+          fieldType: { type: "string" },
+          constraints: [
+            { type: "enum", options: ["A", "B"] },
+            { type: "length", minimumLength: 1, maximumLength: 10 },
+          ],
+        },
+      },
+    };
+    const metadata = PreviewOntologyIrConverter
+      .getPreviewFullMetadataFromBlockData(
+        loaded.ontology,
+        imported,
+        loaded.valueTypes,
+      );
+    const writeFile = vi.fn<(file: string, contents: string) => Promise<void>>()
+      .mockResolvedValue(undefined);
+    await expect(generateClientSdkVersionTwoPointZero(
+      { ...metadata, actionTypes: {} },
+      "test",
+      {
+        readdir: () => Promise.resolve([]),
+        mkdir: () => Promise.resolve(),
+        writeFile,
+      },
+      "/virtual-sdk",
+      "module",
+    )).resolves.toBeUndefined();
+    expect(writeFile).toHaveBeenCalled();
+    expect(metadata.valueTypes).toEqual({});
+    expect(metadata.objectTypes.Item.objectType.properties.id.valueTypeApiName)
+      .toBe("classification");
   });
 
   it("does not read value type blocks for external inputs without local mappings", async () => {

--- a/packages/generator-converters.preview/src/cli/loadSdkInput.test.ts
+++ b/packages/generator-converters.preview/src/cli/loadSdkInput.test.ts
@@ -1,0 +1,196 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { PreviewOntologyIrConverter } from "../PreviewOntologyIrConverter.js";
+import { loadSdkInput } from "./loadSdkInput.js";
+
+vi.mock("node:fs/promises", () => ({ readFile: vi.fn() }));
+
+const inputFile = path.resolve("build/block-results.json");
+const ontology = {
+  objectTypes: {},
+  actionTypes: {},
+  interfaceTypes: {},
+  sharedPropertyTypes: {},
+  linkTypes: {},
+  knownIdentifiers: {
+    valueTypes: { "value-type-rid": { "version-id": "generated-id" } },
+  },
+};
+
+beforeEach(() => {
+  vi.resetAllMocks();
+});
+
+describe("loadSdkInput", () => {
+  it.each([ontology, { ontology }])(
+    "preserves legacy ontology input: %j",
+    async data => {
+      vi.mocked(fs.readFile).mockResolvedValue(JSON.stringify(data));
+      await expect(loadSdkInput({ input: inputFile })).resolves.toEqual({
+        ontology,
+        valueTypes: [],
+      });
+      expect(fs.readFile).toHaveBeenCalledExactlyOnceWith(inputFile, "utf-8");
+    },
+  );
+
+  it("requires exactly one input option", async () => {
+    await expect(loadSdkInput({})).rejects.toThrow("Provide exactly one");
+    await expect(
+      loadSdkInput({ input: inputFile, blockResultsInput: inputFile }),
+    ).rejects.toThrow("Provide exactly one");
+    expect(fs.readFile).not.toHaveBeenCalled();
+  });
+
+  it("retains the existing ontology structure check", async () => {
+    vi.mocked(fs.readFile).mockResolvedValue("{}");
+    await expect(loadSdkInput({ input: inputFile })).rejects.toThrow(
+      "Invalid Ontology structure",
+    );
+  });
+
+  it("loads each connected value type once and selects its latest available version", async () => {
+    const firstOutput = "produced-value-type-classification-1.0.0";
+    const secondOutput = "produced-value-type-classification-1.1.0";
+    const metadata = {
+      apiName: "classification",
+      displayMetadata: { displayName: "Classification" },
+      baseType: { type: "string", string: {} },
+      status: { type: "active", active: {} },
+    };
+    const latest = {
+      version: "1.10.0-10",
+      baseType: { type: "integer", integer: {} },
+      constraints: [],
+    };
+    const data = {
+      ...ontology,
+      knownIdentifiers: {
+        valueTypes: {
+          "value-type-rid": { first: "first-id", second: "second-id" },
+        },
+      },
+    };
+    vi.mocked(fs.readFile)
+      .mockResolvedValueOnce(JSON.stringify([
+        {
+          block_type: "ONTOLOGY",
+          block_data_directory: "ontology",
+          inputs: {
+            first: { type: "valueType" },
+            second: { type: "valueType" },
+            external: { type: "valueType" },
+          },
+          outputs: {},
+          input_mapping_entries: [{ input: "first", output: firstOutput }, {
+            input: "second",
+            output: secondOutput,
+          }],
+          add_on_override: {
+            idToBlockShapeId: { first: "first-id", second: "second-id" },
+          },
+        },
+        {
+          block_type: "VALUE_TYPE",
+          block_data_directory: path.resolve("definitions/classification"),
+          outputs: {
+            [firstOutput]: { type: "valueType" },
+            [secondOutput]: { type: "valueType" },
+          },
+        },
+        {
+          block_type: "VALUE_TYPE",
+          block_data_directory: "unused",
+          outputs: { unused: { type: "valueType" } },
+        },
+        { block_type: "STATIC_DATASET", outputs: {} },
+      ]))
+      .mockResolvedValueOnce(JSON.stringify(data))
+      .mockResolvedValueOnce(JSON.stringify({
+        metadata,
+        versions: [
+          { version: "1.0.0", constraints: [] },
+          latest,
+          { version: "1.10.0-2", constraints: [] },
+          { version: "1.10.0", constraints: [] },
+          { version: "1.1.0", constraints: [] },
+        ],
+      }));
+
+    const loaded = await loadSdkInput({ blockResultsInput: inputFile });
+    expect(loaded).toEqual({
+      ontology: data,
+      valueTypes: [{ ...metadata, ...latest, rid: "value-type-rid" }],
+    });
+    const converted = PreviewOntologyIrConverter
+      .getPreviewFullMetadataFromBlockData(
+        loaded.ontology,
+        undefined,
+        loaded.valueTypes,
+      );
+    expect(JSON.parse(JSON.stringify(converted)).valueTypes).toEqual({
+      classification: {
+        apiName: "classification",
+        displayName: "Classification",
+        rid: "value-type-rid",
+        status: "ACTIVE",
+        version: "1.10.0-10",
+        fieldType: { type: "integer" },
+        constraints: [],
+      },
+    });
+    expect(fs.readFile).toHaveBeenCalledTimes(3);
+    expect(fs.readFile).toHaveBeenNthCalledWith(
+      2,
+      path.resolve("build/ontology/ontology.json"),
+      "utf-8",
+    );
+    expect(fs.readFile).toHaveBeenNthCalledWith(
+      3,
+      path.resolve("definitions/classification/value-types.json"),
+      "utf-8",
+    );
+  });
+
+  it("does not read value type blocks for external inputs without local mappings", async () => {
+    vi.mocked(fs.readFile)
+      .mockResolvedValueOnce(JSON.stringify([
+        {
+          block_type: "ONTOLOGY",
+          block_data_directory: "ontology",
+          inputs: { external: { type: "valueType" } },
+          outputs: {},
+          input_mapping_entries: [],
+        },
+        {
+          block_type: "VALUE_TYPE",
+          block_data_directory: "unused",
+          outputs: {},
+        },
+      ]))
+      .mockResolvedValueOnce(JSON.stringify(ontology));
+
+    await expect(loadSdkInput({ blockResultsInput: inputFile })).resolves
+      .toEqual({ ontology, valueTypes: [] });
+    expect(fs.readFile).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/generator-converters.preview/src/cli/loadSdkInput.ts
+++ b/packages/generator-converters.preview/src/cli/loadSdkInput.ts
@@ -1,0 +1,158 @@
+/*
+ * Copyright 2026 Palantir Technologies, Inc. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as fs from "node:fs/promises";
+import * as path from "node:path";
+
+import type { OntologyBlockDataV2 } from "@osdk/client.unstable";
+import type { InputShape, OutputShape } from "@osdk/client.unstable/api";
+import type { ResolvedValueType } from "@osdk/generator-converters.ontologyir";
+
+type ValueTypeDefinition = {
+  metadata: Pick<
+    ResolvedValueType,
+    "apiName" | "displayMetadata" | "status" | "baseType"
+  >;
+  versions: Array<
+    Pick<ResolvedValueType, "version" | "constraints"> & {
+      baseType?: ResolvedValueType["baseType"];
+    }
+  >;
+};
+
+type ValueTypeConnection = Pick<ResolvedValueType, "rid"> & { output: string };
+type ValueTypeOutput = Omit<ResolvedValueType, "rid">;
+
+export async function loadSdkInput(options: {
+  input?: string;
+  blockResultsInput?: string;
+}): Promise<
+  { ontology: OntologyBlockDataV2; valueTypes: ResolvedValueType[] }
+> {
+  const inputFile = options.input ?? options.blockResultsInput;
+  if (
+    inputFile === undefined
+    || (options.input !== undefined && options.blockResultsInput !== undefined)
+  ) {
+    throw new Error("Provide exactly one of --input or --block-results-input.");
+  }
+
+  const data = await readJson(inputFile);
+  if (options.input !== undefined) {
+    return { ontology: ontologyData(data, inputFile), valueTypes: [] };
+  }
+
+  const blocks = data as Record<string, unknown>[];
+  const ontologyBlock = blocks.find(block => block.block_type === "ONTOLOGY")!;
+  const ontologyFile = blockFile(ontologyBlock, inputFile, "ontology.json");
+  const ontology = ontologyData(await readJson(ontologyFile), ontologyFile);
+  const connections = getValueTypeConnections(ontology, ontologyBlock);
+  const outputs = await loadValueTypeOutputs(blocks, connections, inputFile);
+  const valueTypes = new Map(
+    connections.map((
+      { rid, output },
+    ) => [rid, { ...outputs.get(output)!, rid }]),
+  );
+  return { ontology, valueTypes: Array.from(valueTypes.values()) };
+}
+
+function getValueTypeConnections(
+  ontology: OntologyBlockDataV2,
+  block: Record<string, unknown>,
+): ValueTypeConnection[] {
+  const ridByInternalId = new Map(
+    Object.entries(ontology.knownIdentifiers.valueTypes).flatMap((
+      [rid, versions],
+    ) => Object.values(versions).map(internalId => [internalId, rid] as const)),
+  );
+
+  const inputs = block.inputs as Record<string, InputShape>;
+  const mappings = block.input_mapping_entries as Record<string, string>[];
+  const addOn = block.add_on_override as Record<string, unknown>;
+  const identities = addOn?.idToBlockShapeId as Record<string, string>;
+
+  // Imported value types have external recommendations, not local mappings.
+  return mappings
+    .filter(({ input }) => inputs[input].type === "valueType")
+    .map(({ input, output }) => ({
+      rid: ridByInternalId.get(identities[input])!,
+      output,
+    }));
+}
+
+async function loadValueTypeOutputs(
+  blocks: Record<string, unknown>[],
+  connections: ValueTypeConnection[],
+  inputFile: string,
+): Promise<Map<string, ValueTypeOutput>> {
+  const neededOutputs = new Set(
+    connections.map(connection => connection.output),
+  );
+  const producers = blocks.filter(block =>
+    block.block_type === "VALUE_TYPE"
+    && Object.keys(block.outputs as Record<string, OutputShape>).some(output =>
+      neededOutputs.has(output)
+    )
+  );
+  const entries = await Promise.all(producers.map(async block => {
+    const definition = await readJson(
+      blockFile(block, inputFile, "value-types.json"),
+    ) as ValueTypeDefinition;
+    // Metadata uses the latest available version; numeric suffixes sort after the base version.
+    const [latest] = definition.versions.sort((a, b) =>
+      b.version.localeCompare(a.version, "en", { numeric: true })
+    );
+    const valueType = {
+      ...definition.metadata,
+      ...latest,
+      baseType: latest.baseType ?? definition.metadata.baseType,
+    };
+    return Object.keys(block.outputs as Record<string, OutputShape>).map(
+      output => [output, valueType] as const,
+    );
+  }));
+  return new Map(entries.flat());
+}
+
+function ontologyData(data: unknown, file: string): OntologyBlockDataV2 {
+  const wrapped = data as { ontology?: OntologyBlockDataV2 };
+  const ontology = wrapped?.ontology ?? data as OntologyBlockDataV2;
+  if (
+    !ontology || typeof ontology !== "object" || !("objectTypes" in ontology)
+    || !("actionTypes" in ontology)
+  ) {
+    throw new Error(
+      `Invalid Ontology structure in ${file}. Expected objectTypes and actionTypes fields.`,
+    );
+  }
+  return ontology;
+}
+
+function blockFile(
+  block: Record<string, unknown>,
+  inputFile: string,
+  name: string,
+): string {
+  return path.resolve(
+    path.dirname(inputFile),
+    block.block_data_directory as string,
+    name,
+  );
+}
+
+async function readJson(file: string): Promise<unknown> {
+  return JSON.parse(await fs.readFile(file, "utf-8"));
+}


### PR DESCRIPTION
We want SDK metadata generated from Maker definitions to preserve value types and their constraints. For example, a string property may use a value type that allows only certain values; the SDK metadata needs that definition, not just the primitive string type (right now it's just the string).

Maker already writes these definitions into value type blocks alongside the ontology block. However, today `generate-sdk` reads only `ontology.json`, and the metadata converter returns `valueTypes: {}`, so those definitions never reach `ontology-metadata.json`. In the prior PR in this work #3998 we preserved the identity mappings needed to connect the blocks. This PR then uses them to:

- read the ontology and its connected value type defs from the existing block list
- resolve those connections using the saved mappings
- populate `ontology-metadata.json.valueTypes` with each type’s name, latest version available in its block (this is in-line with behavior elsewhere in platform but lmk if this is wrong), base type, and supported constraints

The definitions go through the existing converters and metadata writer, and the new `--block-results-input` option accepts the value types + ontology data, while `--input` continues accepting a standalone ontology file.

This preserves the definitions in metadata, but FLUP PRs will actually use these definitions, narrow generated TypeScript, and switch Foundry CLI callers for our usecase.


