### PR TITLE
Pass imported ontology metadata to TypeScript Function discovery

### DIFF
--- a/.changeset/smooth-spiders-discover.md
+++ b/.changeset/smooth-spiders-discover.md
@@ -1,0 +1,5 @@
+---
+"@osdk/maker-experimental": patch
+---
+
+Include imported ontology metadata when discovering TypeScript Function signatures.

--- a/packages/maker-experimental/src/cli/main.ts
+++ b/packages/maker-experimental/src/cli/main.ts
@@ -172,6 +172,13 @@ export default async function main(
     );
   }
 
+  const importedOntologyMetadata =
+    commandLineOpts.importJson && fs.existsSync(commandLineOpts.importJson)
+      ? (JSON.parse(
+          await fs.promises.readFile(commandLineOpts.importJson, "utf-8"),
+        ) as ImportedOntologyMetadata)
+      : undefined;
+
   let functionsIrFile;
   if (commandLineOpts.temporaryBlockDataFile) {
     consola.info(
@@ -195,6 +202,7 @@ export default async function main(
         blockDataJson as Parameters<
           typeof PreviewOntologyIrConverter.getPreviewFullMetadataFromBlockData
         >[0],
+        importedOntologyMetadata,
       );
     invariant(
       commandLineOpts.functionsDir && commandLineOpts.nodeModulesDir,
@@ -225,14 +233,9 @@ export default async function main(
     await fs.promises.mkdir(commandLineOpts.buildDir, { recursive: true });
   }
 
-  const importedLinkTypeIdsByApiName =
-    commandLineOpts.importJson && fs.existsSync(commandLineOpts.importJson)
-      ? getImportedLinkTypeIdsByApiName(
-          JSON.parse(
-            await fs.promises.readFile(commandLineOpts.importJson, "utf-8"),
-          ) as ImportedOntologyMetadata,
-        )
-      : undefined;
+  const importedLinkTypeIdsByApiName = importedOntologyMetadata
+    ? getImportedLinkTypeIdsByApiName(importedOntologyMetadata)
+    : undefined;
 
   const {
     ontologyIr,


### PR DESCRIPTION
  Update `@osdk/maker-experimental` to include imported ontology
 metadata when constructing the preview metadata supplied to
 `@foundry/functions-typescript-osdk-discovery`.

   Previously, Function signatures referencing imported ontology
 types could fail discovery with errors such as:

   > `"Edits.Object<MyObjectType>" is not a supported type.`

   The imported metadata is now loaded before Function discovery
 and reused later when resolving imported link type IDs.
