### PR TITLE
Add OTDP Flag to React hooks

### DIFF
--- a/.changeset/bright-hooks-derive.md
+++ b/.changeset/bright-hooks-derive.md
@@ -1,0 +1,6 @@
+---
+"@osdk/client": patch
+"@osdk/react": patch
+---
+
+Support configuring ontology-defined derived property loading in React object hooks.

--- a/packages/client/src/object/convertWireToOsdkObjects/createOsdkObject.ts
+++ b/packages/client/src/object/convertWireToOsdkObjects/createOsdkObject.ts
@@ -23,7 +23,6 @@ import type {
   ReferenceValue,
   SecuredPropertyValue,
 } from "@osdk/foundry.ontologies";
-import deepEqual from "fast-deep-equal";
 import invariant from "tiny-invariant";
 
 import { CipherTextPropertyImpl } from "../../createCipherTextProperty.js";
@@ -62,43 +61,6 @@ const specialPropertyTypes = new Set<BaseWirePropertyTypes>([
 
 const securableSpecialKeys = new Set(["$primaryKey", "$title"]);
 
-const cloneUpdateFields = new WeakMap<ObjectHolder, ReadonlySet<string>>();
-
-/** @internal */
-export function getCloneUpdateFields(
-  value: ObjectHolder,
-): ReadonlySet<string> | undefined {
-  return cloneUpdateFields.get(value);
-}
-
-/** @internal */
-export function clearCloneUpdateFields(value: ObjectHolder): void {
-  cloneUpdateFields.delete(value);
-}
-
-function recordCloneUpdateFields(
-  source: ObjectHolder,
-  clone: ObjectHolder,
-  update: Record<string, any> | undefined,
-): ObjectHolder {
-  const fields = new Set(cloneUpdateFields.get(source));
-  if (update) {
-    const objectDef = source[ObjectDefRef];
-    for (const field of Object.keys(update)) {
-      if (
-        field in objectDef.properties &&
-        !deepEqual(source[field], update[field])
-      ) {
-        fields.add(field);
-      }
-    }
-  }
-  // Store an empty set as well, so OptimisticJob can distinguish a no-op clone
-  // from an object that was not produced by $clone.
-  cloneUpdateFields.set(clone, fields);
-  return clone;
-}
-
 // kept separate so we are not redefining these functions
 // every time an object is created.
 const basePropDefs = {
@@ -119,11 +81,7 @@ const basePropDefs = {
       const def = this[ObjectDefRef];
 
       if (update == null) {
-        return recordCloneUpdateFields(
-          this,
-          createOsdkObject(this[ClientRef], def, { ...rawObj }),
-          update,
-        );
+        return createOsdkObject(this[ClientRef], def, { ...rawObj });
       }
 
       if (
@@ -140,11 +98,7 @@ const basePropDefs = {
       }
 
       const newObject = { ...this[UnderlyingOsdkObject], ...update };
-      return recordCloneUpdateFields(
-        this,
-        createOsdkObject(this[ClientRef], this[ObjectDefRef], newObject),
-        update,
-      );
+      return createOsdkObject(this[ClientRef], this[ObjectDefRef], newObject);
     },
   },
   $objectSpecifier: {

--- a/packages/client/src/object/convertWireToOsdkObjects/createOsdkObject.ts
+++ b/packages/client/src/object/convertWireToOsdkObjects/createOsdkObject.ts
@@ -61,6 +61,40 @@ const specialPropertyTypes = new Set<BaseWirePropertyTypes>([
 
 const securableSpecialKeys = new Set(["$primaryKey", "$title"]);
 
+const cloneUpdateFields = new WeakMap<ObjectHolder, ReadonlySet<string>>();
+
+/** @internal */
+export function getCloneUpdateFields(
+  value: ObjectHolder,
+): ReadonlySet<string> | undefined {
+  return cloneUpdateFields.get(value);
+}
+
+/** @internal */
+export function clearCloneUpdateFields(value: ObjectHolder): void {
+  cloneUpdateFields.delete(value);
+}
+
+function recordCloneUpdateFields(
+  source: ObjectHolder,
+  clone: ObjectHolder,
+  update: Record<string, any> | undefined,
+): ObjectHolder {
+  const fields = new Set(cloneUpdateFields.get(source));
+  if (update) {
+    const objectDef = source[ObjectDefRef];
+    for (const field of Object.keys(update)) {
+      if (field in objectDef.properties) {
+        fields.add(field);
+      }
+    }
+  }
+  if (fields.size > 0) {
+    cloneUpdateFields.set(clone, fields);
+  }
+  return clone;
+}
+
 // kept separate so we are not redefining these functions
 // every time an object is created.
 const basePropDefs = {
@@ -81,7 +115,11 @@ const basePropDefs = {
       const def = this[ObjectDefRef];
 
       if (update == null) {
-        return createOsdkObject(this[ClientRef], def, { ...rawObj });
+        return recordCloneUpdateFields(
+          this,
+          createOsdkObject(this[ClientRef], def, { ...rawObj }),
+          update,
+        );
       }
 
       if (
@@ -98,7 +136,11 @@ const basePropDefs = {
       }
 
       const newObject = { ...this[UnderlyingOsdkObject], ...update };
-      return createOsdkObject(this[ClientRef], this[ObjectDefRef], newObject);
+      return recordCloneUpdateFields(
+        this,
+        createOsdkObject(this[ClientRef], this[ObjectDefRef], newObject),
+        update,
+      );
     },
   },
   $objectSpecifier: {

--- a/packages/client/src/object/convertWireToOsdkObjects/createOsdkObject.ts
+++ b/packages/client/src/object/convertWireToOsdkObjects/createOsdkObject.ts
@@ -23,6 +23,7 @@ import type {
   ReferenceValue,
   SecuredPropertyValue,
 } from "@osdk/foundry.ontologies";
+import deepEqual from "fast-deep-equal";
 import invariant from "tiny-invariant";
 
 import { CipherTextPropertyImpl } from "../../createCipherTextProperty.js";
@@ -84,14 +85,17 @@ function recordCloneUpdateFields(
   if (update) {
     const objectDef = source[ObjectDefRef];
     for (const field of Object.keys(update)) {
-      if (field in objectDef.properties) {
+      if (
+        field in objectDef.properties &&
+        !deepEqual(source[field], update[field])
+      ) {
         fields.add(field);
       }
     }
   }
-  if (fields.size > 0) {
-    cloneUpdateFields.set(clone, fields);
-  }
+  // Store an empty set as well, so OptimisticJob can distinguish a no-op clone
+  // from an object that was not produced by $clone.
+  cloneUpdateFields.set(clone, fields);
   return clone;
 }
 

--- a/packages/client/src/observable/ObservableClient.ts
+++ b/packages/client/src/observable/ObservableClient.ts
@@ -109,6 +109,12 @@ export interface ObserveObjectOptions<
   $loadPropertySecurityMetadata?: boolean;
 
   /**
+   * Controls whether ontology-defined derived properties are loaded. When
+   * omitted, the server's default behavior is used.
+   */
+  $UNSTABLE_loadOntologyDefinedDerivedProperties?: boolean;
+
+  /**
    * When true, includes all properties of the underlying concrete object type
    * for interface queries. Has no effect for non-interface queries.
    */
@@ -181,6 +187,12 @@ export interface ObserveListOptions<
    * populated with conjunctive/disjunctive marking requirements per property.
    */
   $loadPropertySecurityMetadata?: boolean;
+
+  /**
+   * Controls whether ontology-defined derived properties are loaded. When
+   * omitted, the server's default behavior is used.
+   */
+  $UNSTABLE_loadOntologyDefinedDerivedProperties?: boolean;
 
   /**
    * When true, includes all properties of the underlying concrete object type

--- a/packages/client/src/observable/ObservableClient/ObserveLink.ts
+++ b/packages/client/src/observable/ObservableClient/ObserveLink.ts
@@ -58,6 +58,12 @@ export namespace ObserveLinks {
     $includeAllBaseObjectProperties?: boolean;
 
     /**
+     * Controls whether ontology-defined derived properties are loaded. When
+     * omitted, the server's default behavior is used.
+     */
+    $UNSTABLE_loadOntologyDefinedDerivedProperties?: boolean;
+
+    /**
      * When traversing to linked objects via an interface link target, return
      * the full concrete object type instances instead of interface views.
      * Has no effect when the link target is already an object type.

--- a/packages/client/src/observable/internal/BulkObjectLoader.test.ts
+++ b/packages/client/src/observable/internal/BulkObjectLoader.test.ts
@@ -437,4 +437,51 @@ describe(BulkObjectLoader, () => {
 
     vi.useRealTimers();
   });
+
+  it("splits batches and forwards ontology-defined derived properties settings", async () => {
+    const loader = new BulkObjectLoader(client, 25, 100);
+    vi.useFakeTimers();
+
+    const capturedArgs: Array<Record<string, unknown>> = [];
+    const captureMockSet = (data: unknown[]) => {
+      const objectSet: ObjectSet<ObjectTypeDefinition> = {
+        where: () => objectSet,
+        fetchPage: vi.fn((args: Record<string, unknown>) => {
+          capturedArgs.push(args);
+          return Promise.resolve({ data });
+        }),
+      } as Pick<
+        ObjectSet<ObjectTypeDefinition>,
+        "fetchPage" | "where"
+      > as ObjectSet<ObjectTypeDefinition>;
+      return objectSet;
+    };
+
+    client.mockImplementation(() =>
+      captureMockSet([employees[0], employees[1]]),
+    );
+
+    const serverDefault = loader.fetch("Employee", 0);
+    const explicitlyDisabled = loader.fetch(
+      "Employee",
+      1,
+      "object",
+      undefined,
+      false,
+      undefined,
+      false,
+    );
+
+    vi.advanceTimersByTime(26);
+    await Promise.all([serverDefault, explicitlyDisabled]);
+
+    expect(capturedArgs).toHaveLength(2);
+    expect(
+      capturedArgs.map(
+        (args) => args.$UNSTABLE_loadOntologyDefinedDerivedProperties,
+      ),
+    ).toEqual(expect.arrayContaining([undefined, false]));
+
+    vi.useRealTimers();
+  });
 });

--- a/packages/client/src/observable/internal/BulkObjectLoader.ts
+++ b/packages/client/src/observable/internal/BulkObjectLoader.ts
@@ -40,6 +40,7 @@ interface LoadParams {
   select?: readonly string[];
   loadPropertySecurityMetadata?: boolean;
   includeAllBaseObjectProperties: true | undefined;
+  loadOntologyDefinedDerivedProperties?: boolean;
 }
 
 interface Accumulator extends Partial<LoadParams> {
@@ -80,12 +81,14 @@ export class BulkObjectLoader {
     select?: readonly string[],
     loadPropertySecurityMetadata?: boolean,
     includeAllBaseObjectProperties?: boolean,
+    loadOntologyDefinedDerivedProperties?: boolean,
   ): Promise<ObjectHolder> {
     const params: LoadParams = {
       apiName,
       defType,
       select,
       loadPropertySecurityMetadata,
+      loadOntologyDefinedDerivedProperties,
       // The flag is interface-only on the server. Drop it for object fetches
       // so they don't fragment batches or the cache.
       includeAllBaseObjectProperties:
@@ -110,6 +113,8 @@ export class BulkObjectLoader {
       entry.loadPropertySecurityMetadata = params.loadPropertySecurityMetadata;
       entry.includeAllBaseObjectProperties =
         params.includeAllBaseObjectProperties;
+      entry.loadOntologyDefinedDerivedProperties =
+        params.loadOntologyDefinedDerivedProperties;
     } else if (entry.defType !== defType) {
       deferred.reject(
         new PalantirApiError(
@@ -136,11 +141,17 @@ export class BulkObjectLoader {
   #buildSelectKey(params: LoadParams): string {
     const securitySuffix = params.loadPropertySecurityMetadata ? "\0sec" : "";
     const baseSuffix = params.includeAllBaseObjectProperties ? "\0base" : "";
+    const ontologyDefinedDerivedPropertiesSuffix =
+      params.loadOntologyDefinedDerivedProperties == null
+        ? ""
+        : `\0ontologyDefinedDerivedProperties:${params.loadOntologyDefinedDerivedProperties}`;
     return params.select && params.select.length > 0
       ? `${params.apiName}\0${[...params.select]
           .sort()
-          .join(",")}${securitySuffix}${baseSuffix}`
-      : `${params.apiName}${securitySuffix}${baseSuffix}`;
+          .join(
+            ",",
+          )}${securitySuffix}${baseSuffix}${ontologyDefinedDerivedPropertiesSuffix}`
+      : `${params.apiName}${securitySuffix}${baseSuffix}${ontologyDefinedDerivedPropertiesSuffix}`;
   }
 
   #loadObjects(arr: InternalValue[], params: LoadParams) {
@@ -192,6 +203,12 @@ export class BulkObjectLoader {
           params.loadPropertySecurityMetadata ?? false,
         ...(params.includeAllBaseObjectProperties
           ? { $includeAllBaseObjectProperties: true }
+          : {}),
+        ...(params.loadOntologyDefinedDerivedProperties != null
+          ? {
+              $UNSTABLE_loadOntologyDefinedDerivedProperties:
+                params.loadOntologyDefinedDerivedProperties,
+            }
           : {}),
       });
 
@@ -250,6 +267,12 @@ export class BulkObjectLoader {
             false) as boolean,
           ...(params.includeAllBaseObjectProperties
             ? { $includeAllBaseObjectProperties: true }
+            : {}),
+          ...(params.loadOntologyDefinedDerivedProperties != null
+            ? {
+                $UNSTABLE_loadOntologyDefinedDerivedProperties:
+                  params.loadOntologyDefinedDerivedProperties,
+              }
             : {}),
         });
 

--- a/packages/client/src/observable/internal/Store.test.ts
+++ b/packages/client/src/observable/internal/Store.test.ts
@@ -1545,7 +1545,8 @@ describe(Store, () => {
       // Two subscribers that share apiName + pk but differ in any cache-key
       // dimension should observe independent fetches, not share a stale query.
       // Add a new case here whenever a new dimension is added to ObjectCacheKey
-      // (currently: $select, $loadPropertySecurityMetadata, withProperties/Rdp).
+      // (currently: $select, $loadPropertySecurityMetadata,
+      // $UNSTABLE_loadOntologyDefinedDerivedProperties, withProperties/Rdp).
       // Cache-key uniqueness for dimensions the FauxFoundry can't fetch (e.g.
       // $loadPropertySecurityMetadata) is unit-tested at the ObjectsHelper
       // level instead.
@@ -1577,6 +1578,21 @@ describe(Store, () => {
                 employeeId: JOHN_DOE_ID,
               }),
             ),
+        },
+        {
+          name: "$UNSTABLE_loadOntologyDefinedDerivedProperties",
+          optionsA: {
+            apiName: Employee,
+            pk: JOHN_DOE_ID,
+            mode: "force",
+            $UNSTABLE_loadOntologyDefinedDerivedProperties: false,
+          },
+          optionsB: {
+            apiName: Employee,
+            pk: JOHN_DOE_ID,
+            mode: "force",
+            $UNSTABLE_loadOntologyDefinedDerivedProperties: true,
+          },
         },
       ];
 

--- a/packages/client/src/observable/internal/Store.test.ts
+++ b/packages/client/src/observable/internal/Store.test.ts
@@ -1545,8 +1545,7 @@ describe(Store, () => {
       // Two subscribers that share apiName + pk but differ in any cache-key
       // dimension should observe independent fetches, not share a stale query.
       // Add a new case here whenever a new dimension is added to ObjectCacheKey
-      // (currently: $select, $loadPropertySecurityMetadata,
-      // $UNSTABLE_loadOntologyDefinedDerivedProperties, withProperties/Rdp).
+      // (currently: $select, $loadPropertySecurityMetadata, withProperties/Rdp).
       // Cache-key uniqueness for dimensions the FauxFoundry can't fetch (e.g.
       // $loadPropertySecurityMetadata) is unit-tested at the ObjectsHelper
       // level instead.
@@ -1578,21 +1577,6 @@ describe(Store, () => {
                 employeeId: JOHN_DOE_ID,
               }),
             ),
-        },
-        {
-          name: "$UNSTABLE_loadOntologyDefinedDerivedProperties",
-          optionsA: {
-            apiName: Employee,
-            pk: JOHN_DOE_ID,
-            mode: "force",
-            $UNSTABLE_loadOntologyDefinedDerivedProperties: false,
-          },
-          optionsB: {
-            apiName: Employee,
-            pk: JOHN_DOE_ID,
-            mode: "force",
-            $UNSTABLE_loadOntologyDefinedDerivedProperties: true,
-          },
         },
       ];
 

--- a/packages/client/src/observable/internal/actions/OptimisticJob.ts
+++ b/packages/client/src/observable/internal/actions/OptimisticJob.ts
@@ -15,6 +15,7 @@
  */
 
 import { additionalContext } from "../../../Client.js";
+import { getCloneUpdateFields } from "../../../object/convertWireToOsdkObjects/createOsdkObject.js";
 import type { ObjectHolder } from "../../../object/convertWireToOsdkObjects/ObjectHolder.js";
 import type { OptimisticBuilder } from "../../OptimisticBuilder.js";
 import { type Changes } from "../Changes.js";
@@ -71,7 +72,7 @@ export class OptimisticJob {
                 },
                 undefined,
               )
-              .writeToStore(obj, "loading", batch);
+              .writeToStore(obj, "loading", batch, getCloneUpdateFields(obj));
           }
 
           for (const obj of deletedObjects) {

--- a/packages/client/src/observable/internal/actions/OptimisticJob.ts
+++ b/packages/client/src/observable/internal/actions/OptimisticJob.ts
@@ -64,6 +64,10 @@ export class OptimisticJob {
           }
 
           for (const obj of updatedObjects) {
+            const cloneUpdateFields = getCloneUpdateFields(obj);
+            if (cloneUpdateFields?.size === 0) {
+              continue;
+            }
             store.objects
               .getQuery(
                 {
@@ -72,7 +76,7 @@ export class OptimisticJob {
                 },
                 undefined,
               )
-              .writeToStore(obj, "loading", batch, getCloneUpdateFields(obj));
+              .writeToStore(obj, "loading", batch, cloneUpdateFields);
           }
 
           for (const obj of deletedObjects) {

--- a/packages/client/src/observable/internal/actions/OptimisticJob.ts
+++ b/packages/client/src/observable/internal/actions/OptimisticJob.ts
@@ -15,7 +15,6 @@
  */
 
 import { additionalContext } from "../../../Client.js";
-import { getCloneUpdateFields } from "../../../object/convertWireToOsdkObjects/createOsdkObject.js";
 import type { ObjectHolder } from "../../../object/convertWireToOsdkObjects/ObjectHolder.js";
 import type { OptimisticBuilder } from "../../OptimisticBuilder.js";
 import { type Changes } from "../Changes.js";
@@ -64,10 +63,6 @@ export class OptimisticJob {
           }
 
           for (const obj of updatedObjects) {
-            const cloneUpdateFields = getCloneUpdateFields(obj);
-            if (cloneUpdateFields?.size === 0) {
-              continue;
-            }
             store.objects
               .getQuery(
                 {
@@ -76,7 +71,7 @@ export class OptimisticJob {
                 },
                 undefined,
               )
-              .writeToStore(obj, "loading", batch, cloneUpdateFields);
+              .writeToStore(obj, "loading", batch);
           }
 
           for (const obj of deletedObjects) {

--- a/packages/client/src/observable/internal/base-list/BaseListQuery.ts
+++ b/packages/client/src/observable/internal/base-list/BaseListQuery.ts
@@ -97,6 +97,14 @@ export abstract class BaseListQuery<
     return false;
   }
 
+  /**
+   * Whether this query explicitly configures ontology-defined derived property
+   * loading. Subclasses override this to read the canonical cache key.
+   */
+  public get loadOntologyDefinedDerivedProperties(): boolean | undefined {
+    return undefined;
+  }
+
   private _selectFieldSetMemo: ReadonlySet<string> | undefined;
 
   protected abstract get rawSelect(): Canonical<readonly string[]> | undefined;
@@ -169,6 +177,8 @@ export abstract class BaseListQuery<
         this.rdpConfig,
         this.selectFieldSet,
         this.includeAllBaseObjectProperties,
+        undefined,
+        this.loadOntologyDefinedDerivedProperties,
       );
     } else {
       // Items are already cache keys
@@ -529,6 +539,8 @@ export abstract class BaseListQuery<
           this.rdpConfig,
           this.selectFieldSet,
           this.includeAllBaseObjectProperties,
+          undefined,
+          this.loadOntologyDefinedDerivedProperties,
         );
 
         return this._updateList(
@@ -649,6 +661,8 @@ export abstract class BaseListQuery<
         this.rdpConfig,
         this.selectFieldSet,
         this.includeAllBaseObjectProperties,
+        undefined,
+        this.loadOntologyDefinedDerivedProperties,
       );
     } else {
       // Items are already cache keys
@@ -790,6 +804,7 @@ export abstract class BaseListQuery<
           undefined,
           this.includeAllBaseObjectProperties,
           EMPTY_RDP_SET,
+          this.loadOntologyDefinedDerivedProperties,
         );
       });
     } else if (state === "REMOVED") {

--- a/packages/client/src/observable/internal/links/LinksHelper.ts
+++ b/packages/client/src/observable/internal/links/LinksHelper.ts
@@ -100,6 +100,7 @@ export class LinksHelper extends AbstractHelper<
       canonSelect,
       options.$includeAllBaseObjectProperties ? true : undefined,
       options.resolveToObjectType ? true : undefined,
+      options.$UNSTABLE_loadOntologyDefinedDerivedProperties,
     );
 
     return this.store.queries.get(linkCacheKey, () => {

--- a/packages/client/src/observable/internal/links/SpecificLinkCacheKey.ts
+++ b/packages/client/src/observable/internal/links/SpecificLinkCacheKey.ts
@@ -33,6 +33,7 @@ export const ORDER_BY_CLAUSE_IDX = 6;
 export const SELECT_IDX = 7;
 export const INCLUDE_ALL_BASE_PROPERTIES_IDX = 8;
 export const RESOLVE_TO_OBJECT_TYPE_IDX = 9;
+export const LOAD_ONTOLOGY_DEFINED_DERIVED_PROPERTIES_IDX = 10;
 
 /**
  * Storage data format for link query cache entries, similar to ListStorageData
@@ -60,5 +61,6 @@ export interface SpecificLinkCacheKey extends CacheKey<
     select?: Canonical<readonly string[]> | undefined,
     includeAllBaseObjectProperties?: true | undefined,
     resolveToObjectType?: true | undefined,
+    loadOntologyDefinedDerivedProperties?: boolean | undefined,
   ]
 > {}

--- a/packages/client/src/observable/internal/links/SpecificLinkQuery.ts
+++ b/packages/client/src/observable/internal/links/SpecificLinkQuery.ts
@@ -48,6 +48,7 @@ import { tombstone } from "../tombstone.js";
 import { reloadDataAsFullObjects } from "../utils/reloadDataAsFullObjects.js";
 import {
   INCLUDE_ALL_BASE_PROPERTIES_IDX as LINK_INCLUDE_ALL_BASE_PROPERTIES_IDX,
+  LOAD_ONTOLOGY_DEFINED_DERIVED_PROPERTIES_IDX as LINK_LOAD_ONTOLOGY_DEFINED_DERIVED_PROPERTIES_IDX,
   RESOLVE_TO_OBJECT_TYPE_IDX as LINK_RESOLVE_TO_OBJECT_TYPE_IDX,
   SELECT_IDX as LINK_SELECT_IDX,
   type SpecificLinkCacheKey,
@@ -144,6 +145,14 @@ export class SpecificLinkQuery extends BaseListQuery<
     return (
       this.cacheKey.otherKeys[LINK_INCLUDE_ALL_BASE_PROPERTIES_IDX] === true
     );
+  }
+
+  public override get loadOntologyDefinedDerivedProperties():
+    | boolean
+    | undefined {
+    return this.cacheKey.otherKeys[
+      LINK_LOAD_ONTOLOGY_DEFINED_DERIVED_PROPERTIES_IDX
+    ];
   }
 
   /**
@@ -253,6 +262,7 @@ export class SpecificLinkQuery extends BaseListQuery<
       $where?: Record<string, unknown>;
       $select?: readonly string[];
       $includeAllBaseObjectProperties?: true;
+      $UNSTABLE_loadOntologyDefinedDerivedProperties?: boolean;
     } = {
       $pageSize: this.getEffectiveFetchPageSize(),
       $nextPageToken: this.nextPageToken,
@@ -277,6 +287,11 @@ export class SpecificLinkQuery extends BaseListQuery<
       queryParams.$includeAllBaseObjectProperties = true;
     }
 
+    if (this.loadOntologyDefinedDerivedProperties != null) {
+      queryParams.$UNSTABLE_loadOntologyDefinedDerivedProperties =
+        this.loadOntologyDefinedDerivedProperties;
+    }
+
     const response = await linkQuery.fetchPage(queryParams);
 
     // Store the next page token for pagination
@@ -285,7 +300,11 @@ export class SpecificLinkQuery extends BaseListQuery<
     // Honor resolveToObjectType only when the link target is an interface —
     // for concrete object targets the data is already in object form.
     if (this.#resolveToObjectType && target?.kind === "interface") {
-      const fullData = await reloadDataAsFullObjects(client, response.data);
+      const fullData = await reloadDataAsFullObjects(
+        client,
+        response.data,
+        this.loadOntologyDefinedDerivedProperties,
+      );
       return { ...response, data: fullData };
     }
 

--- a/packages/client/src/observable/internal/list/InterfaceListQuery.ts
+++ b/packages/client/src/observable/internal/list/InterfaceListQuery.ts
@@ -116,7 +116,11 @@ export class InterfaceListQuery extends ListQuery {
   protected async postProcessFetchedData(
     data: Osdk.Instance<any>[],
   ): Promise<Osdk.Instance<any>[]> {
-    return reloadDataAsFullObjects(this.store.client, data);
+    return reloadDataAsFullObjects(
+      this.store.client,
+      data,
+      this.loadOntologyDefinedDerivedProperties,
+    );
   }
 
   private wrapObject(object: ObjectHolder): ObjectHolder | InterfaceHolder {

--- a/packages/client/src/observable/internal/list/ListCacheKey.ts
+++ b/packages/client/src/observable/internal/list/ListCacheKey.ts
@@ -35,6 +35,7 @@ export const SELECT_IDX = 8;
 export const LOAD_PROPERTY_SECURITY_IDX = 9;
 export const INCLUDE_ALL_BASE_PROPERTIES_IDX = 10;
 export const RESOLVE_TO_OBJECT_TYPE_IDX = 11;
+export const LOAD_ONTOLOGY_DEFINED_DERIVED_PROPERTIES_IDX = 12;
 
 export interface ListStorageData extends CollectionStorageData {}
 
@@ -55,5 +56,6 @@ export interface ListCacheKey extends CacheKey<
     loadPropertySecurity?: true | undefined,
     includeAllBaseObjectProperties?: true | undefined,
     resolveToObjectType?: true | undefined,
+    loadOntologyDefinedDerivedProperties?: boolean | undefined,
   ]
 > {}

--- a/packages/client/src/observable/internal/list/ListQuery.ts
+++ b/packages/client/src/observable/internal/list/ListQuery.ts
@@ -59,6 +59,7 @@ import { EMPTY_RDP_SET } from "../utils/rdpFieldOperations.js";
 import {
   INCLUDE_ALL_BASE_PROPERTIES_IDX,
   INTERSECT_IDX,
+  LOAD_ONTOLOGY_DEFINED_DERIVED_PROPERTIES_IDX,
   type ListCacheKey,
   ORDER_BY_IDX,
   PIVOT_IDX,
@@ -205,6 +206,14 @@ export abstract class ListQuery extends BaseListQuery<
     return this.cacheKey.otherKeys[INCLUDE_ALL_BASE_PROPERTIES_IDX] === true;
   }
 
+  public override get loadOntologyDefinedDerivedProperties():
+    | boolean
+    | undefined {
+    return this.cacheKey.otherKeys[
+      LOAD_ONTOLOGY_DEFINED_DERIVED_PROPERTIES_IDX
+    ];
+  }
+
   get objectTypes(): ReadonlySet<string> {
     return this.#objectTypesCache ?? new Set([this.apiName]);
   }
@@ -345,6 +354,12 @@ export abstract class ListQuery extends BaseListQuery<
         : {}),
       ...(this.includeAllBaseObjectProperties
         ? { $includeAllBaseObjectProperties: true }
+        : {}),
+      ...(this.loadOntologyDefinedDerivedProperties != null
+        ? {
+            $UNSTABLE_loadOntologyDefinedDerivedProperties:
+              this.loadOntologyDefinedDerivedProperties,
+          }
         : {}),
     });
 
@@ -629,6 +644,7 @@ export abstract class ListQuery extends BaseListQuery<
           undefined,
           this.includeAllBaseObjectProperties,
           EMPTY_RDP_SET,
+          this.loadOntologyDefinedDerivedProperties,
         );
       });
     } else if (state === "REMOVED") {
@@ -708,6 +724,10 @@ export abstract class ListQuery extends BaseListQuery<
       obj.$objectType,
       pk,
       this.rdpConfig ?? undefined,
+      undefined,
+      undefined,
+      this.includeAllBaseObjectProperties ? true : undefined,
+      this.loadOntologyDefinedDerivedProperties,
     );
   }
 }

--- a/packages/client/src/observable/internal/list/ListQueryOptions.ts
+++ b/packages/client/src/observable/internal/list/ListQueryOptions.ts
@@ -38,5 +38,6 @@ export interface ListQueryOptions<
   pivotTo?: string;
   $loadPropertySecurityMetadata?: boolean;
   $includeAllBaseObjectProperties?: boolean;
+  $UNSTABLE_loadOntologyDefinedDerivedProperties?: boolean;
   resolveToObjectType?: boolean;
 }

--- a/packages/client/src/observable/internal/list/ListsHelper.ts
+++ b/packages/client/src/observable/internal/list/ListsHelper.ts
@@ -115,6 +115,7 @@ export class ListsHelper extends AbstractHelper<
       rids,
       select,
       $loadPropertySecurityMetadata,
+      $UNSTABLE_loadOntologyDefinedDerivedProperties,
       resolveToObjectType,
     } = options;
     const { apiName, type } = typeDefinition;
@@ -164,6 +165,7 @@ export class ListsHelper extends AbstractHelper<
       $loadPropertySecurityMetadata ? true : undefined,
       $includeAllBaseObjectProperties,
       canonResolveToObjectType,
+      $UNSTABLE_loadOntologyDefinedDerivedProperties,
     );
 
     return this.store.queries.get(listCacheKey, () => {

--- a/packages/client/src/observable/internal/object/ObjectCacheKey.ts
+++ b/packages/client/src/observable/internal/object/ObjectCacheKey.ts
@@ -29,6 +29,7 @@ export const RDP_CONFIG_IDX = 2;
 export const SELECT_IDX = 3;
 export const LOAD_PROPERTY_SECURITY_IDX = 4;
 export const INCLUDE_ALL_BASE_PROPERTIES_IDX = 5;
+export const LOAD_ONTOLOGY_DEFINED_DERIVED_PROPERTIES_IDX = 6;
 
 export interface ObjectCacheKey extends CacheKey<
   "object",
@@ -41,5 +42,6 @@ export interface ObjectCacheKey extends CacheKey<
     select?: Canonical<readonly string[]> | undefined,
     loadPropertySecurity?: true | undefined,
     includeAllBaseObjectProperties?: true | undefined,
+    loadOntologyDefinedDerivedProperties?: boolean | undefined,
   ]
 > {}

--- a/packages/client/src/observable/internal/object/ObjectQuery.ts
+++ b/packages/client/src/observable/internal/object/ObjectQuery.ts
@@ -53,6 +53,7 @@ export class ObjectQuery extends Query<
   #select: readonly string[] | undefined;
   #loadPropertySecurityMetadata: boolean;
   #includeAllBaseObjectProperties: boolean;
+  #loadOntologyDefinedDerivedProperties: boolean | undefined;
   #implementingTypes: Set<string> | undefined;
 
   constructor(
@@ -66,6 +67,7 @@ export class ObjectQuery extends Query<
     select?: readonly string[],
     loadPropertySecurityMetadata?: boolean,
     includeAllBaseObjectProperties?: boolean,
+    loadOntologyDefinedDerivedProperties?: boolean,
   ) {
     super(
       store,
@@ -90,6 +92,8 @@ export class ObjectQuery extends Query<
     this.#loadPropertySecurityMetadata = loadPropertySecurityMetadata ?? false;
     this.#includeAllBaseObjectProperties =
       includeAllBaseObjectProperties ?? false;
+    this.#loadOntologyDefinedDerivedProperties =
+      loadOntologyDefinedDerivedProperties;
   }
 
   protected _createConnectable(
@@ -153,6 +157,12 @@ export class ObjectQuery extends Query<
           ...(this.#includeAllBaseObjectProperties
             ? { $includeAllBaseObjectProperties: true }
             : {}),
+          ...(this.#loadOntologyDefinedDerivedProperties != null
+            ? {
+                $UNSTABLE_loadOntologyDefinedDerivedProperties:
+                  this.#loadOntologyDefinedDerivedProperties,
+              }
+            : {}),
         });
       obj = fetched as ObjectHolder;
     } else {
@@ -164,6 +174,7 @@ export class ObjectQuery extends Query<
         this.#select,
         this.#loadPropertySecurityMetadata,
         this.#includeAllBaseObjectProperties,
+        this.#loadOntologyDefinedDerivedProperties,
       );
     }
 

--- a/packages/client/src/observable/internal/object/ObjectsHelper.test.ts
+++ b/packages/client/src/observable/internal/object/ObjectsHelper.test.ts
@@ -748,6 +748,27 @@ describe("ObjectsHelper variant cache keys", () => {
     expect(q1.cacheKey).not.toBe(q2.cacheKey);
   });
 
+  it("returns distinct queries for each ontology-defined derived properties setting", () => {
+    const serverDefault = store.objects.getQuery({
+      apiName: Employee,
+      pk: 1,
+    });
+    const explicitlyDisabled = store.objects.getQuery({
+      apiName: Employee,
+      pk: 1,
+      $UNSTABLE_loadOntologyDefinedDerivedProperties: false,
+    });
+    const explicitlyEnabled = store.objects.getQuery({
+      apiName: Employee,
+      pk: 1,
+      $UNSTABLE_loadOntologyDefinedDerivedProperties: true,
+    });
+
+    expect(serverDefault.cacheKey).not.toBe(explicitlyDisabled.cacheKey);
+    expect(serverDefault.cacheKey).not.toBe(explicitlyEnabled.cacheKey);
+    expect(explicitlyDisabled.cacheKey).not.toBe(explicitlyEnabled.cacheKey);
+  });
+
   it("treats no-select and empty-select as the same cache key", () => {
     const qNone = store.objects.getQuery({
       apiName: Employee,

--- a/packages/client/src/observable/internal/object/ObjectsHelper.test.ts
+++ b/packages/client/src/observable/internal/object/ObjectsHelper.test.ts
@@ -750,7 +750,7 @@ describe("ObjectsHelper variant cache keys", () => {
     expect(q1.cacheKey).not.toBe(q2.cacheKey);
   });
 
-  it("isolates fetched variants but propagates only optimistic edits", async () => {
+  it("isolates fetched and optimistic writes across settings", async () => {
     const disabledValue = emp.$clone({ fullName: "Disabled" });
     const enabledValue = emp.$clone({
       fullName: "Enabled",
@@ -804,76 +804,15 @@ describe("ObjectsHelper variant cache keys", () => {
       [serverDefault, explicitlyDisabled, explicitlyEnabled].map(
         (query) => store.getValue(query.cacheKey)?.value?.fullName,
       ),
-    ).toEqual(["From enabled", "From enabled", "From enabled"]);
+    ).toEqual(["From enabled", "Disabled", "Enabled"]);
     expect(store.getValue(explicitlyDisabled.cacheKey)?.value?.office).toBe(
       undefined,
     );
     expect(store.getValue(serverDefault.cacheKey)?.value?.office).toBe(
-      undefined,
+      "Derived value",
     );
 
     store.layers.remove(fromEnabled);
-
-    const fromSpread = createOptimisticId();
-    const spreadJob = new OptimisticJob(store, fromSpread);
-    spreadJob.context.updateObject(
-      enabledValue.$clone({
-        ...enabledValue,
-        fullName: "From spread",
-      }),
-    );
-    await spreadJob.getResult();
-
-    expect(
-      [serverDefault, explicitlyDisabled, explicitlyEnabled].map(
-        (query) => store.getValue(query.cacheKey)?.value?.fullName,
-      ),
-    ).toEqual(["From spread", "From spread", "From spread"]);
-    expect(store.getValue(explicitlyDisabled.cacheKey)?.value?.office).toBe(
-      undefined,
-    );
-    expect(store.getValue(serverDefault.cacheKey)?.value?.office).toBe(
-      undefined,
-    );
-
-    store.layers.remove(fromSpread);
-
-    const unchangedJob = new OptimisticJob(store, createOptimisticId());
-    unchangedJob.context.updateObject(enabledValue.$clone(enabledValue));
-    await unchangedJob.getResult();
-
-    expect(
-      [serverDefault, explicitlyDisabled, explicitlyEnabled].map(
-        (query) => store.getValue(query.cacheKey)?.value?.fullName,
-      ),
-    ).toEqual(["Alice", "Disabled", "Enabled"]);
-    expect(store.getValue(explicitlyDisabled.cacheKey)?.value?.office).toBe(
-      undefined,
-    );
-
-    const fromClear = createOptimisticId();
-    const clearJob = new OptimisticJob(store, fromClear);
-    clearJob.context.updateObject(enabledValue.$clone({ office: undefined }));
-    await clearJob.getResult();
-
-    expect(store.getValue(explicitlyEnabled.cacheKey)?.value?.office).toBe(
-      undefined,
-    );
-
-    store.layers.remove(fromClear);
-
-    const disabledJob = new OptimisticJob(store, createOptimisticId());
-    disabledJob.context.updateObject(
-      disabledValue.$clone({ fullName: "From disabled" }),
-    );
-    await disabledJob.getResult();
-
-    expect(store.getValue(explicitlyEnabled.cacheKey)?.value).toEqual(
-      expect.objectContaining({
-        fullName: "From disabled",
-        office: "Derived value",
-      }),
-    );
 
     subscriptions.forEach((subscription) => subscription.unsubscribe());
   });

--- a/packages/client/src/observable/internal/object/ObjectsHelper.test.ts
+++ b/packages/client/src/observable/internal/object/ObjectsHelper.test.ts
@@ -813,6 +813,55 @@ describe("ObjectsHelper variant cache keys", () => {
     );
 
     store.layers.remove(fromEnabled);
+
+    const fromSpread = createOptimisticId();
+    const spreadJob = new OptimisticJob(store, fromSpread);
+    spreadJob.context.updateObject(
+      enabledValue.$clone({
+        ...enabledValue,
+        fullName: "From spread",
+      }),
+    );
+    await spreadJob.getResult();
+
+    expect(
+      [serverDefault, explicitlyDisabled, explicitlyEnabled].map(
+        (query) => store.getValue(query.cacheKey)?.value?.fullName,
+      ),
+    ).toEqual(["From spread", "From spread", "From spread"]);
+    expect(store.getValue(explicitlyDisabled.cacheKey)?.value?.office).toBe(
+      undefined,
+    );
+    expect(store.getValue(serverDefault.cacheKey)?.value?.office).toBe(
+      undefined,
+    );
+
+    store.layers.remove(fromSpread);
+
+    const unchangedJob = new OptimisticJob(store, createOptimisticId());
+    unchangedJob.context.updateObject(enabledValue.$clone(enabledValue));
+    await unchangedJob.getResult();
+
+    expect(
+      [serverDefault, explicitlyDisabled, explicitlyEnabled].map(
+        (query) => store.getValue(query.cacheKey)?.value?.fullName,
+      ),
+    ).toEqual(["Alice", "Disabled", "Enabled"]);
+    expect(store.getValue(explicitlyDisabled.cacheKey)?.value?.office).toBe(
+      undefined,
+    );
+
+    const fromClear = createOptimisticId();
+    const clearJob = new OptimisticJob(store, fromClear);
+    clearJob.context.updateObject(enabledValue.$clone({ office: undefined }));
+    await clearJob.getResult();
+
+    expect(store.getValue(explicitlyEnabled.cacheKey)?.value?.office).toBe(
+      undefined,
+    );
+
+    store.layers.remove(fromClear);
+
     const disabledJob = new OptimisticJob(store, createOptimisticId());
     disabledJob.context.updateObject(
       disabledValue.$clone({ fullName: "From disabled" }),

--- a/packages/client/src/observable/internal/object/ObjectsHelper.test.ts
+++ b/packages/client/src/observable/internal/object/ObjectsHelper.test.ts
@@ -25,6 +25,7 @@ import {
   InterfaceDefRef,
   ObjectDefRef,
 } from "../../../object/convertWireToOsdkObjects/InternalSymbols.js";
+import { OptimisticJob } from "../actions/OptimisticJob.js";
 import type { Canonical } from "../Canonical.js";
 import { createOptimisticId } from "../OptimisticId.js";
 import type { Rdp } from "../RdpCanonicalizer.js";
@@ -749,7 +750,12 @@ describe("ObjectsHelper variant cache keys", () => {
     expect(q1.cacheKey).not.toBe(q2.cacheKey);
   });
 
-  it("isolates fetched variants but propagates optimistic writes", () => {
+  it("isolates fetched variants but propagates only optimistic edits", async () => {
+    const disabledValue = emp.$clone({ fullName: "Disabled" });
+    const enabledValue = emp.$clone({
+      fullName: "Enabled",
+      office: "Derived value",
+    });
     const serverDefault = store.objects.getQuery({
       apiName: Employee,
       pk: 1,
@@ -773,16 +779,8 @@ describe("ObjectsHelper variant cache keys", () => {
 
     store.batch({}, (batch) => {
       serverDefault.writeToStore(emp as any, "loaded", batch);
-      explicitlyDisabled.writeToStore(
-        emp.$clone({ fullName: "Disabled" }) as any,
-        "loaded",
-        batch,
-      );
-      explicitlyEnabled.writeToStore(
-        emp.$clone({ fullName: "Enabled" }) as any,
-        "loaded",
-        batch,
-      );
+      explicitlyDisabled.writeToStore(disabledValue as any, "loaded", batch);
+      explicitlyEnabled.writeToStore(enabledValue as any, "loaded", batch);
     });
 
     expect(store.getValue(serverDefault.cacheKey)?.value?.fullName).toBe(
@@ -795,19 +793,38 @@ describe("ObjectsHelper variant cache keys", () => {
       "Enabled",
     );
 
-    store.batch({ optimisticId: createOptimisticId() }, (batch) => {
-      serverDefault.writeToStore(
-        emp.$clone({ fullName: "Optimistic" }) as any,
-        "loading",
-        batch,
-      );
-    });
+    const fromEnabled = createOptimisticId();
+    const enabledJob = new OptimisticJob(store, fromEnabled);
+    enabledJob.context.updateObject(
+      enabledValue.$clone({ fullName: "From enabled" }),
+    );
+    await enabledJob.getResult();
 
     expect(
       [serverDefault, explicitlyDisabled, explicitlyEnabled].map(
         (query) => store.getValue(query.cacheKey)?.value?.fullName,
       ),
-    ).toEqual(["Optimistic", "Optimistic", "Optimistic"]);
+    ).toEqual(["From enabled", "From enabled", "From enabled"]);
+    expect(store.getValue(explicitlyDisabled.cacheKey)?.value?.office).toBe(
+      undefined,
+    );
+    expect(store.getValue(serverDefault.cacheKey)?.value?.office).toBe(
+      undefined,
+    );
+
+    store.layers.remove(fromEnabled);
+    const disabledJob = new OptimisticJob(store, createOptimisticId());
+    disabledJob.context.updateObject(
+      disabledValue.$clone({ fullName: "From disabled" }),
+    );
+    await disabledJob.getResult();
+
+    expect(store.getValue(explicitlyEnabled.cacheKey)?.value).toEqual(
+      expect.objectContaining({
+        fullName: "From disabled",
+        office: "Derived value",
+      }),
+    );
 
     subscriptions.forEach((subscription) => subscription.unsubscribe());
   });

--- a/packages/client/src/observable/internal/object/ObjectsHelper.test.ts
+++ b/packages/client/src/observable/internal/object/ObjectsHelper.test.ts
@@ -748,7 +748,7 @@ describe("ObjectsHelper variant cache keys", () => {
     expect(q1.cacheKey).not.toBe(q2.cacheKey);
   });
 
-  it("returns distinct queries for each ontology-defined derived properties setting", () => {
+  it("does not propagate writes across ontology-defined derived property settings", () => {
     const serverDefault = store.objects.getQuery({
       apiName: Employee,
       pk: 1,
@@ -764,9 +764,37 @@ describe("ObjectsHelper variant cache keys", () => {
       $UNSTABLE_loadOntologyDefinedDerivedProperties: true,
     });
 
-    expect(serverDefault.cacheKey).not.toBe(explicitlyDisabled.cacheKey);
-    expect(serverDefault.cacheKey).not.toBe(explicitlyEnabled.cacheKey);
-    expect(explicitlyDisabled.cacheKey).not.toBe(explicitlyEnabled.cacheKey);
+    const subscriptions = [
+      serverDefault,
+      explicitlyDisabled,
+      explicitlyEnabled,
+    ].map((query) => store.subjects.get(query.cacheKey).subscribe(() => {}));
+
+    store.batch({}, (batch) => {
+      serverDefault.writeToStore(emp as any, "loaded", batch);
+      explicitlyDisabled.writeToStore(
+        emp.$clone({ fullName: "Disabled" }) as any,
+        "loaded",
+        batch,
+      );
+      explicitlyEnabled.writeToStore(
+        emp.$clone({ fullName: "Enabled" }) as any,
+        "loaded",
+        batch,
+      );
+    });
+
+    expect(store.getValue(serverDefault.cacheKey)?.value?.fullName).toBe(
+      "Alice",
+    );
+    expect(store.getValue(explicitlyDisabled.cacheKey)?.value?.fullName).toBe(
+      "Disabled",
+    );
+    expect(store.getValue(explicitlyEnabled.cacheKey)?.value?.fullName).toBe(
+      "Enabled",
+    );
+
+    subscriptions.forEach((subscription) => subscription.unsubscribe());
   });
 
   it("treats no-select and empty-select as the same cache key", () => {

--- a/packages/client/src/observable/internal/object/ObjectsHelper.test.ts
+++ b/packages/client/src/observable/internal/object/ObjectsHelper.test.ts
@@ -26,6 +26,7 @@ import {
   ObjectDefRef,
 } from "../../../object/convertWireToOsdkObjects/InternalSymbols.js";
 import type { Canonical } from "../Canonical.js";
+import { createOptimisticId } from "../OptimisticId.js";
 import type { Rdp } from "../RdpCanonicalizer.js";
 import { Store } from "../Store.js";
 import {
@@ -748,7 +749,7 @@ describe("ObjectsHelper variant cache keys", () => {
     expect(q1.cacheKey).not.toBe(q2.cacheKey);
   });
 
-  it("does not propagate writes across ontology-defined derived property settings", () => {
+  it("isolates fetched variants but propagates optimistic writes", () => {
     const serverDefault = store.objects.getQuery({
       apiName: Employee,
       pk: 1,
@@ -793,6 +794,20 @@ describe("ObjectsHelper variant cache keys", () => {
     expect(store.getValue(explicitlyEnabled.cacheKey)?.value?.fullName).toBe(
       "Enabled",
     );
+
+    store.batch({ optimisticId: createOptimisticId() }, (batch) => {
+      serverDefault.writeToStore(
+        emp.$clone({ fullName: "Optimistic" }) as any,
+        "loading",
+        batch,
+      );
+    });
+
+    expect(
+      [serverDefault, explicitlyDisabled, explicitlyEnabled].map(
+        (query) => store.getValue(query.cacheKey)?.value?.fullName,
+      ),
+    ).toEqual(["Optimistic", "Optimistic", "Optimistic"]);
 
     subscriptions.forEach((subscription) => subscription.unsubscribe());
   });

--- a/packages/client/src/observable/internal/object/ObjectsHelper.ts
+++ b/packages/client/src/observable/internal/object/ObjectsHelper.ts
@@ -17,6 +17,7 @@
 import type { ObjectOrInterfaceDefinition, Osdk } from "@osdk/api";
 import deepEqual from "fast-deep-equal";
 
+import { clearCloneUpdateFields } from "../../../object/convertWireToOsdkObjects/createOsdkObject.js";
 import type { InterfaceHolder } from "../../../object/convertWireToOsdkObjects/InterfaceHolder.js";
 import { isInterfaceHolder } from "../../../object/convertWireToOsdkObjects/InterfaceHolder.js";
 import { UnderlyingOsdkObject } from "../../../object/convertWireToOsdkObjects/InternalSymbols.js";
@@ -173,6 +174,10 @@ export class ObjectsHelper extends AbstractHelper<
     selectFields?: ReadonlySet<string>,
     computedRdpFields?: ReadonlySet<string>,
   ): void {
+    if (!batch.optimisticWrite && value !== tombstone) {
+      clearCloneUpdateFields(value);
+    }
+
     const existing = batch.read(sourceCacheKey);
     const dataChanged =
       !existing ||
@@ -243,6 +248,10 @@ export class ObjectsHelper extends AbstractHelper<
         continue;
       }
 
+      const crossesDerivedPropertySetting =
+        targetKey.otherKeys[LOAD_ONTOLOGY_DEFINED_DERIVED_PROPERTIES_IDX] !==
+        sourceCacheKey.otherKeys[LOAD_ONTOLOGY_DEFINED_DERIVED_PROPERTIES_IDX];
+
       // A response fetched with one derived-property loading setting cannot
       // populate a cache entry fetched with another setting. Optimistic writes
       // still represent the same local object edit and must reach every active
@@ -250,8 +259,7 @@ export class ObjectsHelper extends AbstractHelper<
       if (
         !batch.optimisticWrite &&
         value !== tombstone &&
-        targetKey.otherKeys[LOAD_ONTOLOGY_DEFINED_DERIVED_PROPERTIES_IDX] !==
-          sourceCacheKey.otherKeys[LOAD_ONTOLOGY_DEFINED_DERIVED_PROPERTIES_IDX]
+        crossesDerivedPropertySetting
       ) {
         continue;
       }

--- a/packages/client/src/observable/internal/object/ObjectsHelper.ts
+++ b/packages/client/src/observable/internal/object/ObjectsHelper.ts
@@ -17,7 +17,6 @@
 import type { ObjectOrInterfaceDefinition, Osdk } from "@osdk/api";
 import deepEqual from "fast-deep-equal";
 
-import { clearCloneUpdateFields } from "../../../object/convertWireToOsdkObjects/createOsdkObject.js";
 import type { InterfaceHolder } from "../../../object/convertWireToOsdkObjects/InterfaceHolder.js";
 import { isInterfaceHolder } from "../../../object/convertWireToOsdkObjects/InterfaceHolder.js";
 import { UnderlyingOsdkObject } from "../../../object/convertWireToOsdkObjects/InternalSymbols.js";
@@ -174,10 +173,6 @@ export class ObjectsHelper extends AbstractHelper<
     selectFields?: ReadonlySet<string>,
     computedRdpFields?: ReadonlySet<string>,
   ): void {
-    if (!batch.optimisticWrite && value !== tombstone) {
-      clearCloneUpdateFields(value);
-    }
-
     const existing = batch.read(sourceCacheKey);
     const dataChanged =
       !existing ||
@@ -252,15 +247,11 @@ export class ObjectsHelper extends AbstractHelper<
         targetKey.otherKeys[LOAD_ONTOLOGY_DEFINED_DERIVED_PROPERTIES_IDX] !==
         sourceCacheKey.otherKeys[LOAD_ONTOLOGY_DEFINED_DERIVED_PROPERTIES_IDX];
 
-      // A response fetched with one derived-property loading setting cannot
-      // populate a cache entry fetched with another setting. Optimistic writes
-      // still represent the same local object edit and must reach every active
-      // variant. Deletions also remain safe to propagate to all variants.
-      if (
-        !batch.optimisticWrite &&
-        value !== tombstone &&
-        crossesDerivedPropertySetting
-      ) {
+      // Values from one derived-property loading setting cannot populate a
+      // cache entry for another setting. This includes optimistic writes;
+      // explicit variants refresh after the action completes. Deletions remain
+      // safe to propagate to every variant.
+      if (value !== tombstone && crossesDerivedPropertySetting) {
         continue;
       }
 

--- a/packages/client/src/observable/internal/object/ObjectsHelper.ts
+++ b/packages/client/src/observable/internal/object/ObjectsHelper.ts
@@ -66,7 +66,12 @@ export class ObjectsHelper extends AbstractHelper<
       typeof options.apiName === "string"
         ? options.apiName
         : options.apiName.apiName;
-    const { pk, select, $loadPropertySecurityMetadata } = options;
+    const {
+      pk,
+      select,
+      $loadPropertySecurityMetadata,
+      $UNSTABLE_loadOntologyDefinedDerivedProperties,
+    } = options;
 
     const defType = getDefType(options.apiName);
     // The flag is interface-only on the server. Drop it for object queries so
@@ -89,6 +94,7 @@ export class ObjectsHelper extends AbstractHelper<
       canonSelect,
       $loadPropertySecurityMetadata ? true : undefined,
       $includeAllBaseObjectProperties,
+      $UNSTABLE_loadOntologyDefinedDerivedProperties,
     );
 
     return this.store.queries.get(
@@ -105,6 +111,7 @@ export class ObjectsHelper extends AbstractHelper<
           select,
           $loadPropertySecurityMetadata,
           $includeAllBaseObjectProperties,
+          $UNSTABLE_loadOntologyDefinedDerivedProperties,
         ),
     );
   }
@@ -125,6 +132,7 @@ export class ObjectsHelper extends AbstractHelper<
     selectFields?: ReadonlySet<string>,
     includeAllBaseObjectProperties?: boolean,
     computedRdpFields?: ReadonlySet<string>,
+    loadOntologyDefinedDerivedProperties?: boolean,
   ): ObjectCacheKey[] {
     const holders: ReadonlyArray<ObjectHolder | InterfaceHolder> =
       values as ReadonlyArray<ObjectHolder | InterfaceHolder>;
@@ -136,6 +144,8 @@ export class ObjectsHelper extends AbstractHelper<
           apiName: v.$objectType ?? v.$apiName,
           pk: v.$primaryKey,
           $includeAllBaseObjectProperties: includeAllBaseObjectProperties,
+          $UNSTABLE_loadOntologyDefinedDerivedProperties:
+            loadOntologyDefinedDerivedProperties,
         },
         rdpConfig,
       ).writeToStore(

--- a/packages/client/src/observable/internal/object/ObjectsHelper.ts
+++ b/packages/client/src/observable/internal/object/ObjectsHelper.ts
@@ -35,7 +35,10 @@ import {
   mergeObjectFields,
   mergeSelectFields,
 } from "../utils/rdpFieldOperations.js";
-import { type ObjectCacheKey } from "./ObjectCacheKey.js";
+import {
+  LOAD_ONTOLOGY_DEFINED_DERIVED_PROPERTIES_IDX,
+  type ObjectCacheKey,
+} from "./ObjectCacheKey.js";
 import { ObjectQuery } from "./ObjectQuery.js";
 
 function isSuperset(a: ReadonlySet<string>, b: ReadonlySet<string>): boolean {
@@ -237,6 +240,18 @@ export class ObjectsHelper extends AbstractHelper<
 
     for (const targetKey of relatedKeys) {
       if (targetKey === sourceCacheKey || !this.isKeyActive(targetKey)) {
+        continue;
+      }
+
+      // A response fetched with one derived-property loading setting cannot
+      // populate a cache entry fetched with another setting. Deletions remain
+      // safe to propagate to all variants because object existence is
+      // independent of fetch options.
+      if (
+        value !== tombstone &&
+        targetKey.otherKeys[LOAD_ONTOLOGY_DEFINED_DERIVED_PROPERTIES_IDX] !==
+          sourceCacheKey.otherKeys[LOAD_ONTOLOGY_DEFINED_DERIVED_PROPERTIES_IDX]
+      ) {
         continue;
       }
 

--- a/packages/client/src/observable/internal/object/ObjectsHelper.ts
+++ b/packages/client/src/observable/internal/object/ObjectsHelper.ts
@@ -244,10 +244,11 @@ export class ObjectsHelper extends AbstractHelper<
       }
 
       // A response fetched with one derived-property loading setting cannot
-      // populate a cache entry fetched with another setting. Deletions remain
-      // safe to propagate to all variants because object existence is
-      // independent of fetch options.
+      // populate a cache entry fetched with another setting. Optimistic writes
+      // still represent the same local object edit and must reach every active
+      // variant. Deletions also remain safe to propagate to all variants.
       if (
+        !batch.optimisticWrite &&
         value !== tombstone &&
         targetKey.otherKeys[LOAD_ONTOLOGY_DEFINED_DERIVED_PROPERTIES_IDX] !==
           sourceCacheKey.otherKeys[LOAD_ONTOLOGY_DEFINED_DERIVED_PROPERTIES_IDX]

--- a/packages/client/src/observable/internal/objectset/ObjectSetCacheKey.ts
+++ b/packages/client/src/observable/internal/objectset/ObjectSetCacheKey.ts
@@ -33,6 +33,7 @@ export interface ObjectSetOperations {
   select?: Canonical<readonly string[]>;
   pageSize?: number;
   loadPropertySecurity?: true;
+  loadOntologyDefinedDerivedProperties?: boolean;
 }
 
 export interface ObjectSetCacheKey extends CacheKey<

--- a/packages/client/src/observable/internal/objectset/ObjectSetHelper.test.ts
+++ b/packages/client/src/observable/internal/objectset/ObjectSetHelper.test.ts
@@ -112,4 +112,66 @@ describe("ObjectSetHelper RDP canonicalization", () => {
 
     expect(query.rdpConfig).toBeUndefined();
   });
+
+  it("getQuery distinguishes each ontology-defined derived properties setting", () => {
+    const baseObjectSet = client(Employee);
+    const serverDefault = store.objectSets.getQuery({
+      baseObjectSet,
+      mode: "offline",
+    });
+    const explicitlyDisabled = store.objectSets.getQuery({
+      baseObjectSet,
+      mode: "offline",
+      $UNSTABLE_loadOntologyDefinedDerivedProperties: false,
+    });
+    const explicitlyEnabled = store.objectSets.getQuery({
+      baseObjectSet,
+      mode: "offline",
+      $UNSTABLE_loadOntologyDefinedDerivedProperties: true,
+    });
+
+    expect(serverDefault.cacheKey).not.toBe(explicitlyDisabled.cacheKey);
+    expect(serverDefault.cacheKey).not.toBe(explicitlyEnabled.cacheKey);
+    expect(explicitlyDisabled.cacheKey).not.toBe(explicitlyEnabled.cacheKey);
+  });
+
+  it("list queries distinguish each ontology-defined derived properties setting", () => {
+    const serverDefault = store.lists.getQuery({
+      type: Employee,
+    });
+    const explicitlyDisabled = store.lists.getQuery({
+      type: Employee,
+      $UNSTABLE_loadOntologyDefinedDerivedProperties: false,
+    });
+    const explicitlyEnabled = store.lists.getQuery({
+      type: Employee,
+      $UNSTABLE_loadOntologyDefinedDerivedProperties: true,
+    });
+
+    expect(serverDefault.cacheKey).not.toBe(explicitlyDisabled.cacheKey);
+    expect(serverDefault.cacheKey).not.toBe(explicitlyEnabled.cacheKey);
+    expect(explicitlyDisabled.cacheKey).not.toBe(explicitlyEnabled.cacheKey);
+  });
+
+  it("link queries distinguish each ontology-defined derived properties setting", () => {
+    const baseOptions = {
+      srcType: Employee,
+      sourceUnderlyingObjectType: Employee.apiName,
+      pk: 1,
+      linkName: "lead" as const,
+    };
+    const serverDefault = store.links.getQuery(baseOptions);
+    const explicitlyDisabled = store.links.getQuery({
+      ...baseOptions,
+      $UNSTABLE_loadOntologyDefinedDerivedProperties: false,
+    });
+    const explicitlyEnabled = store.links.getQuery({
+      ...baseOptions,
+      $UNSTABLE_loadOntologyDefinedDerivedProperties: true,
+    });
+
+    expect(serverDefault.cacheKey).not.toBe(explicitlyDisabled.cacheKey);
+    expect(serverDefault.cacheKey).not.toBe(explicitlyEnabled.cacheKey);
+    expect(explicitlyDisabled.cacheKey).not.toBe(explicitlyEnabled.cacheKey);
+  });
 });

--- a/packages/client/src/observable/internal/objectset/ObjectSetHelper.test.ts
+++ b/packages/client/src/observable/internal/objectset/ObjectSetHelper.test.ts
@@ -113,65 +113,49 @@ describe("ObjectSetHelper RDP canonicalization", () => {
     expect(query.rdpConfig).toBeUndefined();
   });
 
-  it("getQuery distinguishes each ontology-defined derived properties setting", () => {
+  it("includes the ontology-defined derived properties setting in collection cache keys", () => {
     const baseObjectSet = client(Employee);
-    const serverDefault = store.objectSets.getQuery({
-      baseObjectSet,
-      mode: "offline",
-    });
-    const explicitlyDisabled = store.objectSets.getQuery({
-      baseObjectSet,
-      mode: "offline",
-      $UNSTABLE_loadOntologyDefinedDerivedProperties: false,
-    });
-    const explicitlyEnabled = store.objectSets.getQuery({
-      baseObjectSet,
-      mode: "offline",
-      $UNSTABLE_loadOntologyDefinedDerivedProperties: true,
-    });
-
-    expect(serverDefault.cacheKey).not.toBe(explicitlyDisabled.cacheKey);
-    expect(serverDefault.cacheKey).not.toBe(explicitlyEnabled.cacheKey);
-    expect(explicitlyDisabled.cacheKey).not.toBe(explicitlyEnabled.cacheKey);
-  });
-
-  it("list queries distinguish each ontology-defined derived properties setting", () => {
-    const serverDefault = store.lists.getQuery({
-      type: Employee,
-    });
-    const explicitlyDisabled = store.lists.getQuery({
-      type: Employee,
-      $UNSTABLE_loadOntologyDefinedDerivedProperties: false,
-    });
-    const explicitlyEnabled = store.lists.getQuery({
-      type: Employee,
-      $UNSTABLE_loadOntologyDefinedDerivedProperties: true,
-    });
-
-    expect(serverDefault.cacheKey).not.toBe(explicitlyDisabled.cacheKey);
-    expect(serverDefault.cacheKey).not.toBe(explicitlyEnabled.cacheKey);
-    expect(explicitlyDisabled.cacheKey).not.toBe(explicitlyEnabled.cacheKey);
-  });
-
-  it("link queries distinguish each ontology-defined derived properties setting", () => {
     const baseOptions = {
       srcType: Employee,
       sourceUnderlyingObjectType: Employee.apiName,
       pk: 1,
       linkName: "lead" as const,
     };
-    const serverDefault = store.links.getQuery(baseOptions);
-    const explicitlyDisabled = store.links.getQuery({
-      ...baseOptions,
-      $UNSTABLE_loadOntologyDefinedDerivedProperties: false,
-    });
-    const explicitlyEnabled = store.links.getQuery({
-      ...baseOptions,
-      $UNSTABLE_loadOntologyDefinedDerivedProperties: true,
-    });
+    const settings = [undefined, false, true];
 
-    expect(serverDefault.cacheKey).not.toBe(explicitlyDisabled.cacheKey);
-    expect(serverDefault.cacheKey).not.toBe(explicitlyEnabled.cacheKey);
-    expect(explicitlyDisabled.cacheKey).not.toBe(explicitlyEnabled.cacheKey);
+    expect(
+      new Set(
+        settings.map(
+          (setting) =>
+            store.objectSets.getQuery({
+              baseObjectSet,
+              mode: "offline",
+              $UNSTABLE_loadOntologyDefinedDerivedProperties: setting,
+            }).cacheKey,
+        ),
+      ).size,
+    ).toBe(3);
+    expect(
+      new Set(
+        settings.map(
+          (setting) =>
+            store.lists.getQuery({
+              type: Employee,
+              $UNSTABLE_loadOntologyDefinedDerivedProperties: setting,
+            }).cacheKey,
+        ),
+      ).size,
+    ).toBe(3);
+    expect(
+      new Set(
+        settings.map(
+          (setting) =>
+            store.links.getQuery({
+              ...baseOptions,
+              $UNSTABLE_loadOntologyDefinedDerivedProperties: setting,
+            }).cacheKey,
+        ),
+      ).size,
+    ).toBe(3);
   });
 });

--- a/packages/client/src/observable/internal/objectset/ObjectSetHelper.ts
+++ b/packages/client/src/observable/internal/objectset/ObjectSetHelper.ts
@@ -179,6 +179,11 @@ export class ObjectSetHelper extends AbstractHelper<
       operations.loadPropertySecurity = true;
     }
 
+    if (options.$UNSTABLE_loadOntologyDefinedDerivedProperties != null) {
+      operations.loadOntologyDefinedDerivedProperties =
+        options.$UNSTABLE_loadOntologyDefinedDerivedProperties;
+    }
+
     return operations as Canonical<ObjectSetOperations>;
   }
 }

--- a/packages/client/src/observable/internal/objectset/ObjectSetQuery.ts
+++ b/packages/client/src/observable/internal/objectset/ObjectSetQuery.ts
@@ -128,6 +128,12 @@ export class ObjectSetQuery extends BaseListQuery<
     return this.#operations.select;
   }
 
+  public override get loadOntologyDefinedDerivedProperties():
+    | boolean
+    | undefined {
+    return this.#operations.loadOntologyDefinedDerivedProperties;
+  }
+
   protected get rawSelect(): Canonical<readonly string[]> | undefined {
     return this.#operations.select;
   }
@@ -261,6 +267,12 @@ export class ObjectSetQuery extends BaseListQuery<
         : {}),
       ...(this.options.$loadPropertySecurityMetadata
         ? { $loadPropertySecurityMetadata: true }
+        : {}),
+      ...(this.loadOntologyDefinedDerivedProperties != null
+        ? {
+            $UNSTABLE_loadOntologyDefinedDerivedProperties:
+              this.loadOntologyDefinedDerivedProperties,
+          }
         : {}),
     });
 
@@ -493,6 +505,10 @@ export class ObjectSetQuery extends BaseListQuery<
       obj.$objectType,
       pk,
       this.rdpConfig ?? undefined,
+      undefined,
+      undefined,
+      undefined,
+      this.loadOntologyDefinedDerivedProperties,
     );
   }
 

--- a/packages/client/src/observable/internal/objectset/ObjectSetQueryOptions.ts
+++ b/packages/client/src/observable/internal/objectset/ObjectSetQueryOptions.ts
@@ -87,6 +87,12 @@ export interface ObserveObjectSetOptions<
    * populated with conjunctive/disjunctive marking requirements per property.
    */
   $loadPropertySecurityMetadata?: boolean;
+
+  /**
+   * Controls whether ontology-defined derived properties are loaded. When
+   * omitted, the server's default behavior is used.
+   */
+  $UNSTABLE_loadOntologyDefinedDerivedProperties?: boolean;
 }
 
 export interface ObjectSetQueryOptions extends ObserveObjectSetOptions<

--- a/packages/client/src/observable/internal/utils/reloadDataAsFullObjects.ts
+++ b/packages/client/src/observable/internal/utils/reloadDataAsFullObjects.ts
@@ -33,6 +33,7 @@ function groupBy<T>(arr: T[], fn: (item: T) => string): Record<string, T[]> {
 export async function reloadDataAsFullObjects(
   client: Client,
   data: Osdk.Instance<any>[],
+  loadOntologyDefinedDerivedProperties?: boolean,
 ): Promise<Osdk.Instance<any>[]> {
   if (data.length === 0) {
     return data;
@@ -64,7 +65,15 @@ export async function reloadDataAsFullObjects(
           .where(
             where as Parameters<ObjectSet<ObjectTypeDefinition>["where"]>[0],
           )
-          .fetchPage({ $includeRid: true });
+          .fetchPage({
+            $includeRid: true,
+            ...(loadOntologyDefinedDerivedProperties != null
+              ? {
+                  $UNSTABLE_loadOntologyDefinedDerivedProperties:
+                    loadOntologyDefinedDerivedProperties,
+                }
+              : {}),
+          });
         return [
           apiName,
           Object.fromEntries(result.data.map((x) => [x.$primaryKey, x])),

--- a/packages/react/src/new/useLinks.ts
+++ b/packages/react/src/new/useLinks.ts
@@ -99,6 +99,12 @@ interface UseLinksBaseOptions<T extends ObjectOrInterfaceDefinition> {
    * object type.
    */
   $includeAllBaseObjectProperties?: boolean;
+
+  /**
+   * Controls whether ontology-defined derived properties are loaded. When
+   * omitted, the server's default behavior is used.
+   */
+  $UNSTABLE_loadOntologyDefinedDerivedProperties?: boolean;
 }
 
 export interface UseLinksResult<Q extends ObjectOrInterfaceDefinition> {
@@ -157,6 +163,7 @@ export function useLinks<
   const {
     enabled = true,
     $includeAllBaseObjectProperties,
+    $UNSTABLE_loadOntologyDefinedDerivedProperties,
     resolveToObjectType,
     ...otherOptions
   } = options;
@@ -206,6 +213,7 @@ export function useLinks<
             mode: otherOptions.mode,
             dedupeInterval: otherOptions.dedupeIntervalMs ?? 2_000,
             $includeAllBaseObjectProperties,
+            $UNSTABLE_loadOntologyDefinedDerivedProperties,
             resolveToObjectType,
             ...(canonOptions.$select ? { select: canonOptions.$select } : {}),
           },
@@ -230,6 +238,7 @@ export function useLinks<
     otherOptions.dedupeIntervalMs,
     canonOptions.$select,
     $includeAllBaseObjectProperties,
+    $UNSTABLE_loadOntologyDefinedDerivedProperties,
     !!resolveToObjectType,
   ]);
 

--- a/packages/react/src/new/useObjectSet.tsx
+++ b/packages/react/src/new/useObjectSet.tsx
@@ -119,6 +119,12 @@ export interface UseObjectSetOptions<
   $select?: readonly PropertyKeys<Q>[];
 
   /**
+   * Controls whether ontology-defined derived properties are loaded. When
+   * omitted, the server's default behavior is used.
+   */
+  $UNSTABLE_loadOntologyDefinedDerivedProperties?: boolean;
+
+  /**
    * Enable or disable the query.
    *
    * When `false`, the query will not automatically execute. It will still
@@ -312,6 +318,8 @@ export function useObjectSet<
             autoFetchMore: otherOptions.autoFetchMore,
             streamUpdates,
             select: canonOptions.$select,
+            $UNSTABLE_loadOntologyDefinedDerivedProperties:
+              otherOptions.$UNSTABLE_loadOntologyDefinedDerivedProperties,
           },
           observer,
         );
@@ -338,6 +346,7 @@ export function useObjectSet<
     otherOptions.pageSize,
     otherOptions.autoFetchMore,
     otherOptions.dedupeIntervalMs,
+    otherOptions.$UNSTABLE_loadOntologyDefinedDerivedProperties,
     streamUpdates,
     objectTypeKey,
   ]);

--- a/packages/react/src/new/useOsdkObject.ts
+++ b/packages/react/src/new/useOsdkObject.ts
@@ -43,6 +43,7 @@ export interface UseOsdkObjectOptions<Q extends ObjectOrInterfaceDefinition> {
   $select?: readonly PropertyKeys<Q>[];
   enabled?: boolean;
   $loadPropertySecurityMetadata?: boolean;
+  $UNSTABLE_loadOntologyDefinedDerivedProperties?: boolean;
 
   /**
    * When true, includes all properties of the underlying concrete object type
@@ -76,8 +77,8 @@ export function useOsdkObject<Q extends ObjectOrInterfaceDefinition>(
  *
  * @param type The object type or interface definition
  * @param primaryKey The primary key of the object
- * @param options Options including $select, enabled, $loadPropertySecurityMetadata,
- *                and $includeAllBaseObjectProperties
+ * @param options Options including $select, enabled, property metadata, and
+ *                ontology-defined derived property loading
  */
 export function useOsdkObject<Q extends ObjectOrInterfaceDefinition>(
   type: Q,
@@ -124,6 +125,8 @@ export function useOsdkObject<Q extends ObjectOrInterfaceDefinition>(
   const selectArg = optionsArg?.$select;
   const loadPropertySecurityMetadata =
     optionsArg?.$loadPropertySecurityMetadata;
+  const loadOntologyDefinedDerivedProperties =
+    optionsArg?.$UNSTABLE_loadOntologyDefinedDerivedProperties;
   const includeAllBaseObjectProperties =
     optionsArg?.$includeAllBaseObjectProperties;
 
@@ -170,6 +173,12 @@ export function useOsdkObject<Q extends ObjectOrInterfaceDefinition>(
                   $loadPropertySecurityMetadata: loadPropertySecurityMetadata,
                 }
               : {}),
+            ...(loadOntologyDefinedDerivedProperties != null
+              ? {
+                  $UNSTABLE_loadOntologyDefinedDerivedProperties:
+                    loadOntologyDefinedDerivedProperties,
+                }
+              : {}),
           },
           observer,
         ),
@@ -188,6 +197,7 @@ export function useOsdkObject<Q extends ObjectOrInterfaceDefinition>(
     mode,
     stableSelect,
     loadPropertySecurityMetadata,
+    loadOntologyDefinedDerivedProperties,
     includeAllBaseObjectProperties,
   ]);
 

--- a/packages/react/src/new/useOsdkObjects.ts
+++ b/packages/react/src/new/useOsdkObjects.ts
@@ -173,6 +173,12 @@ interface UseOsdkObjectsBaseOptions<
   $loadPropertySecurityMetadata?: boolean;
 
   /**
+   * Controls whether ontology-defined derived properties are loaded. When
+   * omitted, the server's default behavior is used.
+   */
+  $UNSTABLE_loadOntologyDefinedDerivedProperties?: boolean;
+
+  /**
    * When true, includes all properties of the underlying concrete object type
    * for interface queries. Has no effect for non-interface queries.
    */
@@ -305,6 +311,7 @@ export function useOsdkObjects<
     pivotTo,
     $select,
     $loadPropertySecurityMetadata,
+    $UNSTABLE_loadOntologyDefinedDerivedProperties,
     $includeAllBaseObjectProperties,
     resolveToObjectType,
   } = options ?? {};
@@ -352,6 +359,9 @@ export function useOsdkObjects<
             ...($loadPropertySecurityMetadata
               ? { $loadPropertySecurityMetadata }
               : {}),
+            ...($UNSTABLE_loadOntologyDefinedDerivedProperties != null
+              ? { $UNSTABLE_loadOntologyDefinedDerivedProperties }
+              : {}),
             ...(resolveToObjectType ? { resolveToObjectType: true } : {}),
           },
           observer,
@@ -381,6 +391,7 @@ export function useOsdkObjects<
     pivotTo,
     canonOptions.$select,
     $loadPropertySecurityMetadata,
+    $UNSTABLE_loadOntologyDefinedDerivedProperties,
     $includeAllBaseObjectProperties,
     !!resolveToObjectType,
   ]);

--- a/packages/react/test/useLinks.enabled.test.tsx
+++ b/packages/react/test/useLinks.enabled.test.tsx
@@ -188,6 +188,21 @@ describe("useLinks enabled option", () => {
     expect(options.$includeAllBaseObjectProperties).toBe(true);
   });
 
+  it("should forward explicit false for ontology-defined derived properties", () => {
+    const wrapper = createWrapper();
+
+    renderHook(
+      () =>
+        useLinks(mockObject, "relatedObjects", {
+          $UNSTABLE_loadOntologyDefinedDerivedProperties: false,
+        }),
+      { wrapper },
+    );
+
+    const options = mockObserveLinks.mock.calls[0][2];
+    expect(options.$UNSTABLE_loadOntologyDefinedDerivedProperties).toBe(false);
+  });
+
   describe("resolveToObjectType", () => {
     it("should pass resolveToObjectType: true to observeLinks when true", () => {
       const wrapper = createWrapper();

--- a/packages/react/test/useObjectSet.test.tsx
+++ b/packages/react/test/useObjectSet.test.tsx
@@ -120,6 +120,26 @@ describe(useObjectSet, () => {
     });
   });
 
+  it("should pass explicit false for ontology-defined derived properties", () => {
+    const wrapper = createWrapper();
+
+    renderHook(
+      () =>
+        useObjectSet(mockObjectSet, {
+          $UNSTABLE_loadOntologyDefinedDerivedProperties: false,
+        }),
+      { wrapper },
+    );
+
+    expect(mockObserveObjectSet).toHaveBeenCalledWith(
+      mockObjectSet,
+      expect.objectContaining({
+        $UNSTABLE_loadOntologyDefinedDerivedProperties: false,
+      }),
+      expect.any(Object),
+    );
+  });
+
   describe("data preservation", () => {
     it("should preserve data when object set changes but object type stays the same", () => {
       const wrapper = createWrapper();

--- a/packages/react/test/useOsdkObject.enabled.test.tsx
+++ b/packages/react/test/useOsdkObject.enabled.test.tsx
@@ -135,4 +135,19 @@ describe("useOsdkObject enabled option", () => {
     const options = mockObserveObject.mock.calls[0][2];
     expect(options.$includeAllBaseObjectProperties).toBe(true);
   });
+
+  it("should forward explicit false for ontology-defined derived properties", () => {
+    const wrapper = createWrapper();
+
+    renderHook(
+      () =>
+        useOsdkObject(MockObjectType, "pk-888", {
+          $UNSTABLE_loadOntologyDefinedDerivedProperties: false,
+        }),
+      { wrapper },
+    );
+
+    const options = mockObserveObject.mock.calls[0][2];
+    expect(options.$UNSTABLE_loadOntologyDefinedDerivedProperties).toBe(false);
+  });
 });

--- a/packages/react/test/useOsdkObjects.test.tsx
+++ b/packages/react/test/useOsdkObjects.test.tsx
@@ -247,6 +247,25 @@ describe("useOsdkObjects enabled option", () => {
     );
   });
 
+  it("should pass explicit false for ontology-defined derived properties", () => {
+    const wrapper = createWrapper();
+
+    renderHook(
+      () =>
+        useOsdkObjects(MockObjectType, {
+          $UNSTABLE_loadOntologyDefinedDerivedProperties: false,
+        }),
+      { wrapper },
+    );
+
+    expect(mockObserveList).toHaveBeenCalledWith(
+      expect.objectContaining({
+        $UNSTABLE_loadOntologyDefinedDerivedProperties: false,
+      }),
+      expect.any(Object),
+    );
+  });
+
   it("should not resubscribe when rerendered with a new inline withProperties of the same shape", () => {
     const canonicalWithProperties = { leadName: () => {} };
     const observableClient = {


### PR DESCRIPTION
## Summary

Adds `$UNSTABLE_loadOntologyDefinedDerivedProperties` support to the React OSDK hooks and corresponding observable-client APIs:

- `useOsdkObject`
- `useOsdkObjects`
- `useObjectSet`
- `useLinks`

The option is forwarded through object, list, object-set, link, pagination, batching, and interface-to-object reload paths.

## Cache behavior

The cache treates each setting as a distinct variant:

- `undefined`: use the server default
- `false`: explicitly disable ontology-defined derived properties
- `true`: explicitly enable ontology-defined derived properties

Values fetched under one setting are not propagated into cache entries for another setting. This prevents derived properties from leaking into variants where they were not requested.

## Optimistic updates

Optimistic value updates are intentionally not propagated between different ontology-defined-derived-property settings.

The existing optimistic-update path writes through the server-default cache variant. Consequently, hooks using an explicit `true` or `false` setting will display the updated server value after the action completes and the query is refreshed, rather than displaying the optimistic value. 

This could lead to some times when the UI is out of sync, but it will always later reconsolidate. An alternative to this approach is allow optimistic writes to update all three variants, but this will cause the OTDP values to be temporarily inconsistent during an optimistic update.

## Testing

Added coverage for:

- Forwarding explicit `false` through each React hook
- Separating bulk requests by OTDP setting
- Partitioning object, list, object-set, and link cache entries
- Preventing fetched and optimistic values from crossing OTDP cache variants

Also tested e2e locally