### PR TITLE
Fix test flakes

### DIFF
--- a/.changeset/maker-tests-no-shared-tmp-codegen-dir.md
+++ b/.changeset/maker-tests-no-shared-tmp-codegen-dir.md
@@ -1,6 +1,0 @@
----
-"@osdk/maker": patch
-"@osdk/maker-experimental": patch
----
-
-Stop maker and maker-experimental tests from passing `/tmp/` as `defineOntology`'s output directory. Every test wrote into the machine-global `/tmp/codegen`, whose per-type subdirectories `writeStaticObjects` wipes and recreates on each call, so concurrent test processes raced and intermittently failed with `ENOTEMPTY`. No test asserted on that output, and the tests that do check generated files already use unique directories. Test configuration only; no runtime or API changes.

--- a/.changeset/maker-tests-no-shared-tmp-codegen-dir.md
+++ b/.changeset/maker-tests-no-shared-tmp-codegen-dir.md
@@ -1,0 +1,6 @@
+---
+"@osdk/maker": patch
+"@osdk/maker-experimental": patch
+---
+
+Fix maker and maker-experimental test flakes from re-using the same output directory for their defineOntology calls.

--- a/.changeset/maker-tests-no-shared-tmp-codegen-dir.md
+++ b/.changeset/maker-tests-no-shared-tmp-codegen-dir.md
@@ -1,0 +1,6 @@
+---
+"@osdk/maker": patch
+"@osdk/maker-experimental": patch
+---
+
+Stop maker and maker-experimental tests from passing `/tmp/` as `defineOntology`'s output directory. Every test wrote into the machine-global `/tmp/codegen`, whose per-type subdirectories `writeStaticObjects` wipes and recreates on each call, so concurrent test processes raced and intermittently failed with `ENOTEMPTY`. No test asserted on that output, and the tests that do check generated files already use unique directories. Test configuration only; no runtime or API changes.

--- a/packages/maker-experimental/src/api/overall.test.ts
+++ b/packages/maker-experimental/src/api/overall.test.ts
@@ -65,7 +65,7 @@ function apiNamePreset(apiName: string) {
 
 describe("Experimental Test Suite", () => {
   beforeEach(async () => {
-    await defineOntology("com.palantir.", () => {}, "/tmp/");
+    await defineOntology("com.palantir.", () => {}, undefined);
   });
 
   describe("Empty backing Media Sets", () => {

--- a/packages/maker-experimental/src/conversion/toMarketplace/RecommendationUtils.test.ts
+++ b/packages/maker-experimental/src/conversion/toMarketplace/RecommendationUtils.test.ts
@@ -42,7 +42,7 @@ function callGetExternalRecommendations(
 
 describe("RecommendationUtils", () => {
   beforeEach(async () => {
-    await defineOntology("com.palantir.", () => {}, "/tmp/");
+    await defineOntology("com.palantir.", () => {}, undefined);
   });
 
   it("returns empty array when no imported entities", async () => {

--- a/packages/maker-experimental/src/conversion/toMarketplace/convertInterfaceSchemaMigrations.test.ts
+++ b/packages/maker-experimental/src/conversion/toMarketplace/convertInterfaceSchemaMigrations.test.ts
@@ -79,7 +79,7 @@ function transition(
 
 describe("interface type schema migrations", () => {
   beforeEach(async () => {
-    await defineOntology("com.palantir.", () => {}, "/tmp/");
+    await defineOntology("com.palantir.", () => {}, undefined);
   });
 
   it("omits the migration block when not opted in", async () => {

--- a/packages/maker/src/api/test/actions.test.ts
+++ b/packages/maker/src/api/test/actions.test.ts
@@ -43,7 +43,7 @@ import { type SharedPropertyType } from "../properties/SharedPropertyType.js";
 
 describe("Action Types", () => {
   beforeEach(async () => {
-    await defineOntology("com.palantir.", () => {}, "/tmp/");
+    await defineOntology("com.palantir.", () => {}, undefined);
   });
   it("pairs a listLength interface target with listLengthValidation, not scalar required", () => {
     const person = defineInterface({
@@ -17020,7 +17020,7 @@ describe("Action Types", () => {
           ontologyPackageRid: null,
         });
       },
-      "/tmp/",
+      undefined,
     );
   });
 });

--- a/packages/maker/src/api/test/defineCreateInterfaceLinkAction.test.ts
+++ b/packages/maker/src/api/test/defineCreateInterfaceLinkAction.test.ts
@@ -24,7 +24,7 @@ import { defineOntology, dumpOntologyFullMetadata } from "../defineOntology.js";
 
 describe("defineCreateInterfaceLinkAction", () => {
   beforeEach(async () => {
-    await defineOntology("com.palantir.", () => {}, "/tmp/");
+    await defineOntology("com.palantir.", () => {}, undefined);
   });
 
   it("defineInterfaceLinkConstraint returns a handle describing the constraint", () => {
@@ -629,7 +629,7 @@ describe("defineCreateInterfaceLinkAction", () => {
 
 describe("defineDeleteInterfaceLinkAction", () => {
   beforeEach(async () => {
-    await defineOntology("com.palantir.", () => {}, "/tmp/");
+    await defineOntology("com.palantir.", () => {}, undefined);
   });
 
   it("creates a SINGLE interface-link delete action with singular params", () => {

--- a/packages/maker/src/api/test/interfaceSchemaMigrations.test.ts
+++ b/packages/maker/src/api/test/interfaceSchemaMigrations.test.ts
@@ -96,7 +96,7 @@ function defineWithMigrations(
 
 describe("Interface schema migrations", () => {
   beforeEach(async () => {
-    await defineOntology("com.palantir.", () => {}, "/tmp/");
+    await defineOntology("com.palantir.", () => {}, undefined);
   });
 
   describe("opting in", () => {

--- a/packages/maker/src/api/test/interfaces.test.ts
+++ b/packages/maker/src/api/test/interfaces.test.ts
@@ -24,7 +24,7 @@ import { defineSharedPropertyType } from "../defineSpt.js";
 
 describe("Interfaces", () => {
   beforeEach(async () => {
-    await defineOntology("com.palantir.", () => {}, "/tmp/");
+    await defineOntology("com.palantir.", () => {}, undefined);
   });
 
   it("doesn't let you define the same interface twice", () => {
@@ -1360,7 +1360,7 @@ describe("Interfaces", () => {
           ontologyPackageRid: null,
         });
       },
-      "/tmp/",
+      undefined,
     );
   });
 

--- a/packages/maker/src/api/test/links.test.ts
+++ b/packages/maker/src/api/test/links.test.ts
@@ -31,7 +31,7 @@ import { type InterfaceType } from "../interface/InterfaceType.js";
 
 describe("Link Types", () => {
   beforeEach(async () => {
-    await defineOntology("com.palantir.", () => {}, "/tmp/");
+    await defineOntology("com.palantir.", () => {}, undefined);
   });
   describe("Object Links", () => {
     it("does not allow duplicate link API names", () => {
@@ -2376,7 +2376,7 @@ describe("Link Types", () => {
           ontologyPackageRid: null,
         });
       },
-      "/tmp/",
+      undefined,
     );
   });
 

--- a/packages/maker/src/api/test/markingconstraint.test.ts
+++ b/packages/maker/src/api/test/markingconstraint.test.ts
@@ -21,7 +21,7 @@ import { defineOntology, dumpOntologyFullMetadata } from "../defineOntology.js";
 
 describe("Marking Constraints", () => {
   beforeEach(async () => {
-    await defineOntology("com.palantir.", () => {}, "/tmp/");
+    await defineOntology("com.palantir.", () => {}, undefined);
   });
   it("supports marking constraints with CBAC type and markingInputGroupName", () => {
     const obj = defineObject({

--- a/packages/maker/src/api/test/misc.test.ts
+++ b/packages/maker/src/api/test/misc.test.ts
@@ -32,7 +32,7 @@ import { type SharedPropertyType } from "../properties/SharedPropertyType.js";
 
 describe("Miscellaneous Tests", () => {
   beforeEach(async () => {
-    await defineOntology("com.palantir.", () => {}, "/tmp/");
+    await defineOntology("com.palantir.", () => {}, undefined);
   });
 
   describe("Imports", () => {

--- a/packages/maker/src/api/test/objectStatus.test.ts
+++ b/packages/maker/src/api/test/objectStatus.test.ts
@@ -22,7 +22,7 @@ import type { ObjectTypeStatus } from "../object/ObjectTypeStatus.js";
 
 describe("Object Status", () => {
   beforeEach(async () => {
-    await defineOntology("com.palantir.", () => {}, "/tmp/");
+    await defineOntology("com.palantir.", () => {}, undefined);
   });
 
   describe("Object Status Validation", () => {
@@ -46,7 +46,7 @@ describe("Object Status", () => {
             /Object "validationTest" has "experimental" status, but the following properties have a different status: bar/u,
           );
         },
-        "/tmp/",
+        undefined,
       );
     });
 
@@ -71,7 +71,7 @@ describe("Object Status", () => {
             }),
           ).not.toThrow();
         },
-        "/tmp/",
+        undefined,
       );
     });
 
@@ -98,7 +98,7 @@ describe("Object Status", () => {
             /Object "exampleActiveProp" has "example" status, but the following properties have a different status: bar/u,
           );
         },
-        "/tmp/",
+        undefined,
       );
     });
 
@@ -129,7 +129,7 @@ describe("Object Status", () => {
             /Object "deprecatedActiveProp" has "deprecated" status, but the following properties have a different status: bar/u,
           );
         },
-        "/tmp/",
+        undefined,
       );
     });
 
@@ -154,7 +154,7 @@ describe("Object Status", () => {
             }),
           ).not.toThrow();
         },
-        "/tmp/",
+        undefined,
       );
     });
 
@@ -176,7 +176,7 @@ describe("Object Status", () => {
             }),
           ).not.toThrow();
         },
-        "/tmp/",
+        undefined,
       );
     });
 
@@ -198,7 +198,7 @@ describe("Object Status", () => {
             }),
           ).not.toThrow();
         },
-        "/tmp/",
+        undefined,
       );
     });
   });
@@ -226,7 +226,7 @@ describe("Object Status", () => {
             active: {},
           });
         },
-        "/tmp/",
+        undefined,
       );
     });
 
@@ -253,7 +253,7 @@ describe("Object Status", () => {
             active: {},
           });
         },
-        "/tmp/",
+        undefined,
       );
     });
 
@@ -280,7 +280,7 @@ describe("Object Status", () => {
             experimental: {},
           });
         },
-        "/tmp/",
+        undefined,
       );
     });
 
@@ -315,7 +315,7 @@ describe("Object Status", () => {
             },
           });
         },
-        "/tmp/",
+        undefined,
       );
     });
   });

--- a/packages/maker/src/api/test/objects.test.ts
+++ b/packages/maker/src/api/test/objects.test.ts
@@ -33,7 +33,7 @@ const VECTOR: PropertyTypeTypeVector = {
 
 describe("Object Types", () => {
   beforeEach(async () => {
-    await defineOntology("com.palantir.", () => {}, "/tmp/");
+    await defineOntology("com.palantir.", () => {}, undefined);
   });
 
   it("allows an empty backing Media Set for a media reference property", () => {
@@ -4819,7 +4819,7 @@ describe("Object Types", () => {
             "ri.ontology-package.main.ontology-package.abc-123",
         });
       },
-      "/tmp/",
+      undefined,
     );
   });
 

--- a/packages/maker/src/api/test/spt.test.ts
+++ b/packages/maker/src/api/test/spt.test.ts
@@ -23,7 +23,7 @@ import { defineOntology, dumpOntologyFullMetadata } from "../defineOntology.js";
 import { defineSharedPropertyType } from "../defineSpt.js";
 describe("SPTs", () => {
   beforeEach(async () => {
-    await defineOntology("com.palantir.", () => {}, "/tmp/");
+    await defineOntology("com.palantir.", () => {}, undefined);
   });
 
   it("doesn't let you create the same spt twice", () => {
@@ -835,7 +835,7 @@ describe("SPTs", () => {
           ontologyPackageRid: null,
         });
       },
-      "/tmp/",
+      undefined,
     );
   });
 });

--- a/packages/maker/src/api/test/valueTypes.test.ts
+++ b/packages/maker/src/api/test/valueTypes.test.ts
@@ -26,7 +26,7 @@ import { defineValueType } from "../defineValueType.js";
 
 describe("Value Types", () => {
   beforeEach(async () => {
-    await defineOntology("com.palantir.", () => {}, "/tmp/");
+    await defineOntology("com.palantir.", () => {}, undefined);
   });
 
   it("validates metadata when defining a value type", () => {


### PR DESCRIPTION
Kept seeing test flakes due to concurrent execution of defineOntoloy against the same write dirs; this meant multiple tests may put stuff into the dir, and then when they go to delete the dir after the test, they'd fail due to the dir not being totally empty.

These tests don't actually assert on the written output (and the tests that _do_ already use unique directories); so let's just stop providing a write directory and avoid this problem.