### PR TITLE
tolerate multiple value type constraints in SDK generation

### DIFF
--- a/.changeset/tolerate-multiple-value-type-constraints.md
+++ b/.changeset/tolerate-multiple-value-type-constraints.md
@@ -1,0 +1,5 @@
+---
+"@osdk/generator": patch
+---
+
+Preserve string and boolean enum narrowing when value types have multiple constraints.

--- a/packages/generator/src/v2.0/generateClientSdkVersionTwoPointZero.test.ts
+++ b/packages/generator/src/v2.0/generateClientSdkVersionTwoPointZero.test.ts
@@ -20,6 +20,7 @@ import type {
   ActionParameterType,
   ObjectPropertyType,
   QueryDataType,
+  ValueTypeConstraint,
 } from "@osdk/foundry.ontologies";
 import { consola } from "consola";
 import * as immer from "immer";
@@ -522,6 +523,153 @@ describe("generator", () => {
   let helper: ReturnType<typeof createMockMinimalFiles>;
   beforeEach(async () => {
     helper = createMockMinimalFiles();
+  });
+
+  describe("value type constraints", () => {
+    const enumConstraint: ValueTypeConstraint = {
+      type: "enum",
+      options: ["A", "B"],
+    };
+    const lengthConstraint: ValueTypeConstraint = {
+      type: "length",
+      maximumLength: 10,
+    };
+    const emptyEnum: ValueTypeConstraint = { type: "enum", options: [] };
+
+    it.each<{
+      name: string;
+      constraints: ValueTypeConstraint[];
+      expectedType: string;
+    }>([
+      {
+        name: "enum before length",
+        constraints: [enumConstraint, lengthConstraint],
+        expectedType: "'A' | 'B'",
+      },
+      {
+        name: "enum after length",
+        constraints: [lengthConstraint, enumConstraint],
+        expectedType: "'A' | 'B'",
+      },
+      {
+        name: "no enum",
+        constraints: [lengthConstraint, {
+          type: "regex",
+          pattern: "[A-Z]+",
+          partialMatch: false,
+        }],
+        expectedType: "$PropType['string']",
+      },
+      {
+        name: "empty enum",
+        constraints: [emptyEnum, lengthConstraint],
+        expectedType: "$PropType['string']",
+      },
+      {
+        name: "usable enum after an empty enum",
+        constraints: [emptyEnum, enumConstraint],
+        expectedType: "'A' | 'B'",
+      },
+      {
+        name: "first of multiple enums",
+        constraints: [enumConstraint, { type: "enum", options: ["B"] }],
+        expectedType: "'A' | 'B'",
+      },
+    ])("generates string properties with $name", async ({
+      constraints,
+      expectedType,
+    }) => {
+      const ontology = immer.produce(TodoWireOntology, draft => {
+        draft.valueTypes.emailValueType.constraints = constraints;
+      });
+      await generateClientSdkVersionTwoPointZero(
+        ontology,
+        "",
+        helper.minimalFiles,
+        BASE_PATH,
+      );
+      expect(helper.getFiles()[`${BASE_PATH}/ontology/objects/Person.ts`])
+        .toContain(`readonly email: ${expectedType};`);
+    });
+
+    it("narrows boolean enums without changing property nullability", async () => {
+      const ontology = immer.produce(TodoWireOntology, draft => {
+        draft.objectTypes.Todo.objectType.properties.complete.valueTypeApiName =
+          "completeValueType";
+        draft.valueTypes.completeValueType = {
+          apiName: "completeValueType",
+          displayName: "Complete Value Type",
+          rid: "completeValueTypeRid",
+          version: "1.0.0",
+          fieldType: { type: "boolean" },
+          constraints: [
+            { type: "unsupported", unsupportedType: "custom", params: {} },
+            { type: "enum", options: [true, null] },
+          ],
+        };
+      });
+      await generateClientSdkVersionTwoPointZero(
+        ontology,
+        "",
+        helper.minimalFiles,
+        BASE_PATH,
+      );
+      expect(helper.getFiles()[`${BASE_PATH}/ontology/objects/Todo.ts`])
+        .toContain("readonly complete: true | undefined;");
+    });
+
+    it.each([false, true])(
+      "preserves array enum parentheses with size constraint first: %s",
+      async (sizeFirst) => {
+        const ontology = immer.produce(TodoWireOntology, draft => {
+          const constraints = draft.valueTypes.arrayValueType.constraints;
+          constraints.push({
+            type: "array",
+            uniqueValues: false,
+            minimumSize: 1,
+          });
+          if (sizeFirst) {
+            constraints.reverse();
+          }
+        });
+        await generateClientSdkVersionTwoPointZero(
+          ontology,
+          "",
+          helper.minimalFiles,
+          BASE_PATH,
+        );
+        expect(helper.getFiles()[`${BASE_PATH}/ontology/objects/Todo.ts`])
+          .toContain(`readonly array: ('a' | 'b"c' | "d'e")[] | undefined;`);
+      },
+    );
+
+    it("narrows interface properties with multiple constraints", async () => {
+      const ontology = immer.produce(TodoWireOntology, draft => {
+        draft.valueTypes.interfaceValueType = {
+          ...draft.valueTypes.emailValueType,
+          apiName: "interfaceValueType",
+          rid: "interfaceValueTypeRid",
+          constraints: [lengthConstraint, enumConstraint],
+        };
+        const interfaceType = draft.interfaceTypes.SomeInterface;
+        interfaceType.properties.SomeProperty.valueTypeApiName =
+          "interfaceValueType";
+        interfaceType.allProperties.SomeProperty.valueTypeApiName =
+          "interfaceValueType";
+        draft.sharedPropertyTypes.SomeProperty.valueTypeApiName =
+          "interfaceValueType";
+      });
+      await generateClientSdkVersionTwoPointZero(
+        ontology,
+        "",
+        helper.minimalFiles,
+        BASE_PATH,
+      );
+      expect(
+        helper.getFiles()[`${BASE_PATH}/ontology/interfaces/SomeInterface.ts`],
+      )
+        .toContain("readonly SomeProperty: 'A' | 'B' | undefined;");
+    });
   });
 
   test(

--- a/packages/generator/src/v2.0/wireObjectTypeV2ToSdkObjectConstV2.ts
+++ b/packages/generator/src/v2.0/wireObjectTypeV2ToSdkObjectConstV2.ts
@@ -23,10 +23,7 @@ import type {
   ValueTypeApiName,
   ValueTypeConstraint,
 } from "@osdk/foundry.ontologies";
-import {
-  GeneratorError,
-  wireObjectTypeFullMetadataToSdkObjectMetadata,
-} from "@osdk/generator-converters";
+import { wireObjectTypeFullMetadataToSdkObjectMetadata } from "@osdk/generator-converters";
 import consola from "consola";
 import { EnhancedInterfaceType } from "../GenerateContext/EnhancedInterfaceType.js";
 import { EnhancedObjectType } from "../GenerateContext/EnhancedObjectType.js";
@@ -462,34 +459,29 @@ function getPropTypeOrValueTypeEnum(
     return defaultPropString;
   }
   const valueType = valueTypeMetadata[propertyDefinition.valueTypeApiName];
-  if (valueType == null || valueType.constraints.length === 0) {
+  if (valueType == null) {
     return defaultPropString;
   }
-  if (valueType.constraints.length !== 1) {
-    throw new GeneratorError(
-      "Expected exactly one constraint for value type",
-      { valueTypeApiName: propertyDefinition.valueTypeApiName },
-      { constraintCount: valueType.constraints.length },
+
+  for (let constraint of valueType.constraints) {
+    let shouldWrapWithParentheses = false;
+    if (constraint.type === "array" && constraint.valueConstraint) {
+      constraint = constraint.valueConstraint;
+      shouldWrapWithParentheses = true;
+    }
+
+    const maybeEnumString = maybeGetEnumString(
+      propertyDefinition,
+      constraint,
     );
+    if (maybeEnumString) {
+      return shouldWrapWithParentheses
+        ? `(${maybeEnumString})`
+        : maybeEnumString;
+    }
   }
 
-  let shouldWrapWithParentheses = false;
-  let constraint = valueType.constraints[0];
-  if (constraint.type === "array" && constraint.valueConstraint) {
-    constraint = constraint.valueConstraint;
-    shouldWrapWithParentheses = true;
-  }
-
-  const maybeEnumString = maybeGetEnumString(
-    propertyDefinition,
-    constraint,
-  );
-
-  return maybeEnumString
-    ? (
-      shouldWrapWithParentheses ? `(${maybeEnumString})` : maybeEnumString
-    )
-    : defaultPropString;
+  return defaultPropString;
 }
 
 function maybeGetEnumString(


### PR DESCRIPTION
A value type can have an enum constraint alongside other constraints, such as a string length limit. The SDK generator currently requires exactly one constraint when narrowing string or boolean properties, so these definitions cause generation to fail with `Expected exactly one constraint for value type`.

This PR scans the constraints and reuses the existing enum formatter. If multiple enum constraints are present, we take the intersection of them, matching other usages elsewhere in the platform. For example, a string enum allowing `A` or `B` alongside a length limit now generates `'A' | 'B'` instead of throwing. If no usable enum exists, the property keeps its primitive type.

